### PR TITLE
Refactor reports to be useable for services

### DIFF
--- a/UI/Reports/PNL.html
+++ b/UI/Reports/PNL.html
@@ -2,8 +2,6 @@
 account_data = report.account_data;
 
 FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -108,15 +106,15 @@ END ;
 <div class="export-links">
   <div class="export-link"
        ><a target="_blank" rel="noopener noreferrer"
-           href="[% LINK %]&amp;format=PDF">[[% text('PDF') %]]</a>
+           href="[% REPORT_LINK %]&amp;format=PDF">[[% text('PDF') %]]</a>
   </div>
   <div class="export-link"
        ><a target="_blank" rel="noopener noreferrer"
-           href="[% LINK %]&amp;format=HTML">[[% text('HTML') %]]</a>
+           href="[% REPORT_LINK %]&amp;format=HTML">[[% text('HTML') %]]</a>
   </div>
   <div class="export-link"
        ><a target="_blank" rel="noopener noreferrer"
-           href="[% LINK %]&amp;format=CSV">[[% text('CSV') %]]</a>
+           href="[% REPORT_LINK %]&amp;format=CSV">[[% text('CSV') %]]</a>
   </div>
 [% END %]
 </div>

--- a/UI/Reports/PNL.html
+++ b/UI/Reports/PNL.html
@@ -22,7 +22,7 @@ END ;
 <body class="financial-statement [% dojo_theme %] [% hierarchy %]">
 <div id="PNL" class="financial-statement [% hierarchy %]"> <!-- Also used in balance sheet! -->
 <h1>[% name %]</h1>
-<div class="company-name">[% company_name %]</div>
+<div class="company-name">[% SETTINGS.company_name %]</div>
 <div class="company-address">[% company_address %]</div>
 
 <table class="income_statement" style="border-collapse: collapse">

--- a/UI/Reports/aging_report.html
+++ b/UI/Reports/aging_report.html
@@ -4,8 +4,6 @@ PROCESS "elements.html";
 
 PROCESS "dynatable.html";
 
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-
 %]
 <body class="lsmb [% dojo_theme %]">
 <div class="report_header"><label>[% text('Report Name') %]:</label>
@@ -90,27 +88,27 @@ PROCESS button element_data = {
 };
  %]
 </form><br />
-<a href="[% LINK %]">[[% text('permalink') %]]</a>&nbsp;
+<a href="[% REPORT_LINK %]">[[% text('permalink') %]]</a>&nbsp;
 [% IF FORMATS.grep('PDF').size()
 %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=PDF' %]">[[% text('PDF') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=PDF' %]">[[% text('PDF') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('TXT').size();
 %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=CSV' %]">[[% text('CSV') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=CSV' %]">[[% text('CSV') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('XLS').size() %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=XLS' %]">[[% text('XLS') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=XLS' %]">[[% text('XLS') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('XLSX').size() %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=XLSX' %]">[[% text('XLSX') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=XLSX' %]">[[% text('XLSX') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('ODS').size() %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=ODS' %]">[[% text('ODS') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=ODS' %]">[[% text('ODS') %]]</a>&nbsp;
 [% END; %]
 </body>

--- a/UI/Reports/aging_report.html
+++ b/UI/Reports/aging_report.html
@@ -5,33 +5,34 @@ PROCESS "elements.html";
 PROCESS "dynatable.html";
 
 %]
-<body class="lsmb [% dojo_theme %]">
+<body>
 <div class="report_header"><label>[% text('Report Name') %]:</label>
 <span class="report_header">[% name %]</span>
 </div>
 <div class="report_header"><label>[% text('Company') %]:</label>
-<span class="report_header">[% request.company %]</span>
+<span class="report_header">[% SETTINGS.company_name %]</span>
 </div>
 [% FOREACH LINE IN hlines %]
 <div class="report_header"><label>[% LINE.text %]:</label>
-<span class="report_header">[% request.${LINE.name} %]</span>
+<span class="report_header">[% LINE.value %]</span>
 </div>
 [% END %]
 
 <form data-dojo-type="lsmb/Form" method="get" action="report_aging.pl">
 [%
 
+PROCESS input element_data = {
+         name = 'form_id'
+         value = FORM_ID
+         type = 'hidden'
+};
 FOREACH KEY IN [ 'entity_class', 'to_date', 'report_type',
                  'overdue', 'c0', 'c30', 'c60', 'c90'];
-    IF KEY == 'rows';
-       NEXT;
-    ELSE;
-        PROCESS input element_data = {
-             name = KEY
-             type = 'hidden'
-            value = request.$KEY
-        };
-    END;
+    PROCESS input element_data = {
+          name = KEY
+          type = 'hidden'
+          value = report.$KEY
+    };
 END;
 
 PROCESS input element_data = {

--- a/UI/Reports/balance_sheet.html
+++ b/UI/Reports/balance_sheet.html
@@ -1,8 +1,6 @@
 [%
 
 FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -109,13 +107,13 @@ END ;
 <div class="export-links">
   <div class="export-link"
        ><a target="_blank" rel="noopener noreferrer"
-           href="[% LINK %]&amp;format=PDF">[[% text('PDF') %]]</a></div>
+           href="[% REPORT_LINK %]&amp;format=PDF">[[% text('PDF') %]]</a></div>
   <div class="export-link"
        ><a target="_blank" rel="noopener noreferrer"
-           href="[% LINK %]&amp;format=HTML">[[% text('HTML') %]]</a></div>
+           href="[% REPORT_LINK %]&amp;format=HTML">[[% text('HTML') %]]</a></div>
   <div class="export-link"
        ><a target="_blank" rel="noopener noreferrer"
-           href="[% LINK %]&amp;format=CSV">[[% text('CSV') %]]</a></div>
+           href="[% REPORT_LINK %]&amp;format=CSV">[[% text('CSV') %]]</a></div>
 </div>
 [% END %]
 </div>

--- a/UI/Reports/balance_sheet.html
+++ b/UI/Reports/balance_sheet.html
@@ -22,7 +22,7 @@ END ;
 <div id="PNL" class="financial-statement [% hierarchy %] balance-sheet">  <!-- TODO: Find better name!! -->
 <h1>[% text('Balance Sheet') %]</h1>
 
-<div class="company-name">[% company_name %]</div>
+<div class="company-name">[% SETTINGS.company_name %]</div>
 <div class="company-address">[% company_address %]</div>
 
 <table class="balancesheet" style="border-collapse: collapse">

--- a/UI/Reports/co/filter_bm.html
+++ b/UI/Reports/co/filter_bm.html
@@ -1,7 +1,7 @@
 [% PROCESS 'elements.html' %]
 <body class="lsmb [% dojo_theme %]">
 
-<form data-dojo-type="lsmb/Form" method="get" action="[% request.script %]">
+<form data-dojo-type="lsmb/Form" method="get" action="[% SCRIPT %]">
 [% PROCESS input element_data = {
     type = "hidden"
     name = "sort"

--- a/UI/Reports/co/filter_cd.html
+++ b/UI/Reports/co/filter_cd.html
@@ -1,7 +1,7 @@
 [% PROCESS 'elements.html' %]
 <body class="lsmb [% dojo_theme %]">
 
-<form data-dojo-type="lsmb/Form" method="get" action="[% request.script %]">
+<form data-dojo-type="lsmb/Form" method="get" action="[% SCRIPT %]">
 [% PROCESS input element_data = {
     type = "hidden"
     name = "sort"

--- a/UI/Reports/display_report.html
+++ b/UI/Reports/display_report.html
@@ -10,7 +10,7 @@ FORMATS = LIST_FORMATS();
 <body class="lsmb [% dojo_theme %]">
 <form data-dojo-type="lsmb/Form"
       method="post"
-      action="[% request.script %]"
+      action="[% SCRIPT %]"
       id="search-report-dynatable" >
   <div class="heading_section">
     <div class="report_header"><label>[% text('Report Name') %]:</label>
@@ -27,22 +27,14 @@ FORMATS = LIST_FORMATS();
   </div>
   [% PROCESS input element_data = {
          name = 'form_id'
-         value = request.form_id
+         value = FORM_ID
          type = 'hidden'
       } %]
-  [% # legacy... we want explicit 'hiddens'...
-     FOREACH K IN request.hiddens.keys;
+  [% FOREACH K IN HIDDENS.keys;
          PROCESS input element_data = {
          name = K
          type = 'hidden'
-         value = request.hiddens.$K
-         };
-         END; %]
-  [% FOREACH K IN hiddens.keys;
-         PROCESS input element_data = {
-         name = K
-         type = 'hidden'
-         value = hiddens.$K
+         value = HIDDENS.$K
          };
          END; %]
   [% PROCESS dynatable tbody = {rows = rows }

--- a/UI/Reports/display_report.html
+++ b/UI/Reports/display_report.html
@@ -5,15 +5,6 @@ PROCESS "elements.html";
 PROCESS "dynatable.html";
 
 FORMATS = LIST_FORMATS();
-QSTRING = request.query_string;
-
-IF NOT QSTRING.match('company=');
-   ESCAPED_COMPANY = request.company FILTER uri;
-   QSTRING = QSTRING _ '&amp;company=' _ ESCAPED_COMPANY;
-END;
-
-LINK = request.script _ '?' _ QSTRING;
-
 
 %]
 <body class="lsmb [% dojo_theme %]">
@@ -26,21 +17,11 @@ LINK = request.script _ '?' _ QSTRING;
       <span class="report_header">[% name %]</span>
     </div>
     <div class="report_header"><label>[% text('Company') %]:</label>
-      <span class="report_header">[% request.company %]</span>
+      <span class="report_header">[% company_name %]</span>
     </div>
     [% FOREACH LINE IN hlines %]
     <div class="report_header"><label>[% LINE.text %]:</label>
-      <span class="report_header">
-        [%
-           IF LINE.value;
-              LINE.value;
-           ELSIF request.${LINE.name};
-              request.${LINE.name};
-           ELSE;
-              report.${LINE.name};
-           END;
-           %]
-      </span>
+      <span class="report_header"> [% LINE.value %] </span>
     </div>
     [% END %]
   </div>
@@ -76,26 +57,26 @@ END; %]
 FOREACH BUTTON IN buttons;
   PROCESS button element_data = BUTTON;
 END; %]<br />
-<a href="[% LINK %]">[[% text('permalink') %]]</a>&nbsp;
+<a href="[% REPORT_LINK %]">[[% text('permalink') %]]</a>&nbsp;
 [% IF FORMATS.grep('PDF').size() %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=PDF' %]">[[% text('PDF') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=PDF' %]">[[% text('PDF') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('TXT').size(); %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=CSV' %]">[[% text('CSV') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=CSV' %]">[[% text('CSV') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('ODS').size() %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=ODS' %]">[[% text('ODS') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=ODS' %]">[[% text('ODS') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('XLS').size(); %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=XLS' %]">[[% text('XLS') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=XLS' %]">[[% text('XLS') %]]</a>&nbsp;
 [% END;
 IF FORMATS.grep('XLSX').size(); %]
 <a target="_blank" rel="noopener noreferrer"
-   href="[% LINK _ '&amp;format=XLSX' %]">[[% text('XLSX') %]]</a>&nbsp;
+   href="[% REPORT_LINK _ '&amp;format=XLSX' %]">[[% text('XLSX') %]]</a>&nbsp;
 [% END; %]
 </form>
 </body>

--- a/UI/Reports/display_report.html
+++ b/UI/Reports/display_report.html
@@ -17,7 +17,7 @@ FORMATS = LIST_FORMATS();
       <span class="report_header">[% name %]</span>
     </div>
     <div class="report_header"><label>[% text('Company') %]:</label>
-      <span class="report_header">[% company_name %]</span>
+      <span class="report_header">[% SETTINGS.company_name %]</span>
     </div>
     [% FOREACH LINE IN hlines %]
     <div class="report_header"><label>[% LINE.text %]:</label>

--- a/UI/src/components/BusinessTypes.vue
+++ b/UI/src/components/BusinessTypes.vue
@@ -15,6 +15,7 @@ const store = useBusinessTypesStore();
 </script>
 
 <template>
+    <h1 class="listtop">{{ t("Configure Type of Businesses") }}</h1>
     <ConfigTable
         :columns="COLUMNS"
         :store="store"

--- a/UI/src/components/ConfigTable.vue
+++ b/UI/src/components/ConfigTable.vue
@@ -3,14 +3,11 @@
 import { computed, inject } from "vue";
 import { useI18n } from "vue-i18n";
 import { storeToRefs } from "pinia";
-import { useI18n } from "vue-i18n";
 import { contextRef } from "@/robot-vue";
 import { useSessionUserStore } from "@/store/sessionUser";
 
 import { createTableMachine } from "./ConfigTable.machines.js";
 import ConfigTableRow from "./ConfigTableRow.vue";
-
-const { t } = useI18n();
 
 const props = defineProps([
     "columns",

--- a/UI/src/components/ConfigTable.vue
+++ b/UI/src/components/ConfigTable.vue
@@ -3,6 +3,7 @@
 import { computed, inject } from "vue";
 import { useI18n } from "vue-i18n";
 import { storeToRefs } from "pinia";
+import { useI18n } from "vue-i18n";
 import { contextRef } from "@/robot-vue";
 import { useSessionUserStore } from "@/store/sessionUser";
 
@@ -21,10 +22,11 @@ const props = defineProps([
 ]);
 const notify = inject("notify");
 
+const { t } = useI18n();
 const user = useSessionUserStore();
 const hasRole = user.hasRole; // import the function from the store's getter
 
-const { items } = storeToRefs(props.store);
+const { items, _links, apiURL } = storeToRefs(props.store);
 
 const { service, send, state } = createTableMachine(props.store, {
     cb: {
@@ -36,6 +38,11 @@ const { service, send, state } = createTableMachine(props.store, {
 const editingId = contextRef(service, "editingId");
 const hasEdit = computed(() => hasRole(props.editRole));
 const hasCreate = computed(() => hasRole(props.createRole));
+
+const absURL = new URL(apiURL.value, window.location);
+function u(relURL) {
+    return new URL(relURL, absURL);
+}
 
 </script>
 
@@ -91,6 +98,12 @@ const hasCreate = computed(() => hasRole(props.createRole));
                 </tfoot>
             </template>
         </table>
+    </div>
+    <div v-if="_links.length > 0">
+        <span>{{ t("Download: ") }}</span>
+        <span v-for="link in _links" :key="link.href">
+            <a :href="u(link.href)" target="_blank">[ {{ link.title }} ]</a>
+        </span>
     </div>
 </template>
 

--- a/UI/src/components/GIFI.vue
+++ b/UI/src/components/GIFI.vue
@@ -15,6 +15,7 @@ const store = useGIFIsStore();
 </script>
 
 <template>
+    <h1 class="listtop">{{ t("Configure GIFI codes") }}</h1>
     <ConfigTable
         :columns="COLUMNS"
         :store="store"

--- a/UI/src/components/Languages.vue
+++ b/UI/src/components/Languages.vue
@@ -15,6 +15,7 @@ const store = useLanguagesStore();
 </script>
 
 <template>
+    <h1 class="listtop">{{ t("Configure languages") }}</h1>
     <ConfigTable
         :columns="COLUMNS"
         :store="store"

--- a/UI/src/components/Pricegroups.vue
+++ b/UI/src/components/Pricegroups.vue
@@ -14,6 +14,7 @@ const pricegroupsStore = usePricegroupsStore();
 </script>
 
 <template>
+    <h1 class="listtop">{{ t("Configure pricegroups") }}</h1>
     <ConfigTable
         :columns="COLUMNS"
         :store="pricegroupsStore"

--- a/UI/src/components/SIC.vue
+++ b/UI/src/components/SIC.vue
@@ -15,6 +15,7 @@ const store = useSICsStore();
 </script>
 
 <template>
+    <h1 class="listtop">{{ t("Configure Standard Industry Codes (SIC)") }}</h1>
     <ConfigTable
         :columns="COLUMNS"
         :store="store"

--- a/UI/src/components/Warehouses.vue
+++ b/UI/src/components/Warehouses.vue
@@ -14,6 +14,7 @@ const warehousesStore = useWarehousesStore();
 </script>
 
 <template>
+    <h1 class="listtop">{{ t("Configure warehouses") }}</h1>
     <ConfigTable
         :columns="COLUMNS"
         :store="warehousesStore"

--- a/UI/src/store/business-types.js
+++ b/UI/src/store/business-types.js
@@ -10,6 +10,7 @@ export const useBusinessTypesStore = defineStore("business-types", {
             fields: ["id", "description", "discount"],
             id: "id",
             items: [],
+            _links: [],
             url: "contacts/business-types"
         };
     }

--- a/UI/src/store/configTemplate.js
+++ b/UI/src/store/configTemplate.js
@@ -4,11 +4,15 @@ export const configStoreTemplate = {
     // to be mixed in at the parent level:
     // state: () => {
     //    return {
-    //        fields: ["id", "description"],
-    //        items: [],
-    //        url: "products/warehouses/"
+    //        "fields": ["id", "description"],
+    //        "items": [],
+    //        "_links": [],
+    //        "url": "products/warehouses/"
     //    };
     // },
+    getters: {
+        apiURL: (state) => `./erp/api/v0/${state.url}`
+    },
     actions: {
         async initialize() {
             const response = await fetch(`./erp/api/v0/${this.url}`, {
@@ -16,7 +20,9 @@ export const configStoreTemplate = {
             });
 
             if (response.ok) {
-                this.items = await response.json();
+                const rv = await response.json();
+                this.items = rv.items;
+                this._links = rv._links;
             } else {
                 throw new Error(`HTTP Error: ${response.status}`);
             }

--- a/UI/src/store/gifis.js
+++ b/UI/src/store/gifis.js
@@ -10,6 +10,7 @@ export const useGIFIsStore = defineStore("gifis", {
             fields: ["accno", "description"],
             id: "accno",
             items: [],
+            _links: [],
             url: "gl/gifi"
         };
     }

--- a/UI/src/store/languages.js
+++ b/UI/src/store/languages.js
@@ -10,6 +10,7 @@ export const useLanguagesStore = defineStore("languages", {
             fields: ["code", "description"],
             id: "code",
             items: [],
+            _links: [],
             url: "languages"
         };
     }

--- a/UI/src/store/pricegroups.js
+++ b/UI/src/store/pricegroups.js
@@ -10,6 +10,7 @@ export const usePricegroupsStore = defineStore("pricegroups", {
             fields: ["id", "description"],
             id: "id",
             items: [],
+            _links: [],
             url: "products/pricegroups"
         };
     }

--- a/UI/src/store/sics.js
+++ b/UI/src/store/sics.js
@@ -10,6 +10,7 @@ export const useSICsStore = defineStore("sics", {
             fields: ["code", "description"],
             id: "code",
             items: [],
+            _links: [],
             url: "contacts/sic"
         };
     }

--- a/UI/src/store/warehouses.js
+++ b/UI/src/store/warehouses.js
@@ -11,7 +11,7 @@ export const useWarehousesStore = defineStore("warehouses", {
             id: "id",
             items: [],
             _links: [],
-            url: "products/warehouses/"
+            url: "products/warehouses"
         };
     }
 });

--- a/UI/src/store/warehouses.js
+++ b/UI/src/store/warehouses.js
@@ -10,7 +10,8 @@ export const useWarehousesStore = defineStore("warehouses", {
             fields: ["id", "description"],
             id: "id",
             items: [],
-            url: "products/warehouses"
+            _links: [],
+            url: "products/warehouses/"
         };
     }
 });

--- a/cpanfile
+++ b/cpanfile
@@ -113,6 +113,7 @@ requires 'Template::Parser';
 requires 'Template::Provider';
 requires 'Text::CSV';
 requires 'Text::Markdown';
+requires 'URI';
 requires 'URI::Escape';
 requires 'Workflow', '1.59';
 requires 'Workflow::Context', '1.59';

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -644,11 +644,14 @@ sub report_renderer_ui {
   return sub {
       my ($template_name, $report, $vars, $cvars) = @_;
       $vars->{REPORT_LINK} = $uri->as_string;
+      $vars->{SCRIPT} = $request->{script};
       $vars->{SETTINGS} = {
           papersize    => 'letter', # default paper size when not configured
           (%{$request->{_company_config} // {}},)
       };
       $vars->{SETTINGS}->{company_name} ||= $request->{company};
+      $vars->{HIDDENS} = $request->{hiddens};
+      $vars->{FORM_ID} = $request->{form_id};
 
       return $ui->render($request, "Reports/$template_name", $vars, $cvars);
   };

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -150,6 +150,26 @@ The name of the language, translated into the user's selected language
 
 =back
 
+=item enabled_countries()
+
+Returns arrayref of hashes with the following keys:
+
+=over
+
+=item id
+
+The internal identifier for the country
+
+=item short_name
+
+The 2-leter iso code of the country
+
+=item name
+
+The country's full name translated into the user's selected language
+
+=back
+
 =item report_renderer_ui
 
 Returns a code reference to render a report on the UI - pass as the
@@ -209,6 +229,7 @@ use DateTime::Format::Duration::ISO8601;
 use Encode qw(perlio_ok);
 use HTTP::Headers::Fast;
 use HTTP::Status qw( HTTP_OK ) ;
+use Locale::CLDR;
 use Locales unicode => 1;
 use Log::Any;
 use PGObject;
@@ -594,6 +615,20 @@ sub enabled_languages {
                                 // $_->{description})
             }
         } $self->call_procedure(funcname => 'person__list_languages')
+        ];
+}
+
+sub enabled_countries {
+    my ($self) = @_;
+
+    my $regions = Locale::CLDR->new($self->{_user}->{language})->all_regions;
+    return [
+        map {
+            +{
+                $_->%*,
+                name => $regions->{$_->{short_name}} // $_->{name}
+            }
+        } $self->call_procedure(funcname => 'location_list_country')
         ];
 }
 

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -644,6 +644,11 @@ sub report_renderer_ui {
   return sub {
       my ($template_name, $report, $vars, $cvars) = @_;
       $vars->{REPORT_LINK} = $uri->as_string;
+      $vars->{SETTINGS} = {
+          papersize    => 'letter', # default paper size when not configured
+          (%{$request->{_company_config} // {}},)
+      };
+      $vars->{SETTINGS}->{company_name} ||= $request->{company};
 
       return $ui->render($request, "Reports/$template_name", $vars, $cvars);
   };
@@ -666,6 +671,11 @@ sub report_renderer_doc {
                $request->{_wire}->get( 'output_formatter' )->get( uc($request->{format} || 'HTML' ) ),
             );
 
+        $vars->{SETTINGS} = {
+            papersize    => 'letter', # default paper size when not configured
+            (%{$request->{_company_config} // {}},)
+        };
+        $vars->{SETTINGS}->{company_name} ||= $request->{company};
         $template->render($vars, $cvars);
 
         my $charset = '';

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -176,7 +176,7 @@ Returns a code reference to render a report on the UI - pass as the
 named argument 'renderer' to the C<LedgerSMB::Report->render> method.
 
   my $report = LedgerSMB::Report
-  $report->render($request, renderer => $request->report_renderer_ui);
+  $report->render( renderer => $request->report_renderer_ui);
 
 
 =item report_renderer_doc
@@ -185,7 +185,7 @@ Returns a code reference to render a report as a document - pass as the
 named argument 'renderer' to the C<LedgerSMB::Report->render> method.
 
   my $report = LedgerSMB::Report
-  $report->render($request, renderer => $request->report_renderer_doc);
+  $report->render( renderer => $request->report_renderer_doc);
 
 
 =item render_report($report)
@@ -720,7 +720,7 @@ sub render_report {
         # render as UI element
         $renderer = $request->report_renderer_ui;
     }
-    return $report->render($request, renderer => $renderer);
+    return $report->render( renderer => $renderer);
 }
 
 =head1 LICENSE AND COPYRIGHT

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -134,6 +134,21 @@ Month info in hashref format in 01 => January format
 
 =back
 
+=item enabled_languages()
+
+Returns arrayref of hashes with the following keys:
+
+=over
+
+=item value
+
+The code of the language as per the CLDR
+
+=item text
+
+The name of the language, translated into the user's selected language
+
+=back
 
 =item report_renderer_ui
 
@@ -194,6 +209,7 @@ use DateTime::Format::Duration::ISO8601;
 use Encode qw(perlio_ok);
 use HTTP::Headers::Fast;
 use HTTP::Status qw( HTTP_OK ) ;
+use Locales unicode => 1;
 use Log::Any;
 use PGObject;
 use Plack;
@@ -566,6 +582,20 @@ sub all_years {
                            } @years ] };
 }
 
+sub enabled_languages {
+    my ($self) = @_;
+
+    my $l = Locales->new( $self->{_user}->{language} );
+    return [
+        map {
+            +{
+                value => $_->{code},
+                text => ucfirst($l->get_language_from_code($_->{code})
+                                // $_->{description})
+            }
+        } $self->call_procedure(funcname => 'person__list_languages')
+        ];
+}
 
 sub report_renderer_ui {
   my ($request) = @_;

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -651,7 +651,7 @@ sub report_renderer_doc {
             path     => 'DB',
             dbh      => $request->{dbh},
             output_options => {
-                filename => $report->output_name($request),
+                filename => $report->output_name,
             },
             format_plugin   =>
                $request->{_wire}->get( 'output_formatter' )->get( uc($request->{format} || 'HTML' ) ),

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -234,6 +234,7 @@ use Locales unicode => 1;
 use Log::Any;
 use PGObject;
 use Plack;
+use URI;
 use URI::Escape;
 
 use LedgerSMB::App_State;
@@ -274,6 +275,11 @@ sub new {
     $self->{_setting} = $request->env->{'lsmb.setting'};
     $self->{_req} = $request;
     $self->{_wire} = $wire;
+
+    $self->{_uri} = URI->new(
+        $request->env->{'lsmb.script'} . "?$self->{query_string}",
+        $request->request_uri
+        );
 
     # Initialize ourselves from parameters in $self->{_req}
     $self->_process_args;
@@ -379,16 +385,6 @@ sub _process_args {
         }
     }
     return;
-}
-
-sub get_relative_url {
-    my ($self) = @_;
-
-    return Encode::decode(
-        'utf8',
-        uri_unescape(
-            $self->{script} .
-            ($self->{query_string} ? "?$self->{query_string}" : '')));
 }
 
 sub upload {

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -276,8 +276,9 @@ sub new {
     $self->{_req} = $request;
     $self->{_wire} = $wire;
 
+    my $q = $self->{query_string} // '';
     $self->{_uri} = URI->new(
-        $request->env->{'lsmb.script'} . "?$self->{query_string}",
+        $request->env->{'lsmb.script'} . ($q ? "?$q" : ''),
         $request->request_uri
         );
 

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -228,7 +228,8 @@ use Carp;
 use DateTime::Format::Duration::ISO8601;
 use Encode qw(perlio_ok);
 use HTTP::Headers::Fast;
-use HTTP::Status qw( HTTP_OK ) ;
+use HTTP::Status qw( HTTP_OK );
+use List::Util qw( pairgrep );
 use Locale::CLDR;
 use Locales unicode => 1;
 use Log::Any;
@@ -632,9 +633,17 @@ sub enabled_countries {
 sub report_renderer_ui {
   my ($request) = @_;
   my $ui = LedgerSMB::Template::UI->new_UI;
+  my $uri = $request->{_uri}->clone;
+  if (not pairgrep { $a eq 'company' } $uri->query_form) {
+      $uri->query_form(
+          $uri->query_form,
+          company => $request->{company},
+          );
+  }
 
   return sub {
       my ($template_name, $report, $vars, $cvars) = @_;
+      $vars->{REPORT_LINK} = $uri->as_string;
 
       return $ui->render($request, "Reports/$template_name", $vars, $cvars);
   };

--- a/lib/LedgerSMB/App_State.pm
+++ b/lib/LedgerSMB/App_State.pm
@@ -25,7 +25,7 @@ The following are objects that are expected to be stored in this namespace:
 
 =cut
 
-our $User;
+our $User = {};
 
 =item User
 

--- a/lib/LedgerSMB/I18N.pm
+++ b/lib/LedgerSMB/I18N.pm
@@ -136,28 +136,6 @@ sub get_country_list {
     ];
 }
 
-=item get_language_list($request, $language)
-
-Get a language localized list to allow user selection
-
-=cut
-
-sub get_language_list {
-    my ($request, $language) = @_;
-    my $locale = Locales->new($language);
-    my @rows = $request->call_dbmethod(funcname => 'person__list_languages');
-    my @languages;
-    for (@rows) {
-        my $text = $locale->get_language_from_code(lc($_->{code}));
-        push @languages, {
-            value => $_->{code},
-            text => ucfirst($text // $_->{description})
-        }
-    }
-    @languages = sort { $a->{text} cmp $b->{text} } @languages;
-    return @languages;
-}
-
 =item location_list_country_localized($request, $language)
 
 Get the country list, localized according to the desired language

--- a/lib/LedgerSMB/I18N.pm
+++ b/lib/LedgerSMB/I18N.pm
@@ -136,27 +136,6 @@ sub get_country_list {
     ];
 }
 
-=item location_list_country_localized($request, $language)
-
-Get the country list, localized according to the desired language
-
-Use the provided language of default to user
-
-=cut
-
-sub location_list_country_localized {
-    my $request = shift;
-    my $language = shift // $request->{_user}->{language};
-    my @country_list = $request->call_procedure(
-                     funcname => 'location_list_country'
-    );
-    my %regions = %{Locale::CLDR->new($language)->all_regions};
-    foreach (@country_list) {
-      $_->{name} = $regions{$_->{short_name}}
-        if defined $regions{$_->{short_name}};
-    }
-    return @country_list;
-}
 =back
 
 =head1 LICENSE AND COPYRIGHT

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -331,6 +331,11 @@ sub setup_url_space {
                 require_version => $LedgerSMB::VERSION;
             my $router = router 'erp/api';
             $router->hooks('before' => \&_hook_psgi_logger);
+            $router->hooks(
+                'before' => sub {
+                    my ($env, $settings) = @_;
+                    $env->{wire} = $wire;
+                });
             sub { return $router->dispatch(@_); };
         };
 

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -371,7 +371,7 @@ sub render {
 }
 
 
-=head2 output_name($request)
+=head2 output_name
 
 Returns the suggested file name to be used to store the report.
 
@@ -379,8 +379,6 @@ Returns the suggested file name to be used to store the report.
 
 sub output_name {
     my $self = shift;
-    my $request = shift;
-
     my $name = $self->name // '';
     $name =~ s/ /_/g;
 

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -367,7 +367,7 @@ sub render {
     my $request = shift;
 
     $self->run_report($request) if not defined $self->rows;
-    return $self->_render($request, renderer => 'render', @_);
+    return $self->_render(renderer => 'render', @_);
 }
 
 
@@ -401,7 +401,7 @@ sub output_name {
 # Render the report.
 
 sub _render {
-    my ($self, $request) = @_;
+    my $self = shift;
     my $template;
     my %args = ( @_ );
 
@@ -534,14 +534,10 @@ sub _render {
         return [map { +{ %$_, %{shift @newlines} } } @$lines ];
     };
 
-    my $setting = LedgerSMB::Setting->new(%$request);
     return $args{renderer}->(
         $template, $self,
         {
             report          => $self,
-            company_name    => ($setting->get('company_name')
-                                || $request->{company}),
-            company_address => $setting->get('company_address'),
             new_heads       => $replace_hnames,
             name            => $self->name,
             hlines          => $self->header_lines,

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -539,9 +539,9 @@ sub _render {
         $template, $self,
         {
             report          => $self,
-            company_name    => $setting->get('company_name'),
+            company_name    => ($setting->get('company_name')
+                                || $request->{company}),
             company_address => $setting->get('company_address'),
-            request         => $request,
             new_heads       => $replace_hnames,
             name            => $self->name,
             hlines          => $self->header_lines,
@@ -550,8 +550,6 @@ sub _render {
             buttons         => $self->buttons,
             options         => $self->options,
             rows            => $self->rows,
-
-            DBNAME          => $request->{company},
         });
 }
 

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -214,7 +214,7 @@ Url for order redirection.  Internal only.
 
 has order_url  => (is => 'rw', isa => 'Maybe[Str]');
 
-=item relative_url
+=head2 relative_url
 
 L<URI> object initialized with the script name and query string.
 
@@ -223,8 +223,7 @@ L<URI> object initialized with the script name and query string.
 has relative_url => (
     is => 'ro',
     isa => 'URI',
-    required => 1,
-    # trick to get the value initialized from the $request object
+    # trick to get the value initialized from the $request object:
     init_arg => '_uri');
 
 =head2 show_subtotals
@@ -542,7 +541,7 @@ Returns a list of columns based on selected ones from the report
 sub show_cols {
     my ($self, $request) = @_;
     my @retval;
-    my @columns = @{$self->columns($request)};
+    my @columns = @{$self->columns};
     for my $ref (@columns){
         if ($request->{"col_$ref->{col_id}"}){
             push @retval, $ref;

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -49,7 +49,7 @@ A report could then be generated with the following:
 
     use LedgerSMB::Report::MinimalReportExample;
     my $report = LedgerSMB::Report::MinimalReportExample->new();
-    $report->render($request);
+    $report->render();
 
 
 =head1 DESCRIPTION
@@ -364,10 +364,9 @@ the template).
 
 sub render {
     my $self = shift;
-    my $request = shift;
 
-    $self->run_report($request) if not defined $self->rows;
-    return $self->_render(renderer => 'render', @_);
+    $self->run_report() if not defined $self->rows;
+    return $self->_render(@_);
 }
 
 
@@ -403,7 +402,7 @@ sub output_name {
 sub _render {
     my $self = shift;
     my $template;
-    my %args = ( @_ );
+    my %args = @_;
 
     # This is a hook for other modules to use to override the default
     # template --CT

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -103,6 +103,19 @@ Display type for column data.  May be one of:
 
 Base for href.  Only meaningful if type is href
 
+=item money
+
+Boolean value indicating whether the column contains monetary values.
+
+=item pwidth
+
+Relative width of the column on the generated table.
+
+=item html_only
+
+Boolean value indicating whether the column should only be included in
+html reports.
+
 =item class
 
 CSS class (additional) for the column.

--- a/lib/LedgerSMB/Report/Aging.pm
+++ b/lib/LedgerSMB/Report/Aging.pm
@@ -31,6 +31,10 @@ use LedgerSMB::I18N;
 
 use List::Util qw(none);
 
+
+has 'languages' => (is => 'ro',
+                    required => 1);
+
 =head1 PROPERTIES
 
 =over
@@ -87,12 +91,6 @@ sub columns {
         $base_href = 'ar.pl?action=edit&id='; # for details
     }
 
-
-    ###BUG: This is bleeding abstractions like crazy: the Report class itself
-    # already *has* LedgerSMB::I18N mixed in (::I18N is a role!)
-    my @languages =
-        LedgerSMB::I18N::get_language_list($self,$request->{_user}->{language});
-
     push @COLUMNS,
       {col_id => 'select',
          type => 'checkbox',
@@ -108,7 +106,7 @@ sub columns {
       {col_id => 'language',
          name => $self->Text('Language'),
          type => 'select',
-      options => \@languages,
+      options => $self->languages,
        pwidth => '0', };
 
    if ($self->report_type eq 'detail'){
@@ -295,7 +293,7 @@ sub run_report{
     for my $row (@rows) {
         next if ($self->has_details_filter
                  and none { $_ == $row->{id} } $self->details_filter->@*);
-        $row->{language} //= $request->{_user}->{language};
+        $row->{language} //= $self->language;
         push @result, $row;
 
         if ($self->report_type eq 'detail') {

--- a/lib/LedgerSMB/Report/Aging.pm
+++ b/lib/LedgerSMB/Report/Aging.pm
@@ -196,15 +196,7 @@ Returns the name of the template to use
 =cut
 
 sub template {
-    my ($self) = @_;
-    if (not $self->format or (uc($self->format) eq 'HTML')
-           or (uc($self->format) eq 'PDF'))
-    {
-           return 'aging_report';
-    }
-    else {
-       return undef;
-    }
+    return 'aging_report';
 }
 
 =back

--- a/lib/LedgerSMB/Report/Aging.pm
+++ b/lib/LedgerSMB/Report/Aging.pm
@@ -8,8 +8,7 @@ LedgerSMB::Report::Aging - AR/AP Aging reports for LedgerSMB
 =head1 SYNPOSIS
 
   my $agereport = LedgerSMB::Report::Aging->new(%$request);
-  $agereport->run;
-  $agereport->render($request, $format);
+  $agereport->render();
 
 =head1 DESCRIPTION
 
@@ -277,7 +276,7 @@ Runs the report, and assigns rows to $self->rows.
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'report__invoice_aging_' .
                                                 $self->report_type);
     my @result;

--- a/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
+++ b/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
@@ -9,7 +9,7 @@ Report
 =head1 SYNPOSIS
 
  my $report = LedgerSMB::Report::Assets::Net_Book_Value->new(%$request);
- $report->render($request);
+ $report->render();
 
 =head1 DESCRIPTION
 
@@ -134,7 +134,7 @@ sub name {
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'asset_nbv_report');
     for my $row(@rows){
         $row->{row_id} = $row->{id};

--- a/lib/LedgerSMB/Report/Balance_Sheet.pm
+++ b/lib/LedgerSMB/Report/Balance_Sheet.pm
@@ -8,7 +8,7 @@ LedgerSMB::Report::Balance_Sheet - The LedgerSMB Balance Sheet Report
 =head1 SYNOPSIS
 
  my $report = LedgerSMB::Report::Balance_Sheet->new(%$request);
- $report->render($request);
+ $report->render();
 
 =head1 DESCRIPTION
 
@@ -82,7 +82,7 @@ the balance sheet.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
 
     die $self->Text('Required period type')
            if $self->comparison_periods and $self->interval eq 'none';

--- a/lib/LedgerSMB/Report/Budget/Search.pm
+++ b/lib/LedgerSMB/Report/Budget/Search.pm
@@ -121,16 +121,16 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'date_from',
-             text => $self->Text('Start Date')},
-            {name => 'date_to',
-             text => $self->Text('End Date')},
-            {name => 'accno',
-             text => $self->Text('Account Number')},
-            {name => 'reference',
-             text => $self->Text('Reference')},
-            {name => 'source',
-             text => $self->Text('Source')}];
+    return [{value => $self->date_from,
+             text  => $self->Text('Start Date')},
+            {value => $self->date_to,
+             text  => $self->Text('End Date')},
+            {value => $self->accno,
+             text  => $self->Text('Account Number')},
+            {value => $self->reference,
+             text  => $self->Text('Reference')},
+            {value => $self->source,
+             text  => $self->Text('Source')}];
 }
 
 =back

--- a/lib/LedgerSMB/Report/Budget/Search.pm
+++ b/lib/LedgerSMB/Report/Budget/Search.pm
@@ -8,8 +8,7 @@ LedgerSMB::Reports::Budget::Search - Search for Budgets
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::Budget::Search->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -208,7 +207,7 @@ Runs the report
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'budget__search');
     for my $r(@rows){
         $r->{row_id} = $r->{id};

--- a/lib/LedgerSMB/Report/Budget/Variance.pm
+++ b/lib/LedgerSMB/Report/Budget/Variance.pm
@@ -8,8 +8,7 @@ LedgerSMB::Report::Budget::Variance - Variance Report per Budget
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::Budget::Variance->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -200,7 +199,7 @@ Runs the report, setting rows for rendering.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'budget__variance_report');
     return $self->rows(\@rows);
 }

--- a/lib/LedgerSMB/Report/Budget/Variance.pm
+++ b/lib/LedgerSMB/Report/Budget/Variance.pm
@@ -115,13 +115,13 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'reference',
+    return [{value => $self->reference,
              text => $self->Text('Budget Number')},
-            {name => 'description',
+            {value => $self->description,
              text => $self->Text('Description')},
-            {name => 'start_date',
+            {value => $self->start_date,
              text => $self->Text('Start Date')},
-            {name => 'end_date',
+            {value => $self->end_date,
              text => $self->Text('End Date')},];
 }
 

--- a/lib/LedgerSMB/Report/COA.pm
+++ b/lib/LedgerSMB/Report/COA.pm
@@ -8,8 +8,7 @@ LedgerSMB::Report::COA - Chart of Accounts List for LedgerSMB
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::COA->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -151,7 +150,7 @@ Runs the report, and assigns rows to $self->rows.
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'report__coa');
     for my $r(@rows){
         my $ct;

--- a/lib/LedgerSMB/Report/Contact/History.pm
+++ b/lib/LedgerSMB/Report/Contact/History.pm
@@ -144,16 +144,16 @@ sub name {
 sub header_lines {
     my ($self) = @_;
      return [
-            {name => 'name',
-             text => $self->Text('Name')},
+            {value => $self->name_part,
+             text  => $self->Text('Name')},
 
-            {name => 'meta_number',
-             text => $self->Text('Account Number')},
-            {name => 'from_date',
-             text => $self->Text('Start Date')},
+            {value => $self->meta_number,
+             text  => $self->Text('Account Number')},
+            {value => $self->from_date,
+             text  => $self->Text('Start Date')},
 
-            {name => 'to_date',
-             text => $self->Text('End Date')},
+            {value => $self->to_date,
+             text  => $self->Text('End Date')},
 
 
       ];

--- a/lib/LedgerSMB/Report/Contact/History.pm
+++ b/lib/LedgerSMB/Report/Contact/History.pm
@@ -9,8 +9,7 @@ and more.
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::Contact::History->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -331,7 +330,7 @@ Runs the report, populates rows.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my $proc = 'eca__history';
     $proc .= '_summary' if $self->is_summary;
     my @rows = $self->call_dbmethod(funcname => $proc);

--- a/lib/LedgerSMB/Report/Contact/Purchase.pm
+++ b/lib/LedgerSMB/Report/Contact/Purchase.pm
@@ -9,8 +9,7 @@ generate Reports
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::Contact::Purchase->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -275,7 +274,7 @@ Runs the report, populates rows.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows;
     if ($self->summarize){
        @rows = $self->call_dbmethod(

--- a/lib/LedgerSMB/Report/Contact/Purchase.pm
+++ b/lib/LedgerSMB/Report/Contact/Purchase.pm
@@ -141,10 +141,10 @@ sub name {
 sub header_lines {
     my ($self) = @_;
      return [
-            {name => 'name_part',
-             text => $self->Text('Name')},
-            {name => 'meta_number',
-             text => $self->Text('Account Number')}
+            {value => $self->name_part,
+             text  => $self->Text('Name')},
+            {value => $self->meta_number,
+             text  => $self->Text('Account Number')}
        ];
 }
 

--- a/lib/LedgerSMB/Report/Contact/Search.pm
+++ b/lib/LedgerSMB/Report/Contact/Search.pm
@@ -101,10 +101,10 @@ sub name {
 sub header_lines {
     my ($self) = @_;
      return [
-            {name => 'name_part',
-             text => $self->Text('Name')},
-            {name => 'meta_number',
-             text => $self->Text('Account Number')}
+            {value => $self->name_part,
+             text  => $self->Text('Name')},
+            {value => $self->meta_number,
+             text  => $self->Text('Account Number')}
        ];
 }
 

--- a/lib/LedgerSMB/Report/Contact/Search.pm
+++ b/lib/LedgerSMB/Report/Contact/Search.pm
@@ -9,8 +9,7 @@ and more.
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::GL->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -269,7 +268,7 @@ Runs the report, populates rows.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @contact_info;
     push @contact_info, $self->phone if $self->phone;
     push @contact_info, $self->email if $self->email;

--- a/lib/LedgerSMB/Report/File/Incoming.pm
+++ b/lib/LedgerSMB/Report/File/Incoming.pm
@@ -113,7 +113,7 @@ Sets the rows.  This is just a wrapper around LedgerSMB::Report::File->list
 =cut
 
 sub run_report {
-    my ($self,$request) = $_;
+    my ($self) = $_;
     my @rows = $self->list;
     $_->{row_id} = $_->{id} for @rows;
     return $self->rows(\@rows);

--- a/lib/LedgerSMB/Report/File/Internal.pm
+++ b/lib/LedgerSMB/Report/File/Internal.pm
@@ -95,7 +95,7 @@ Sets the rows.  This is just a wrapper around LedgerSMB::Report::File->list
 =cut
 
 sub run_report {
-    my ($self,$request) = $_;
+    my ($self) = $_;
     my @rows = $self->list;
     $_->{row_id} = $_->{id} for @rows;
     return $self->rows(\@rows);

--- a/lib/LedgerSMB/Report/GL.pm
+++ b/lib/LedgerSMB/Report/GL.pm
@@ -8,8 +8,7 @@ LedgerSMB::Report::GL - GL Reports for LedgerSMB
 =head1 SYNPOSIS
 
   my $glreport = LedgerSMB::Report::GL->new(%$request);
-  $glreport->run;
-  $glreport->render($request, $format);
+  $glreport->render();
 
 =head1 DESCRIPTION
 
@@ -323,7 +322,7 @@ sub _exclude_from_totals {
 }
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my $accno = $self->accno;
     $accno =~ s/--.*//;
     $self->accno($accno);

--- a/lib/LedgerSMB/Report/GL.pm
+++ b/lib/LedgerSMB/Report/GL.pm
@@ -211,15 +211,15 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'from_date',
+    return [{value => $self->from_date,
              text => $self->Text('Start Date')},
-            {name => 'to_date',
+            {value => $self->to_date,
              text => $self->Text('End Date')},
-            {name => 'accno',
+            {value => $self->accno,
              text => $self->Text('Account Number')},
-            {name => 'reference',
+            {value => $self->reference,
              text => $self->Text('Reference')},
-            {name => 'source',
+            {value => $self->source,
              text => $self->Text('Source')}];
 }
 

--- a/lib/LedgerSMB/Report/Inventory/Activity.pm
+++ b/lib/LedgerSMB/Report/Inventory/Activity.pm
@@ -162,10 +162,10 @@ sub columns {
 sub header_lines {
     my ($self) = @_;
     return [
-      { name => 'partnumber',  text => $self->Text('Partnumber') },
-      { name => 'description', text => $self->Text('Description') },
-      { name => 'date_from',   text => $self->Text('From Date') },
-      { name => 'date_to',     text => $self->Text('To Date') },
+      { value => $self->partnumber,  text => $self->Text('Partnumber') },
+      { value => $self->description, text => $self->Text('Description') },
+      { value => $self->date_from,   text => $self->Text('From Date') },
+      { value => $self->date_to,     text => $self->Text('To Date') },
     ];
 }
 

--- a/lib/LedgerSMB/Report/Inventory/Activity.pm
+++ b/lib/LedgerSMB/Report/Inventory/Activity.pm
@@ -24,7 +24,7 @@ Implements a listing of parts, reporting numbers in 4 categories of activity:
 =head1 SYNOPSIS
 
  my $report = LedgerSMB::Report::Inventory::Activity->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -188,7 +188,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'inventory__activity');
     for my $r (@rows) {
        $r->{row_id} = $r->{partnumber};

--- a/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
+++ b/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
@@ -78,7 +78,7 @@ sub name {
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'source', text => $self->Text('Source') }];
+    return [{value => $self->source, text => $self->Text('Source') }];
 }
 
 =item columns

--- a/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
+++ b/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
@@ -10,7 +10,7 @@ Details report for LedgerSMB
 
  my $rpt = LedgerSMB::Report::Inventory::Adj_Details->new(%$request);
  $rpt->run_report($request);
- $rpt->render($request);
+ $report->render();
 
 =cut
 
@@ -140,7 +140,7 @@ sub set_buttons {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my ($rpt) = $self->call_dbmethod(funcname => 'inventory_adjust__get');
     $self->_include_buttons(defined $rpt->{trans_id});
     $self->source($rpt->{source});

--- a/lib/LedgerSMB/Report/Inventory/History.pm
+++ b/lib/LedgerSMB/Report/Inventory/History.pm
@@ -187,7 +187,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'goods__history');
     return $self->rows(
         [  map { { (%$_, (row_id => $_->{id})) } } @rows ]

--- a/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
@@ -12,7 +12,7 @@ Implements a listing of parts groups
 =head1 SYNOPSIS
 
  my $report = LedgerSMB::Report::Inventory::Partsgroups->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -91,7 +91,7 @@ Populates rows
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'partsgroup__search');
     $_->{row_id} = $_->{id} for (@rows);
     return $self->rows(\@rows);

--- a/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
@@ -67,7 +67,7 @@ sub columns {
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'partsgroup',
+    return [{value => $self->partsgroup,
              text => $self->Text('Partsgroup') }];
 }
 

--- a/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
@@ -12,7 +12,7 @@ Implements a listing of price groups.
 =head1 SYNOPSIS
 
   my $report = LedgerSMB::Report::Inventory::Pricegroups->new(%$request);
-  $report->render($request);
+  $report->render();
 
 =cut
 
@@ -91,7 +91,7 @@ Populates rows
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'pricegroup__search');
     $_->{row_id} = $_->{id} for (@rows);
     return $self->rows(\@rows);

--- a/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
@@ -67,8 +67,8 @@ sub columns {
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'partsgroup',
-             text => $self->Text('Price Group') }];
+    return [{value => $self->pricegroup,
+             text  => $self->Text('Price Group') }];
 }
 
 =head2 name

--- a/lib/LedgerSMB/Report/Inventory/Search.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search.pm
@@ -9,7 +9,7 @@ LedgerSMB
 =head1 SYNPOSIS
 
  my $report = LedgerSMB::Report::Inventory::Search->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -348,7 +348,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'goods__search');
     for my $r (@rows){
         $r->{row_id} = $r->{id};

--- a/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
@@ -79,13 +79,13 @@ sub name {
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'from_date',
+    return [{value => $self->from_date,
              text => $self->Text('Start Date') },
-            {name => 'to_date',
+            {value => $self->to_date,
              text => $self->Text('End Date') },
-            {name => 'partnumber',
+            {value => $self->partnumber,
              text => $self->Text('Including partnumber') },
-            {name => 'source',
+            {value => $self->source,
              text => $self->Text('Source starting with') },
            ];
 }

--- a/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
@@ -10,7 +10,7 @@ inventory adjustments
 
  my $rpt = LedgerSMB::Report::Inventory::Search_Adj->new(%$request);
  $rpt->run_report($request);
- $rpt->render($request);
+ $report->render();
 
 =cut
 
@@ -126,7 +126,7 @@ sub columns {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'inventory_adjust__search');
     for my $row (@rows) {
         $row->{ar_invnumber_suffix} = $row->{ar_invoice_id};

--- a/lib/LedgerSMB/Report/Invoices/COGS.pm
+++ b/lib/LedgerSMB/Report/Invoices/COGS.pm
@@ -185,7 +185,7 @@ Populates and returns $report->rows.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'report__incoming_cogs_line');
     for my $row (@rows){
         $row->{partnumber_href_suffix} = $row->{parts_id};

--- a/lib/LedgerSMB/Report/Invoices/COGS.pm
+++ b/lib/LedgerSMB/Report/Invoices/COGS.pm
@@ -154,14 +154,14 @@ sub columns {
 sub header_lines {
     my ($self) = @_;
     return [
-       { name => 'from_date',
-         text => $self->Text('Start Date'), },
-       { name => 'to_date',
-         text => $self->Text('End Date'), },
-       { name => 'partnumber',
-         text => $self->Text('Part Number'), },
-       { name => 'description',
-         text => $self->Text('Part Description'), },
+       { value => $self->from_date,
+         text  => $self->Text('Start Date'), },
+       { value => $self->to_date,
+         text  => $self->Text('End Date'), },
+       { value => $self->partnumber,
+         text  => $self->Text('Part Number'), },
+       { value => $self->description,
+         text  => $self->Text('Part Description'), },
     ];
 }
 

--- a/lib/LedgerSMB/Report/Invoices/Outstanding.pm
+++ b/lib/LedgerSMB/Report/Invoices/Outstanding.pm
@@ -172,7 +172,7 @@ has '+order_by' => (default => 'meta_number');
 =cut
 
 sub columns {
-    my ($self, $request) = @_;
+    my ($self) = @_;
     my ($inv_label, $inv_href_base);
     if ($self->is_detailed){
         $inv_label = $self->Text('Invoice');

--- a/lib/LedgerSMB/Report/Invoices/Outstanding.pm
+++ b/lib/LedgerSMB/Report/Invoices/Outstanding.pm
@@ -9,7 +9,7 @@ LedgerSMB
 =head1 SYNOPSIS
 
  my $report = LedgerSMB::Report::Invoices::Outstanding->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -323,7 +323,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my $procname = 'report__aa_outstanding';
     if ($self->is_detailed){
        $procname .= '_details';

--- a/lib/LedgerSMB/Report/Invoices/Payments.pm
+++ b/lib/LedgerSMB/Report/Invoices/Payments.pm
@@ -181,13 +181,13 @@ sub header_lines {
     } else {
         die 'Invalid entity class';
     }
-    return [{name => 'meta_number', text => $meta_number },
-            {name => 'cash_accno',
-             text => $self->Text('Account Number') },
-            {name => 'from_date',
-             text => $self->Text('From Date')},
-            {name => 'to_date',
-             text => $self->Text('To Date')}
+    return [{value => $self->meta_number, text => $meta_number },
+            {value => $self->cash_accno,
+             text  => $self->Text('Account Number') },
+            {value => $self->from_date,
+             text  => $self->Text('From Date')},
+            {value => $self->to_date,
+             text  => $self->Text('To Date')}
            ];
 }
 

--- a/lib/LedgerSMB/Report/Invoices/Payments.pm
+++ b/lib/LedgerSMB/Report/Invoices/Payments.pm
@@ -8,7 +8,7 @@ LedgerSMB::Report::Invoices::Payments - Payment Search Report for LedgerSMB
 =head1 SYNPOSIS
 
  my $report = LedgerSMB::Report::Invoices::Payments->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -215,7 +215,7 @@ Runs the report and sets $self->rows
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     die $self->Text('Must have cash account in batch')
         if $self->batch_id and not defined $self->cash_accno;
     my @rows = $self->call_dbmethod(funcname => 'payment__search');

--- a/lib/LedgerSMB/Report/Invoices/Transactions.pm
+++ b/lib/LedgerSMB/Report/Invoices/Transactions.pm
@@ -9,7 +9,7 @@ LedgerSMB
 =head1 SYNOPSIS
 
   my $report = LedgerSMB::Report::Invoices::Transactions(%$request);
-  $report->render($request);
+  $report->render();
 
 =cut
 
@@ -342,7 +342,7 @@ This runs the report and sets the $report->rows.
 
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     $self->approved;
     my @rows = $self->call_dbmethod(funcname => 'report__aa_transactions');
     for my $r(@rows){

--- a/lib/LedgerSMB/Report/Listings/Asset.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset.pm
@@ -150,7 +150,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'asset__search');
     for my $r(@rows){
        $r->{row_id} = $r->{id};

--- a/lib/LedgerSMB/Report/Listings/Asset.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset.pm
@@ -125,11 +125,10 @@ sub columns {
 sub header_lines {
     my ($self) = @_;
     return  [
-     { name => 'tag',         text => $self->Text('Tag') },
-     { name => 'description', text => $self->Text('Description') },
-     {name => 'purchase_date',text => $self->Text('Purchase Date')},
-     {name => 'purchase_value',
-        text => $self->Text('Purchase Value') },
+     { value => $self->tag,            text => $self->Text('Tag') },
+     { value => $self->description,    text => $self->Text('Description') },
+     { value => $self->purchase_date,  text => $self->Text('Purchase Date')},
+     { value => $self->purchase_value, text => $self->Text('Purchase Value') },
    ];
 }
 

--- a/lib/LedgerSMB/Report/Listings/Asset_Class.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset_Class.pm
@@ -95,10 +95,10 @@ Label and method
 sub header_lines {
     my ($self) = @_;
     return [
-       {name => 'label',
-        text => $self->Text('Label') },
-       {name => 'method',
-        text => $self->Text('Depreciation Method') },
+       {value => $self->label,
+        text  => $self->Text('Label') },
+       {value => $self->method,
+        text  => $self->Text('Depreciation Method') },
     ];
 }
 

--- a/lib/LedgerSMB/Report/Listings/Business_Type.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Type.pm
@@ -9,7 +9,7 @@ LedgerSMB
 =head1 SYNPOPSIS
 
   my $report = LedgerSMB::Report::Listings::Business_Type->new(%$request);
-  $report->render($request);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -78,7 +78,7 @@ Runs the report and returns the results for rendering.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     $self->manual_totals(1); #don't display totals
     my @rows = $self->call_dbmethod(funcname => 'business_type__list');
     for my $ref(@rows){

--- a/lib/LedgerSMB/Report/Listings/Business_Unit.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Unit.pm
@@ -90,7 +90,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     return $self->rows([
       map { +{ %$_, row_id => $_->{id}, } }
        $self->call_dbmethod(funcname => 'business_unit__list_by_class',

--- a/lib/LedgerSMB/Report/Listings/GIFI.pm
+++ b/lib/LedgerSMB/Report/Listings/GIFI.pm
@@ -76,7 +76,7 @@ None
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'gifi__list');
     for my $row (@rows){
         $row->{row_id} = $row->{accno};

--- a/lib/LedgerSMB/Report/Listings/Language.pm
+++ b/lib/LedgerSMB/Report/Listings/Language.pm
@@ -72,7 +72,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'person__list_languages');
     for my $row(@rows){
         $row->{row_id} = $row->{code};

--- a/lib/LedgerSMB/Report/Listings/Overpayments.pm
+++ b/lib/LedgerSMB/Report/Listings/Overpayments.pm
@@ -179,7 +179,7 @@ sub set_buttons {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'payment__overpayments_list');
     for my $r (@rows){
        $r->{row_id} = $r->{payment_id};

--- a/lib/LedgerSMB/Report/Listings/Overpayments.pm
+++ b/lib/LedgerSMB/Report/Listings/Overpayments.pm
@@ -102,11 +102,11 @@ sub name {
 sub header_lines {
     my ($self) = @_;
     return [
-      {name => 'meta_number', text => $self->Text('Counterparty Code')}.
-      {name => 'date_from',   text => $self->Text('Date From')},
-      {name => 'date_to',     text => $self->Text('Date To')},
-      {name => 'amount_from', text => $self->Text('Amount From')},
-      {name => 'amount_to',   text =>  $self->Text('Amount To')},
+      { value => $self->meta_number, text => $self->Text('Counterparty Code')}.
+      { value => $self->date_from,   text => $self->Text('Date From')},
+      { value => $self->date_to,     text => $self->Text('Date To')},
+      { value => $self->amount_from, text => $self->Text('Amount From')},
+      { value => $self->amount_to,   text => $self->Text('Amount To')},
     ];
 }
 

--- a/lib/LedgerSMB/Report/Listings/SIC.pm
+++ b/lib/LedgerSMB/Report/Listings/SIC.pm
@@ -70,7 +70,7 @@ sub name {
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'sic__list');
     for my $row(@rows){
         $row->{row_id} = $row->{code};

--- a/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
+++ b/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
@@ -150,7 +150,7 @@ my %jtype = (
     );
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     $self->manual_totals(1); #don't display totals
     my @rows = $self->call_dbmethod(funcname => 'journal__search');
     for my $ref(@rows){

--- a/lib/LedgerSMB/Report/Listings/Templates.pm
+++ b/lib/LedgerSMB/Report/Listings/Templates.pm
@@ -69,7 +69,7 @@ Just the language_code
 sub header_lines {
     my ($self) = @_;
     return [
-        { name => 'language_code', text => $self->Text('Language') },
+        { value => $self->language_code, text => $self->Text('Language') },
         ];
 };
 

--- a/lib/LedgerSMB/Report/Listings/Templates.pm
+++ b/lib/LedgerSMB/Report/Listings/Templates.pm
@@ -91,7 +91,7 @@ Populates the $report->rows.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'templates__list');
     for my $ref(@rows){
         $ref->{row_id} =

--- a/lib/LedgerSMB/Report/Listings/Warehouse.pm
+++ b/lib/LedgerSMB/Report/Listings/Warehouse.pm
@@ -65,7 +65,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'warehouse__list');
     for my $row(@rows){
         $row->{row_id} = $row->{id};

--- a/lib/LedgerSMB/Report/Orders.pm
+++ b/lib/LedgerSMB/Report/Orders.pm
@@ -8,7 +8,7 @@ LedgerSMB::Report::Orders - Search for Orders and Quotations in LedgerSMB
 =head1 SYNPOSIS
 
  my $report = LedgerSMB::Report::Orders->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -290,7 +290,7 @@ script should do that separately.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'order__search');
     for my $r(@rows){
        $r->{row_id} = $r->{id};

--- a/lib/LedgerSMB/Report/PNL.pm
+++ b/lib/LedgerSMB/Report/PNL.pm
@@ -107,7 +107,7 @@ sub columns {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
 
     my @lines = $self->report_base();
     my $row_map = ($self->gifi) ?

--- a/lib/LedgerSMB/Report/PNL/ECA.pm
+++ b/lib/LedgerSMB/Report/PNL/ECA.pm
@@ -82,11 +82,11 @@ sub name { my ($self) = @_; return $self->Text('ECA Income Statement') }
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'name',
+    return [{value => $self->legal_name,
             text => $self->Text('Name') },
-            {name => 'meta_number',
+            {value => $self->meta_number,
             text => $self->Text('Account Number')},
-            {name => 'control_code',
+            {value => $self->control_code,
             text => $self->Text('Control Code')}
           ];
 }

--- a/lib/LedgerSMB/Report/PNL/ECA.pm
+++ b/lib/LedgerSMB/Report/PNL/ECA.pm
@@ -8,7 +8,7 @@ LedgerSMB::Report::PNL::ECA - Income Statement-like Reports for Customers
 =head1 SYNPOSIS
 
  my $rpt = LedgerSMB::Report::PNL::ECA->new(%$request);
- $rpt->render($request);
+ $report->render();
 
 =head1 DESCRIPTION
 

--- a/lib/LedgerSMB/Report/PNL/Income_Statement.pm
+++ b/lib/LedgerSMB/Report/PNL/Income_Statement.pm
@@ -8,7 +8,7 @@ LedgerSMB::Report::PNL::Income_Statement - Basic Income Statement for LedgerSMB
 =head1 SYNPOSIS
 
  my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(%$request);
- $rpt->render($request);
+ $report->render();
 
 =head1 DESCRIPTION
 

--- a/lib/LedgerSMB/Report/PNL/Income_Statement.pm
+++ b/lib/LedgerSMB/Report/PNL/Income_Statement.pm
@@ -52,8 +52,8 @@ sub name { my ($self) = @_; return $self->Text('Income Statement') }
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'basis',
-            text => $self->Text('Reporting Basis') }];
+    return [{value => $self->basis,
+             text  => $self->Text('Reporting Basis') }];
 }
 
 =back

--- a/lib/LedgerSMB/Report/PNL/Invoice.pm
+++ b/lib/LedgerSMB/Report/PNL/Invoice.pm
@@ -77,11 +77,9 @@ sub name { my ($self) = @_; return $self->Text('Invoice Profit/Loss') }
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'name',
-            text => $self->Text('Name') },
-            {name => 'invnumber',
+    return [{value => $self->invnumber,
             text => $self->Text('Invoice Number') },
-            {name => 'transdate',
+            {value => $self->transdate,
             text => $self->Text('Transaction Date') },
     ];
 }

--- a/lib/LedgerSMB/Report/PNL/Invoice.pm
+++ b/lib/LedgerSMB/Report/PNL/Invoice.pm
@@ -9,7 +9,7 @@ invoices
 =head1 SYNPOSIS
 
  my $rpt = LedgerSMB::Report::PNL::Invoice->new(%$request);
- $rpt->render($request);
+ $report->render();
 
 =head1 DESCRIPTION
 

--- a/lib/LedgerSMB/Report/PNL/Product.pm
+++ b/lib/LedgerSMB/Report/PNL/Product.pm
@@ -8,7 +8,7 @@ LedgerSMB::Report::PNL::Product - Profit/Loss reports on Products
 =head1 SYNPOSIS
 
  my $rpt = LedgerSMB::Report::PNL::Product->new(%$request);
- $rpt->render($request);
+ $report->render();
 
 =head1 DESCRIPTION
 

--- a/lib/LedgerSMB/Report/PNL/Product.pm
+++ b/lib/LedgerSMB/Report/PNL/Product.pm
@@ -73,9 +73,9 @@ sub name { my ($self) = @_;
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'partnumber',
+    return [{value => $self->partnumber,
             text => $self->Text('Part Number') },
-            {name => 'description',
+            {value => $self->description,
             text => $self->Text('Description') },
     ];
 }

--- a/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
@@ -112,7 +112,7 @@ has unit => (is => 'ro', isa => 'Str', required => '0');
 =cut
 
 sub run_report {
-    my ($self,$request) = $_;
+    my ($self) = $_;
     my @rows = $self->call_dbmethod(funcname => 'payroll_deduction_type__search');
     $_->{row_id} = $_->{id} for @rows;
     return $self->rows(@rows);

--- a/lib/LedgerSMB/Report/Payroll/Income_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Income_Types.pm
@@ -112,7 +112,7 @@ has unit => (is => 'ro', isa => 'Str', required => '0');
 =cut
 
 sub run_report {
-    my ($self,$request) = $_;
+    my ($self) = $_;
     my @rows = $self->call_dbmethod(funcname => 'payroll_income_type__search');
     $_->{row_id} = $_->{id} for @rows;
     return $self->rows(@rows);

--- a/lib/LedgerSMB/Report/Reconciliation/Summary.pm
+++ b/lib/LedgerSMB/Report/Reconciliation/Summary.pm
@@ -9,7 +9,7 @@ LedgerSMB
 =head1 SYNPOSIS
 
  my $report = LedgerSMB::Report::Reconciliation::Summary->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -207,7 +207,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     $self->manual_totals(1);
     my @rows = $self->call_dbmethod(funcname => 'reconciliation__search');
     my @accounts = $self->call_dbmethod(

--- a/lib/LedgerSMB/Report/Reconciliation/Summary.pm
+++ b/lib/LedgerSMB/Report/Reconciliation/Summary.pm
@@ -178,14 +178,14 @@ sub columns {
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'date_from',
-             text => $self->Text('From Date')},
-            {name => 'date_to',
-             text => $self->Text('To Date') },
-            {name => 'balance_from',
-             text => $self->Text('From Amount')},
-            {name => 'balance_to',
-             text => $self->Text('To Amount')}
+    return [{value => $self->date_from,
+             text  => $self->Text('From Date')},
+            {value => $self->date_to,
+             text  => $self->Text('To Date') },
+            {value => $self->balance_from,
+             text  => $self->Text('From Amount')},
+            {value => $self->balance_to,
+             text  => $self->Text('To Amount')}
      ];
 }
 

--- a/lib/LedgerSMB/Report/Taxform/Details.pm
+++ b/lib/LedgerSMB/Report/Taxform/Details.pm
@@ -113,10 +113,10 @@ sub columns {
 sub header_lines {
     my ($self) = @_;
     return [
-       { name => 'from_date', text => $self->Text('From Date') },
-       { name => 'to_date',   text => $self->Text('To Date') },
-       { name => 'taxform',   text => $self->Text('Tax Form') },
-       { name => 'meta_number',   text => $self->Text('Account Number') },
+        { value => $self->from_date,   text => $self->Text('From Date') },
+        { value => $self->to_date,     text => $self->Text('To Date') },
+        { value => $self->taxform,     text => $self->Text('Tax Form') },
+        { value => $self->meta_number, text => $self->Text('Account Number') },
     ];
 }
 

--- a/lib/LedgerSMB/Report/Taxform/Details.pm
+++ b/lib/LedgerSMB/Report/Taxform/Details.pm
@@ -149,7 +149,7 @@ sub buttons {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my $tf = LedgerSMB::DBObject::TaxForm
         ->new(dbh => $self->_dbh )
         ->get($self->tax_form_id);

--- a/lib/LedgerSMB/Report/Taxform/List.pm
+++ b/lib/LedgerSMB/Report/Taxform/List.pm
@@ -92,7 +92,7 @@ sub buttons {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'tax_form__list_all');
     for my $row(@rows){
         $row->{row_id} = $row->{id};

--- a/lib/LedgerSMB/Report/Taxform/Summary.pm
+++ b/lib/LedgerSMB/Report/Taxform/Summary.pm
@@ -107,9 +107,9 @@ sub columns {
 sub header_lines {
     my ($self) = @_;
     return [
-       { name => 'from_date', text => $self->Text('From Date') },
-       { name => 'to_date',   text => $self->Text('To Date') },
-       { name => 'taxform',   text => $self->Text('Tax Form') },
+       { value => $self->from_date, text => $self->Text('From Date') },
+       { value => $self->to_date,   text => $self->Text('To Date') },
+       { value => $self->taxform,   text => $self->Text('Tax Form') },
     ];
 }
 

--- a/lib/LedgerSMB/Report/Taxform/Summary.pm
+++ b/lib/LedgerSMB/Report/Taxform/Summary.pm
@@ -9,7 +9,7 @@ forms for LedgerSMB
 =head1 SYNPOSIS
 
  $report = LedgerSMB::Report::Taxform::Summary->new(%$request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -141,7 +141,7 @@ sub buttons {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my $tf = LedgerSMB::DBObject::TaxForm
         ->new(dbh => $self->_dbh )
         ->get($self->tax_form_id);

--- a/lib/LedgerSMB/Report/Timecards.pm
+++ b/lib/LedgerSMB/Report/Timecards.pm
@@ -8,7 +8,7 @@ LedgerSMB::Report::Timecards - Time and materials reports for LedgerSMB
 =head1 SYNOPSIS
 
  my $report = LedgerSMB::Report::Timecards->new(%$request);
- $report->render($request);
+ $report->render();
 
 =head1 DESCRIPTION
 
@@ -172,7 +172,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'timecard__report');
     for my $row (@rows){
         $row->{"day$row->{weekday}"} = $row->{qty};

--- a/lib/LedgerSMB/Report/Timecards.pm
+++ b/lib/LedgerSMB/Report/Timecards.pm
@@ -143,12 +143,12 @@ sub columns {
 
 sub header_lines  {
     my ($self) = @_;
-    return [{ name => 'date_from',
-              text => $self->Text('From Date'), },
-            { name => 'date_to',
-              text => $self->Text('To Date'), },
-            { name => 'partnumber',
-              text => $self->Text('Partnumber'), },
+    return [{ value => $self->date_from,
+              text  => $self->Text('From Date'), },
+            { value => $self->date_to,
+              text  => $self->Text('To Date'), },
+            { value => $self->partnumber,
+              text  => $self->Text('Partnumber'), },
     ];
 }
 

--- a/lib/LedgerSMB/Report/Trial_Balance.pm
+++ b/lib/LedgerSMB/Report/Trial_Balance.pm
@@ -196,8 +196,6 @@ sub header_lines {
              text => $self->Text('From date') },
             {value => $self->to_date,
              text => $self->Text('To Date') },
-            {value => $self->ignore_yearend,
-             text => $self->Text('Ignore Year-ends') },
             ];
 }
 

--- a/lib/LedgerSMB/Report/Trial_Balance.pm
+++ b/lib/LedgerSMB/Report/Trial_Balance.pm
@@ -192,11 +192,11 @@ sub columns {
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'from_date',
+    return [{value => $self->from_date,
              text => $self->Text('From date') },
-            {name => 'to_date',
+            {value => $self->to_date,
              text => $self->Text('To Date') },
-            {name => 'ignore_yearend',
+            {value => $self->ignore_yearend,
              text => $self->Text('Ignore Year-ends') },
             ];
 }

--- a/lib/LedgerSMB/Report/Trial_Balance.pm
+++ b/lib/LedgerSMB/Report/Trial_Balance.pm
@@ -15,13 +15,13 @@ Unlike other reports, trial balance reports can be saved:
 We can then run it:
 
  $report->run_report($request);
- $report->render($request);
+ $report->render();
 
 We can also retrieve a previous report from the database and run it:
 
  my $report = LedgerSMB::Report::Trial_Balance->get($id);
  $report->run_report($request);
- $report->render($request);
+ $report->render();
 
 =cut
 
@@ -214,7 +214,7 @@ Runs the trial balance report.
 =cut
 
 sub run_report {
-    my ($self,$request) = @_;
+    my ($self) = @_;
     $self->manual_totals('1');
     $self->approved;
     my @rawrows = $self->call_dbmethod(funcname => 'trial_balance__generate');

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -157,7 +157,7 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'batch_id',
+    return [{value => $self->batch_id,
              text => $self->Text('Batch ID')}, ]
 }
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -11,8 +11,7 @@ in LedgerSMB
   my $report = LedgerSMB::Report::Unapproved::Batch_Detail->new(
       %$request
   );
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -38,6 +38,10 @@ use Moose;
 use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
+
+has languages => (is => 'ro',
+                  required => 1);
+
 =head1 PROPERTIES
 
 =over
@@ -237,12 +241,10 @@ Runs the report, and assigns rows to $self->rows.
 
 sub run_report{
     my ($self, $request) = @_;
-    my @languages =
-        LedgerSMB::I18N::get_language_list($self,$request->{_user}->{language});
 
     $self->options([{
        name => 'language',
-       options => \@languages,
+       options => $self->languages,
        default_value => [$self->default_language],
     }, {
        name => 'media',

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -9,8 +9,7 @@ LedgerSMB
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::Unapproved::Batch_Overview->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -206,7 +205,7 @@ properties.
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     $self->get_rows();
     return;
 }

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -186,14 +186,14 @@ Returns the inputs to display on header.
 sub header_lines {
     my ($self) = @_;
     return [
-            {name => 'class_name',
-             text => $self->_locale->text('Transaction Type')},
-            {name => 'description',
-             text => $self->_locale->text('Description')},
-            {name => 'amount_gt',
-             text => $self->_locale->text('Amount Greater Than')},
-            {name => 'amount_lt',
-             text => $self->_locale->text('Amount Less Than')},
+            {value => $self->class_name,
+             text  => $self->_locale->text('Transaction Type')},
+            {value => $self->description,
+             text  => $self->_locale->text('Description')},
+            {value => $self->amount_gt,
+             text  => $self->_locale->text('Amount Greater Than')},
+            {value => $self->amount_lt,
+             text  => $self->_locale->text('Amount Less Than')},
     ];
 }
 

--- a/lib/LedgerSMB/Report/Unapproved/Drafts.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Drafts.pm
@@ -9,8 +9,7 @@ transactions) in LedgerSMB
 =head1 SYNPOSIS
 
   my $report = LedgerSMB::Report::Unapproved::Drafts->new(%$request);
-  $report->run;
-  $report->render($request, $format);
+  $report->render();
 
 =head1 DESCRIPTION
 
@@ -245,7 +244,7 @@ Runs the report, and assigns rows to $self->rows.
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'draft__search');
     for my $ref (@rows){
         my $script = $ref->{type};

--- a/lib/LedgerSMB/Report/Unapproved/Drafts.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Drafts.pm
@@ -141,18 +141,18 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'type',
-             text => $self->Text('Draft Type')},
-            {name => 'reference',
-             text => $self->Text('Reference')},
-            {name => 'from_date',
-             text => $self->Text('From Date')},
-            {name => 'to_date',
-             text => $self->Text('To Date')},
-            {name => 'amount_gt',
-             text => $self->Text('Amount Greater Than')},
-            {name => 'amount_lt',
-             text => $self->Text('Amount Less Than')}, ]
+    return [{value => $self->type,
+             text  => $self->Text('Draft Type')},
+            {value => $self->reference,
+             text  => $self->Text('Reference')},
+            {value => $self->from_date,
+             text  => $self->Text('From Date')},
+            {value => $self->to_date,
+             text  => $self->Text('To Date')},
+            {value => $self->amount_gt,
+             text  => $self->Text('Amount Greater Than')},
+            {value => $self->amount_lt,
+             text  => $self->Text('Amount Less Than')}, ]
 }
 
 =back

--- a/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
+++ b/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
@@ -133,10 +133,10 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'date_from',
-             text => $self->Text('Start Date')},
-            {name => 'date_to',
-             text =>  $self->Text('End Date')},]
+    return [{value => $self->date_from,
+             text  => $self->Text('Start Date')},
+            {value => $self->date_to,
+             text  =>  $self->Text('End Date')},]
 }
 
 =back

--- a/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
+++ b/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
@@ -8,8 +8,7 @@ LedgerSMB::Report::co::Balance_y_Mayor - Colombian Balance/Ledger Rpt
 =head1 SYNPOSIS
 
   my $bmreport = LedgerSMB::Report::co::Balance_y_Mayor->new(%$request);
-  $bmreport->run;
-  $bmreport->render($request, $format);
+  $bmreport->render();
 
 =head1 DESCRIPTION
 
@@ -176,7 +175,7 @@ Runs the report, and assigns rows to $self->rows.
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'report__general_balance');
     return $self->rows(\@rows);
 }

--- a/lib/LedgerSMB/Report/co/Caja_Diaria.pm
+++ b/lib/LedgerSMB/Report/co/Caja_Diaria.pm
@@ -9,7 +9,7 @@ LedgerSMB::Report::co::Caja_Diaria - Caja Diaria Reports (Colombia)
 
   my $cdreport = LedgerSMB::Report::co::Caja_Diaria->new(%$request);
   $cdreport->run;
-  $cdreport->render($request, $format);
+  $cdreport->render();
 
 =head1 DESCRIPTION
 
@@ -186,7 +186,7 @@ Runs the report, and assigns rows to $self->rows.
 =cut
 
 sub run_report{
-    my ($self,$request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'report__cash_summary');
     for my $ref(@rows){
         $ref->{document_type} = $doctypes->{$ref->{document_type}}

--- a/lib/LedgerSMB/Report/co/Caja_Diaria.pm
+++ b/lib/LedgerSMB/Report/co/Caja_Diaria.pm
@@ -125,14 +125,14 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'date_from',
-             text => $self->Text('Start Date')},
-            {name => 'date_to',
-             text => $self->Text('End Date')},
-            {name => 'accno',
-             text => $self->Text('Account Number Start')},
-            {name => 'reference',
-             text => $self->Text('Account Number End')},]
+    return [{value => $self->date_from,
+             text  => $self->Text('Start Date')},
+            {value => $self->date_to,
+             text  => $self->Text('End Date')},
+            {value => $self->accno,
+             text  => $self->Text('Account Number Start')},
+            {value => $self->reference,
+             text  => $self->Text('Account Number End')},]
 }
 
 =back

--- a/lib/LedgerSMB/Router.pm
+++ b/lib/LedgerSMB/Router.pm
@@ -90,7 +90,7 @@ our @EXPORT = ## no critic (ProhibitAutomaticExportation)
 our @EXPORT_OK = qw(router);
 our %EXPORT_TAGS = (
     all => [ qw( any del get head options patch post put
-             hook json locale set user )]
+             hook json locale set setting user )]
     );
 
 =head1 MODULE METHODS
@@ -493,6 +493,9 @@ sub api {
 
             $has_body = reftype $triplet->[2] ne 'ARRAY'
                 or Plack::Util::content_length($triplet->[2]);
+            my $content_type =
+                (Plack::Util::header_get($triplet->[1], 'Content-Type')
+                 =~ s/;(.*)$//r);
             ($result, $errors, $warnings) =
                 $schema->validate_response(
                     method => $env->{REQUEST_METHOD},
@@ -502,11 +505,7 @@ sub api {
                         header => { $triplet->[1]->@* },
                         path => $params,
                         query => $req->query_parameters->as_hashref_mixed,
-                        body => [
-                            $has_body,
-                            Plack::Util::header_get($triplet->[1], 'Content-Type'),
-                            $triplet->[2]
-                            ]
+                        body => [ $has_body, $content_type, $triplet->[2] ]
                     });
             return error($req, HTTP_INTERNAL_SERVER_ERROR, [], @$errors)
                 if scalar(@$errors) > 0;

--- a/lib/LedgerSMB/Routes/ERP/API/Contacts.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Contacts.pm
@@ -108,7 +108,7 @@ sub _get_sics {
     }
     die $sth->errstr if $sth->err;
 
-    return \@results;
+    return { items => \@results, _links => [] };
 }
 
 sub _update_sic {
@@ -302,7 +302,7 @@ sub _get_businesstypes {
     }
     die $sth->errstr if $sth->err;
 
-    return \@results;
+    return { items => \@results, _links => [] };
 }
 
 sub _update_businesstype {
@@ -449,9 +449,18 @@ paths:
           content:
             application/json:
               schema:
-                type: array
+                type: object
+                required:
+                  - items
+                properties:
+                  _links:
+                    type: array
+                    items:
+                      type: object
                 items:
-                  $ref: '#/components/schemas/SIC'
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SIC'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -620,9 +629,18 @@ paths:
           content:
             application/json:
               schema:
-                type: array
+                type: object
+                required:
+                  - items
+                properties:
+                  _links:
+                    type: array
+                    items:
+                      type: object
                 items:
-                  $ref: '#/components/schemas/BusinessType'
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/BusinessType'
         400:
           $ref: '#/components/responses/400'
         401:

--- a/lib/LedgerSMB/Routes/ERP/API/Contacts.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Contacts.pm
@@ -23,6 +23,9 @@ use warnings;
 
 use HTTP::Status qw( HTTP_OK HTTP_CREATED HTTP_CONFLICT );
 
+use LedgerSMB::PSGI::Util qw( template_response );
+use LedgerSMB::Report::Listings::Business_Type;
+use LedgerSMB::Report::Listings::SIC;
 use LedgerSMB::Router appname => 'erp/api';
 
 set logger => 'erp.api.contacts';
@@ -93,7 +96,7 @@ sub _get_sic {
 }
 
 sub _get_sics {
-    my ($c) = @_;
+    my ($c, $formatter) = @_;
     my $sth = $c->dbh->prepare(
         q|SELECT * FROM sic ORDER BY code|
         ) or die $c->dbh->errstr;
@@ -108,7 +111,17 @@ sub _get_sics {
     }
     die $sth->errstr if $sth->err;
 
-    return { items => \@results, _links => [] };
+    return {
+        items => \@results,
+        _links => [
+            map {
+                +{
+                    rel => 'download',
+                    href => "?format=$_",
+                    title => $_
+                }
+            } $formatter->get_formats->@* ]
+    };
 }
 
 sub _update_sic {
@@ -145,8 +158,20 @@ sub _update_sic {
 
 get api '/contacts/sic' => sub {
     my ($env, $r, $c, $body, $params) = @_;
+    my $formatter = $env->{wire}->get( 'output_formatter' );
 
-    my $response = _get_sics( $c );
+    if (my $format = $r->query_parameters->get('format')) {
+        my $report = LedgerSMB::Report::Listings::SIC->new(
+            _dbh => $c->dbh,
+            language => 'en',
+            );
+        my $renderer = $formatter->report_doc_renderer( $c->dbh, $format );
+
+        return template_response( $report->render( renderer => $renderer ),
+                                  disposition => 'attach');
+    }
+
+    my $response = _get_sics( $c, $formatter );
     return [ 200,
              [ 'Content-Type' => 'application/json; charset=UTF-8' ],
              $response  ];
@@ -286,7 +311,7 @@ sub _get_businesstype {
 }
 
 sub _get_businesstypes {
-    my ($c) = @_;
+    my ($c, $formatter) = @_;
     my $sth = $c->dbh->prepare(
         q|SELECT * FROM business ORDER BY id|
         ) or die $c->dbh->errstr;
@@ -302,7 +327,17 @@ sub _get_businesstypes {
     }
     die $sth->errstr if $sth->err;
 
-    return { items => \@results, _links => [] };
+    return {
+        items => \@results,
+        _links => [
+            map {
+                +{
+                    rel => 'download',
+                    href => "?format=$_",
+                    title => $_
+                }
+            } $formatter->get_formats->@* ]
+    };
 }
 
 sub _update_businesstype {
@@ -340,8 +375,20 @@ sub _update_businesstype {
 
 get api '/contacts/business-types' => sub {
     my ($env, $r, $c, $body, $params) = @_;
+    my $formatter = $env->{wire}->get( 'output_formatter' );
 
-    my $response = _get_businesstypes( $c );
+    if (my $format = $r->query_parameters->get('format')) {
+        my $report = LedgerSMB::Report::Listings::Business_Type->new(
+            _dbh => $c->dbh,
+            language => 'en',
+            );
+        my $renderer = $formatter->report_doc_renderer( $c->dbh, $format );
+
+        return template_response( $report->render( renderer => $renderer ),
+                                  disposition => 'attach');
+    }
+
+    my $response = _get_businesstypes( $c, $formatter );
     return [ 200,
              [ 'Content-Type' => 'application/json; charset=UTF-8' ],
              $response  ];

--- a/lib/LedgerSMB/Routes/ERP/API/GeneralLedger.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/GeneralLedger.pm
@@ -108,7 +108,7 @@ sub _get_gifis {
     }
     die $sth->errstr if $sth->err;
 
-    return \@results;
+    return { items => \@results, _links => [] };
 }
 
 sub _update_gifi {
@@ -253,9 +253,18 @@ paths:
           content:
             application/json:
               schema:
-                type: array
+                type: object
+                required:
+                  - items
+                properties:
+                  _links:
+                    type: array
+                    items:
+                      type: object
                 items:
-                  $ref: '#/components/schemas/GIFI'
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/GIFI'
         400:
           $ref: '#/components/responses/400'
         401:

--- a/lib/LedgerSMB/Routes/ERP/API/Products.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Products.pm
@@ -23,6 +23,9 @@ use warnings;
 
 use HTTP::Status qw( HTTP_OK HTTP_CREATED HTTP_CONFLICT );
 
+use LedgerSMB::PSGI::Util qw( template_response );
+use LedgerSMB::Report::Inventory::Pricegroups;
+use LedgerSMB::Report::Listings::Warehouse;
 use LedgerSMB::Router appname => 'erp/api';
 
 set logger => 'erp.api.products';
@@ -93,7 +96,7 @@ sub _get_pricegroup {
 }
 
 sub _get_pricegroups {
-    my ($c) = @_;
+    my ($c, $formatter) = @_;
     my $sth = $c->dbh->prepare(
         q|SELECT id, pricegroup as description FROM pricegroup ORDER BY id|
         ) or die $c->dbh->errstr;
@@ -108,7 +111,17 @@ sub _get_pricegroups {
     }
     die $sth->errstr if $sth->err;
 
-    return { items => \@results, _links => [] };
+    return {
+        items => \@results,
+        _links => [
+            map {
+                +{
+                    rel => 'download',
+                    href => "?format=$_",
+                    title => $_
+                }
+            } $formatter->get_formats->@* ]
+    };
 }
 
 sub _update_pricegroup {
@@ -145,8 +158,20 @@ sub _update_pricegroup {
 
 get api '/products/pricegroups' => sub {
     my ($env, $r, $c, $body, $params) = @_;
+    my $formatter = $env->{wire}->get( 'output_formatter' );
 
-    my $response = _get_pricegroups( $c );
+    if (my $format = $r->query_parameters->get('format')) {
+        my $report = LedgerSMB::Report::Inventory::Pricegroups->new(
+            _dbh => $c->dbh,
+            language => 'en',
+            );
+        my $renderer = $formatter->report_doc_renderer( $c->dbh, $format );
+
+        return template_response( $report->render( renderer => $renderer ),
+                                  disposition => 'attach');
+    }
+
+    my $response = _get_pricegroups( $c, $formatter );
     return [ 200,
              [ 'Content-Type' => 'application/json; charset=UTF-8' ],
              $response  ];
@@ -284,7 +309,7 @@ sub _get_warehouse {
 }
 
 sub _get_warehouses {
-    my ($c) = @_;
+    my ($c, $formatter) = @_;
     my $sth = $c->dbh->prepare(
         q|SELECT * FROM warehouse ORDER BY id|
         ) or die $c->dbh->errstr;
@@ -299,7 +324,17 @@ sub _get_warehouses {
     }
     die $sth->errstr if $sth->err;
 
-    return { items => \@results, _links => [] };
+    return {
+        items => \@results,
+        _links => [
+            map {
+                +{
+                    rel => 'download',
+                    href => "?format=$_",
+                    title => $_
+                }
+            } $formatter->get_formats->@* ]
+    };
 }
 
 sub _update_warehouse {
@@ -335,8 +370,20 @@ sub _update_warehouse {
 
 get api '/products/warehouses' => sub {
     my ($env, $r, $c, $body, $params) = @_;
+    my $formatter = $env->{wire}->get( 'output_formatter' );
 
-    my $response = _get_warehouses( $c );
+    if (my $format = $r->query_parameters->get('format')) {
+        my $report = LedgerSMB::Report::Listings::Warehouse->new(
+            _dbh => $c->dbh,
+            language => 'en',
+            );
+        my $renderer = $formatter->report_doc_renderer( $c->dbh, $format );
+
+        return template_response( $report->render( renderer => $renderer ),
+                                  disposition => 'attach');
+    }
+
+    my $response = _get_warehouses( $c, $formatter );
     return [ 200,
              [ 'Content-Type' => 'application/json; charset=UTF-8' ],
              $response  ];

--- a/lib/LedgerSMB/Routes/ERP/API/Products.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Products.pm
@@ -108,7 +108,7 @@ sub _get_pricegroups {
     }
     die $sth->errstr if $sth->err;
 
-    return \@results;
+    return { items => \@results, _links => [] };
 }
 
 sub _update_pricegroup {
@@ -299,7 +299,7 @@ sub _get_warehouses {
     }
     die $sth->errstr if $sth->err;
 
-    return \@results;
+    return { items => \@results, _links => [] };
 }
 
 sub _update_warehouse {
@@ -443,9 +443,18 @@ paths:
           content:
             application/json:
               schema:
-                type: array
+                type: object
+                required:
+                  - items
+                properties:
+                  _links:
+                    type: array
+                    items:
+                      type: object
                 items:
-                  $ref: '#/components/schemas/Pricegroup'
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Pricegroup'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -614,9 +623,18 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Warehouse'
+                type: object
+                required:
+                  - items
+                properties:
+                  _links:
+                    type: array
+                    items:
+                      type: object
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Warehouse'
         400:
           $ref: '#/components/responses/400'
         401:

--- a/lib/LedgerSMB/Scripts/admin.pm
+++ b/lib/LedgerSMB/Scripts/admin.pm
@@ -70,12 +70,8 @@ sub list_sessions {
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'Reports/display_report', {
         name    => $request->{_locale}->text('Active Sessions'),
-        script  => 'admin.pl',
-        form    => $admin,
         columns => $columns,
         rows    => \@sessions,
-        buttons => [],
-        hiddens => [],
     });
 }
 

--- a/lib/LedgerSMB/Scripts/asset.pm
+++ b/lib/LedgerSMB/Scripts/asset.pm
@@ -391,15 +391,15 @@ sub display_report {
     {
         $hiddens->{$hide} = $request->{$hide};
     }
-    $request->{hiddens} = $hiddens;
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'Reports/display_report', {
-                        name => $title,
-                     request => $request,
-                     columns => $cols,
-                        rows => $rows,
-                     hiddens => $hiddens,
-                     buttons => $buttons,
+        FORM_ID => $request->{form_id},
+        HIDDENS => $hiddens,
+        SCRIPT  => $request->{script},
+        name    => $title,
+        columns => $cols,
+        rows    => $rows,
+        buttons => $buttons,
     });
 }
 
@@ -438,7 +438,6 @@ sub report_results {
     my $locale = $request->{_locale};
     my $ar = LedgerSMB::DBObject::Asset_Report->new(%$request);
     $ar->get_metadata;
-    my $title = $locale->text('Report Results');
     my @results = $ar->search;
     my $base_href = 'asset.pl?action=report_details&'.
                      "expense_acct=$ar->{expense_acct}";
@@ -536,11 +535,13 @@ sub report_results {
     $ar->{hiddens} = $hiddens;
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'Reports/display_report', {
-         request => $ar,
-            name => $title,
+         FORM_ID => $request->{form_id},
+         HIDDENS => $hiddens,
+         SCRIPT  => $request->{script},
+         name    => $locale->text('Report Results'),
          rows    => $rows,
          columns => $cols,
-        buttons  => $buttons,
+         buttons => $buttons,
    });
 }
 
@@ -647,14 +648,15 @@ sub report_details {
                    value => 'report_details_approve'
                    },
     ];
-    $report->{hiddens} = { id => $report->{id} };
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'Reports/display_report', {
-                    request => $report,
-                       name => $title,
-                    columns => $cols,
-                       rows => $rows,
-                    buttons => $buttons
+        FORM_ID => $request->{form_id},
+        HIDDENS => { id => $report->{id} },
+        SCRIPT  => $request->{script},
+        name    => $title,
+        columns => $cols,
+        rows    => $rows,
+        buttons => $buttons
     });
 }
 
@@ -748,19 +750,20 @@ sub partial_disposal_details {
                    value => 'disposal_details_approve'
                    },
         ];
-    $report->{hiddens} = {
-        id => $report->{id},
-        gain_acct => $report->{gain_acct},
-        loss_acct => $report->{loss_acct},
-    };
 
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'Reports/display_report', {
-                    request => $report,
-                       name => $title,
-                    columns => $cols,
-                       rows => $rows,
-                    buttons => $buttons
+        SCRIPT  => $request->{script},
+        HIDDENS => {
+            id        => $report->{id},
+            gain_acct => $report->{gain_acct},
+            loss_acct => $report->{loss_acct},
+        },
+        FORM_ID => $request->{form_id},
+        name    => $title,
+        columns => $cols,
+        rows    => $rows,
+        buttons => $buttons
     });
 }
 
@@ -853,20 +856,21 @@ sub disposal_details {
                    value => 'disposal_details_approve'
                    },
         ];
-    $report->{hiddens} = {
-        id        => $report->{id},
-        gain_acct => $report->{gain_acct},
-        loss_acct => $report->{loss_acct},
-    };
     my $title = $locale->text('Disposal Report [_1] on date [_2]',
                      $report->{id}, $report->{report_date});
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'Reports/display_report', {
-                       name => $title,
-                    request => $report,
-                    columns => $cols,
-                       rows => $rows,
-                    buttons => $buttons
+        SCRIPT  => $request->{script},
+        HIDDENS => {
+            id        => $report->{id},
+            gain_acct => $report->{gain_acct},
+            loss_acct => $report->{loss_acct},
+        },
+        FORM_ID => $request->{form_id},
+        name    => $title,
+        columns => $cols,
+        rows    => $rows,
+        buttons => $buttons
     });
 }
 

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -187,9 +187,7 @@ sub defaults_screen {
         $request->{$skey} = $request->setting->get($skey);
     }
 
-    my @country_list =
-        LedgerSMB::I18N::location_list_country_localized($request,
-            $request->{_company_config}->{default_language});
+    my @country_list = $request->enabled_countries->@*;
     unshift @country_list, {}
         if ! defined $request->{default_country};
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -307,7 +307,7 @@ sub _main_screen {
     my @plugins = grep { /^[^.]/ && -f "UI/Contact/plugins/$_" } readdir($dh2);
     closedir $dh2;
 
-    my @country_list = LedgerSMB::I18N::location_list_country_localized($request);
+    my @country_list = $request->enabled_countries->@*;
     my @entity_classes =
         map { $_->{class} = $locale->maketext($_->{class}) ; $_ }
         $request->call_procedure(

--- a/lib/LedgerSMB/Scripts/journal.pm
+++ b/lib/LedgerSMB/Scripts/journal.pm
@@ -33,8 +33,10 @@ sub chart_of_accounts {
     my ($request) = @_;
 
     return $request->render_report(
-        LedgerSMB::Report::COA->new(_locale => $request->{_locale},
-                                    dbh => $request->{dbh})
+        LedgerSMB::Report::COA->new(
+            _locale => $request->{_locale},
+            _uri => $request->{_uri},
+            dbh => $request->{dbh})
         );
 }
 

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -280,14 +280,14 @@ sub pre_bulk_post_report {
     }];
     delete $request->{$_}
        for qw(action dbh);
-    $request->{hiddens} = { %$request }; # prevent circular reference
-    delete $request->{form_id};
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render(
         $request,
         'Reports/display_report',
         {
-            request => $request,
+            SCRIPT  => $request->{script},
+            HIDDENS => { %$request },
+            FORM_ID => $request->{form_id},
             name    => $request->{_locale}->text('Payment batch'),
             columns => $cols,
             rows    => $rows,

--- a/lib/LedgerSMB/Scripts/payroll.pm
+++ b/lib/LedgerSMB/Scripts/payroll.pm
@@ -44,7 +44,7 @@ with different inputs.
 
 sub show_income_type {
     my ($request) = @_;
-    my @country_list = LedgerSMB::I18N::location_list_country_localized($request);
+    my @country_list = $request->enabled_countries->@*;
     @{$request->{pics}} = $request->call_procedure(
        funcname => 'payroll_pic__list', args => [$request->{country_id}]
     ) if $request->{country_id};
@@ -87,7 +87,7 @@ Displays the income type search screen
 
 sub search_income_type {
     my ($request) = @_;
-    my @country_list = LedgerSMB::I18N::location_list_country_localized($request);
+    my @country_list = $request->enabled_countries->@*;
 
     return LedgerSMB::Template::UI->new_UI
         ->render($request, 'payroll/income_search', $request);

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -315,6 +315,7 @@ sub generate_statement {
         $request->{entity_id} = $entity_id;
         my $aging_report = LedgerSMB::Report::Aging->new(
             (ref $filters{$eca}) ? (details_filter => $filters{$eca}) : (),
+            languages => $request->enabled_languages,
             %$request);
         $aging_report->run_report($request);
         my $statement = {

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -57,8 +57,11 @@ sub run_report{
                if $request->{"business_unit_$count"};
     }
     return $request->render_report(
-        LedgerSMB::Report::Aging->new(%$request)
-        );
+        LedgerSMB::Report::Aging->new(
+            %$request,
+            language => $request->{_user}->{language},
+            languages => $request->enabled_languages
+        ));
 }
 
 

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -182,9 +182,11 @@ sub _render_statement_batch {
         {
             buttons => \@buttons,
             columns => \@columns,
-            hiddens => {
+            HIDDENS => {
                 workflow_id => $wf_id,
             },
+            SCRIPT  => $request->{script},
+            FORM_ID => $request->{form_id},
             hlines => [
                 {
                     text => $locale->text('Status'),
@@ -193,8 +195,6 @@ sub _render_statement_batch {
             ],
             rows    => $rows,
             name    => $locale->text('E-mail aging reminder status'),
-            request => $request,
-            DBNAME  => $request->{company},
         });
 }
 

--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -98,8 +98,7 @@ sub start_report {
     if (!$request->{report_name}){
         die $request->{_locale}->text('No report specified');
     }
-    @{$request->{country_list}} =
-        LedgerSMB::I18N::location_list_country_localized($request);
+    $request->{country_list} = $request->enabled_countries;
     @{$request->{employees}} =  $request->call_procedure(
         funcname => 'employee__all_salespeople'
     );

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1142,8 +1142,7 @@ sub _render_user {
         funcname => 'person__list_salutations'
     );
 
-    @{$request->{countries}} =
-        LedgerSMB::I18N::location_list_country_localized($request);
+    $request->{countries} = $request->enabled_countries;
     my $locale = $request->{_locale};
 
     @{$request->{perm_sets}} = (

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -29,6 +29,7 @@ use LedgerSMB::Form;
 use LedgerSMB::Report::Taxform::Summary;
 use LedgerSMB::Report::Taxform::Details;
 use LedgerSMB::Report::Taxform::List;
+use LedgerSMB::Setting;
 use LedgerSMB::Template;
 use LedgerSMB::Template::UI;
 
@@ -69,7 +70,9 @@ sub _taxform_screen
 {
     my ($request) = @_;
     my $taxform = LedgerSMB::DBObject::TaxForm->new(%$request);
-    $taxform->get_metadata();
+    $taxform->{countries} = $request->enabled_countries;
+    $taxform->{default_country} =
+        LedgerSMB::Setting->new(%$request)->get('default_country');
 
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'taxform/add_taxform', $taxform);
@@ -238,7 +241,7 @@ sub list_all {
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2010-2018 The LedgerSMB Core Team
+Copyright (C) 2010-2022 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -286,6 +286,8 @@ sub get_batch {
     return $request->render_report(
         LedgerSMB::Report::Unapproved::Batch_Detail->new(
             default_language => $setting->get('default_language'),
+            language         => $request->{_user}->{language},
+            languages        => $request->enabled_languages,
             %$request,
         ));
 }
@@ -518,7 +520,11 @@ and gl transactions are not printed.
 
 sub print_batch {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Unapproved::Batch_Detail->new(%$request);
+    my $report = LedgerSMB::Report::Unapproved::Batch_Detail->new(
+        %$request,
+        language         => $request->{_user}->{language},
+        languages        => $request->enabled_languages,
+        );
     $request->{format} = 'pdf';
     $request->{media} = 'zip';
 

--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -69,7 +69,7 @@ sub _wrap_html {
             check_id => _check_hashid( $failing_check ),
             database => $request->{database},
             resubmit_action => $request->{resubmit_action},
-            action_url => $request->get_relative_url,
+            action_url => $request->{_uri}->as_string,
         });
 
     $template = LedgerSMB::Template::UI->new_UI;

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -407,6 +407,7 @@ sub get_template_args {
                       format => $extension,
                       language_code => $self->{language},
                       PARSER => $parser,
+                      _dbh => $self->{dbh}
                   }),
               # We need this provider in order to allow the templates to
               # depend on 'dynatable.*'

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -32,15 +32,8 @@ our @pre_render_cbs = (
     sub {
         my ($request, $template, $vars, $cvars) = @_;
         $vars->{USER} = $request->{_user};
-        $vars->{DBNAME} = $request->{company};
         $vars->{locale} = $vars->{language} // $vars->{locale};
         $cvars->{locale} = $cvars->{language} // $cvars->{locale};
-        if ($request->{company} && $request->{_company_config}) {
-            $vars->{SETTINGS} = {
-                papersize => 'letter', # default paper size when not configured
-                (%{$request->{_company_config}},)
-            };
-        }
     },
     );
 

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -102,6 +102,7 @@ sub render_string {
     my ($self, $request, $template, $vars, $cvars) = @_;
     my $locale;
     $vars //= {};
+    delete $vars->{HIDDENS}->{form_id} if $vars->{HIDDENS};
 
     for my $cb (@pre_render_cbs) {
         $cb->($request, $template, $vars, $cvars);

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -131,6 +131,7 @@ sub render_string {
                     value => 'screen'
                 } )
           ],
+          SETTINGS => $request->{_company_settings},
           # translation of constant-string arguments
           text => sub {
               if ($locale) {

--- a/locale/LedgerSMB.pot
+++ b/locale/LedgerSMB.pot
@@ -2,12 +2,12 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.10.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:54+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -90,7 +90,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -102,7 +102,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -147,7 +147,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr ""
 
@@ -163,8 +163,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -172,8 +172,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -181,11 +181,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -210,22 +210,22 @@ msgstr ""
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -306,7 +306,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -697,11 +697,11 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -713,13 +713,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -783,9 +783,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -798,12 +798,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -819,16 +819,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -867,7 +867,7 @@ msgstr ""
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -997,7 +997,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr ""
 
@@ -1067,13 +1067,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1158,12 +1158,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1243,15 +1243,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Business Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1302,9 +1302,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1452,11 +1452,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1516,7 +1516,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1601,8 +1601,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1649,12 +1649,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1665,7 +1689,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1693,7 +1717,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1750,7 +1774,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1838,7 +1862,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1850,7 +1874,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1878,7 +1902,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1889,7 +1913,7 @@ msgstr ""
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1916,22 +1940,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1950,7 +1974,7 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1966,8 +1990,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2029,7 +2053,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2106,17 +2130,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2146,8 +2170,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2226,7 +2250,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2241,7 +2265,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2252,7 +2276,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr ""
 
@@ -2337,11 +2361,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2354,7 +2378,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2366,7 +2390,7 @@ msgstr ""
 msgid "Delete User"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2389,21 +2413,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2411,11 +2435,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2437,7 +2461,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2458,15 +2482,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2483,13 +2507,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2557,7 +2581,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2583,16 +2607,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2600,11 +2624,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2636,6 +2660,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2644,11 +2672,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2675,9 +2703,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2707,7 +2735,7 @@ msgstr ""
 msgid "E-mail address missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2868,7 +2896,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2924,14 +2952,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2975,7 +3003,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -2984,7 +3012,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -2993,7 +3021,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3017,7 +3045,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3054,7 +3082,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3062,7 +3090,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3183,7 +3211,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr ""
 
@@ -3199,7 +3227,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3343,7 +3371,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3366,11 +3394,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3401,7 +3429,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3409,7 +3437,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3516,7 +3544,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3558,18 +3586,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3721,7 +3749,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3742,7 +3770,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3796,9 +3824,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3827,7 +3855,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3842,10 +3870,10 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3938,7 +3966,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr ""
 
@@ -3970,7 +3998,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr ""
 
@@ -3978,7 +4006,7 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
@@ -4011,7 +4039,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4239,7 +4267,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4328,11 +4356,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4353,7 +4381,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr ""
 
@@ -4370,12 +4398,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4470,7 +4498,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4504,15 +4532,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr ""
@@ -4572,7 +4599,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4624,7 +4651,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4656,7 +4683,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4727,9 +4754,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4769,7 +4796,7 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr ""
 
@@ -4813,8 +4840,8 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4831,7 +4858,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4839,7 +4866,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr ""
 
@@ -4913,7 +4940,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4945,7 +4972,7 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5035,9 +5062,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5046,8 +5073,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5086,8 +5113,8 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5115,7 +5142,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5144,7 +5171,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5211,7 +5238,7 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5272,11 +5299,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5442,7 +5469,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5450,7 +5477,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5571,7 +5598,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5631,15 +5658,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5699,7 +5726,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5725,7 +5752,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5741,7 +5768,7 @@ msgstr ""
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5953,13 +5980,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6029,12 +6056,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6046,7 +6073,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6113,7 +6140,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6289,8 +6316,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6468,7 +6495,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
@@ -6652,7 +6679,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6709,7 +6736,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6729,7 +6756,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6813,8 +6840,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6861,8 +6888,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6932,8 +6959,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -6979,14 +7006,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7010,7 +7037,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7062,8 +7089,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7174,8 +7201,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7183,8 +7210,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7504,8 +7531,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7584,7 +7611,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7630,14 +7657,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7659,7 +7686,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7687,7 +7714,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7701,7 +7728,7 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7810,9 +7837,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7870,7 +7897,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7911,11 +7938,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8044,7 +8071,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8058,7 +8085,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8105,7 +8132,7 @@ msgstr ""
 msgid "Variable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8114,8 +8141,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8189,7 +8216,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
 msgstr ""
@@ -8202,7 +8229,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8330,13 +8357,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8575,7 +8602,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/ar_EG.po
+++ b/locale/po/ar_EG.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Arabic (Egypt) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && "
 "n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "ارصدة موردين متبقية"
@@ -111,7 +111,7 @@ msgstr "ارصدة موردين متبقية"
 msgid "AP Transaction"
 msgstr "حركة حساب مورد"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "حركات حساب الموردين"
 
@@ -146,7 +146,7 @@ msgstr "فاتورة مورد"
 msgid "AR Invoices"
 msgstr "فواتير الموردين"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "ارصدة عملاء "
@@ -157,7 +157,7 @@ msgstr "ارصدة عملاء "
 msgid "AR Transaction"
 msgstr "حركة حساب عميل"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "حركات حساب العملاء"
 
@@ -174,8 +174,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "حركة حساب عميل"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -183,8 +183,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "الوصول ممنوع"
 
@@ -192,11 +192,11 @@ msgstr "الوصول ممنوع"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -221,22 +221,22 @@ msgstr "حساب"
 msgid "Account Description"
 msgstr "وصف الحساب"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "اسم الحساب"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -688,11 +688,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -710,11 +710,11 @@ msgstr ""
 msgid "Amount"
 msgstr "الكمية"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -726,13 +726,13 @@ msgstr "الرصيد "
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -796,9 +796,9 @@ msgid "Approval Status"
 msgstr "حالة القبول"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "موافقة"
@@ -811,12 +811,12 @@ msgstr "موافقة"
 msgid "Approved"
 msgstr "تمت الموافقة"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "تمت الموافقة بواسطة"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "تمت الموافقة في"
 
@@ -832,16 +832,16 @@ msgstr ""
 msgid "Apr"
 msgstr "ابريل"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "ابريل"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr "أصول"
 msgid "Asset Account"
 msgstr "حساب أصول"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Aug"
 msgstr "اغسطس"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "اغسطس"
 
@@ -1081,13 +1081,13 @@ msgstr "قاعدة بيانات احتياطية"
 msgid "Backup Roles"
 msgstr "أدوار النسخ الاحتياطي"
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "رصيد"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1173,12 +1173,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr "ميزانية"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "الرقم الضريبى"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "تكلفة البضاعة المباعة"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr "تغيير كلمة المرور"
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "قائمة الحسابات"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1618,8 +1618,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1666,12 +1666,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1682,7 +1706,7 @@ msgstr "تأكيد العملية"
 msgid "Confirm!"
 msgstr "تاكيد"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "تعارض مع بيانات موجودة، ربما أدخلت هذا من قبل؟"
 
@@ -1710,7 +1734,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1767,7 +1791,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1855,7 +1879,7 @@ msgstr "الدولة:"
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1867,7 +1891,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr "إنشاء قاعدة البيانات؟"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1895,7 +1919,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1906,7 +1930,7 @@ msgstr "دائن"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1933,22 +1957,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "عملة"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1967,7 +1991,7 @@ msgstr "عملة"
 msgid "Currency"
 msgstr "عملة"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1983,8 +2007,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2047,7 +2071,7 @@ msgstr " عميل غير موجود في الملف"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2124,17 +2148,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2164,8 +2188,8 @@ msgstr "تنسيق التاريخ"
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2244,7 +2268,7 @@ msgstr "يوم(أيام)"
 msgid "Days"
 msgstr "أيام"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2259,7 +2283,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2270,7 +2294,7 @@ msgstr ""
 msgid "Dec"
 msgstr "ديسمبر"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "ديسمبر"
 
@@ -2355,11 +2379,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2372,7 +2396,7 @@ msgstr ""
 msgid "Delete"
 msgstr "الغاء"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2385,7 +2409,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "إنشاء مستخدم"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2408,21 +2432,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "تاريخ الوصول"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2430,11 +2454,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2456,7 +2480,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2477,15 +2501,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2502,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2576,7 +2600,7 @@ msgstr "تفاصيل"
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2602,16 +2626,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2619,11 +2643,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2655,6 +2679,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr "د."
@@ -2663,11 +2691,11 @@ msgstr "د."
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2681,11 +2709,11 @@ msgstr "مسودات"
 msgid "Drawing"
 msgstr "رسم"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2694,9 +2722,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2726,7 +2754,7 @@ msgstr "بريد الكتروني"
 msgid "E-mail address missing!"
 msgstr "عنوان البريد الالكتروني غير موجود"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2887,7 +2915,7 @@ msgstr "أحد عشر"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr "بريد الكتروني"
 
@@ -2944,14 +2972,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2995,7 +3023,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3004,7 +3032,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3013,7 +3041,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3038,7 +3066,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "اسم الدولة"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3075,7 +3103,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3083,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3095,7 +3123,7 @@ msgstr ""
 msgid "Exch"
 msgstr "سعر  الصرف"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3204,7 +3232,7 @@ msgstr ""
 msgid "Feb"
 msgstr "فبراير"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "فبراير"
 
@@ -3220,7 +3248,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3364,7 +3392,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3387,11 +3415,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3422,7 +3450,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3430,7 +3458,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3442,7 +3470,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3450,7 +3478,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3537,7 +3565,7 @@ msgstr ""
 msgid "HR"
 msgstr "موارد بشرية"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3579,18 +3607,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3743,7 +3771,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3764,7 +3792,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3818,9 +3846,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3849,7 +3877,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3864,10 +3892,10 @@ msgstr "تاريخ الفاتورة غير موجود"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3960,7 +3988,7 @@ msgstr ""
 msgid "Jan"
 msgstr "يناير"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "يناير"
 
@@ -3992,7 +4020,7 @@ msgstr ""
 msgid "Jul"
 msgstr "يولية"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "يولية"
 
@@ -4000,7 +4028,7 @@ msgstr "يولية"
 msgid "Jun"
 msgstr "يونية"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "يونية"
@@ -4033,7 +4061,7 @@ msgstr "تكلفة عمالة"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4261,7 +4289,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4350,11 +4378,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4375,7 +4403,7 @@ msgstr ""
 msgid "Mar"
 msgstr "مارس"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "مارس"
 
@@ -4392,12 +4420,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "مايو"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4492,7 +4520,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4526,15 +4554,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "الاسم"
@@ -4594,7 +4621,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4646,7 +4673,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4678,7 +4705,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4749,9 +4776,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4791,7 +4818,7 @@ msgstr ""
 msgid "Nov"
 msgstr "نوفمبر"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "نوفمبر"
 
@@ -4836,8 +4863,8 @@ msgstr ""
 msgid "Number:"
 msgstr "الرقم"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4854,7 +4881,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4862,7 +4889,7 @@ msgstr ""
 msgid "Oct"
 msgstr "اكتوبر"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "اكتوبر"
 
@@ -4938,7 +4965,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "امر"
@@ -4970,7 +4997,7 @@ msgstr "تاريخ الامر غير موجود"
 msgid "Order Entry"
 msgstr "ادخال الامر"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5061,9 +5088,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5072,8 +5099,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5113,8 +5140,8 @@ msgstr "رقم بوليصة الشحن غير موجود"
 msgid "Packing list"
 msgstr "قائمة تعبئة"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5142,7 +5169,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5172,7 +5199,7 @@ msgstr "تفاصيل"
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5240,7 +5267,7 @@ msgstr "المدفوعات"
 msgid "Payment"
 msgstr "الدفع النقدى"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5302,11 +5329,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Post"
 msgstr "تسجيل"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5601,7 +5628,7 @@ msgstr ""
 msgid "Print"
 msgstr "طباعة"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5661,15 +5688,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5729,7 +5756,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5755,7 +5782,7 @@ msgid "Purchase Orders"
 msgstr "اوامر شراء"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "قيمة أمر الشراء"
 
@@ -5772,7 +5799,7 @@ msgstr "امر شراء"
 msgid "Purchased"
 msgstr "تم الشراء"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5987,13 +6014,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6063,12 +6090,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr "اسم التقرير"
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "نتائج التقرير"
 
@@ -6080,7 +6107,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "نوع التقرير"
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,7 +6175,7 @@ msgstr ""
 msgid "Required by"
 msgstr "مطلوب من قبل"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6326,8 +6353,8 @@ msgstr "عروض اسعار للعملاء"
 msgid "Sales:"
 msgstr "المبيعات:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6505,7 +6532,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "الشاشة"
@@ -6689,7 +6716,7 @@ msgstr ""
 msgid "Sell"
 msgstr "بيع"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6746,7 +6773,7 @@ msgstr "سبتمبر"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "سبتمبر"
 
@@ -6766,7 +6793,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "رقم تسلسلي"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6851,8 +6878,8 @@ msgstr "شحن إلى"
 msgid "Ship To:"
 msgstr "شحن إلى:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6899,8 +6926,8 @@ msgstr "تاريخ الشحن غير موجود!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6971,8 +6998,8 @@ msgstr ""
 msgid "Some"
 msgstr "بعض"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7018,14 +7045,14 @@ msgstr "اساس"
 msgid "Standard Industrial Codes"
 msgstr "الاكواد الصناعية القياسية"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7049,7 +7076,7 @@ msgid "Startdate"
 msgstr "تاريخ يدء العمل"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7101,8 +7128,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7214,8 +7241,8 @@ msgstr "الإجمالي"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7223,8 +7250,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7545,8 +7572,8 @@ msgstr ""
 msgid "Thu"
 msgstr "الخميس"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7625,7 +7652,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr "حتى تاريخ"
@@ -7671,14 +7698,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7700,7 +7727,7 @@ msgstr ""
 msgid "Total"
 msgstr "مجموع"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,7 +7755,7 @@ msgstr "حركة"
 msgid "Transaction Approval"
 msgstr "الموافقة على الحركة"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7742,7 +7769,7 @@ msgstr "تاريخ الحركة غير موجود"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7851,9 +7878,9 @@ msgid "Two"
 msgstr "اثنان"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7911,7 +7938,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7952,11 +7979,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr "فك القفل"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8085,7 +8112,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8099,7 +8126,7 @@ msgstr "مستخدم"
 msgid "User Name"
 msgstr "اسم المستخدم"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr "المستخدم موجود، هل تريد استيراده؟"
 
@@ -8147,7 +8174,7 @@ msgstr ""
 msgid "Variable"
 msgstr "متوفر"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8156,8 +8183,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8231,7 +8258,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "مورد غير موجود في الملف"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8245,7 +8272,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8374,13 +8401,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8619,7 +8646,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/bg.po
+++ b/locale/po/bg.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Задължения към доставчици"
@@ -110,7 +110,7 @@ msgstr "Задължения към доставчици"
 msgid "AP Transaction"
 msgstr "Превод покупка"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Преводи покупки"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Вземания от клиенти"
@@ -156,7 +156,7 @@ msgstr "Вземания от клиенти"
 msgid "AR Transaction"
 msgstr "Превод продажба"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Преводи продажби"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Превод продажба"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Сметка"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr "Натрупване"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Остарял"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Сума"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Сума за получаване"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Апр"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Април"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Актив"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Авг"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Август"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Баланс"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Направления"
 msgid "Business Number"
 msgstr "Номер на направление"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "COGS"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1469,11 +1469,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Сметкоплан"
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1619,8 +1619,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1667,12 +1667,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1683,7 +1707,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Съгласие!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1711,7 +1735,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Кредит"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1934,22 +1958,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Валута"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Валута"
 msgid "Currency"
 msgstr "Валута"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "Липсва клиента в базите!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2125,17 +2149,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr "Ден(дни)"
 msgid "Days"
 msgstr "Дни"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr "Дебитно известие към фактура"
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Дек"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Декември"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Изтрии"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2386,7 +2410,7 @@ msgstr "Изтрии задачата"
 msgid "Delete User"
 msgstr "Изтрии"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Дата на доставка"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2431,11 +2455,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2478,15 +2502,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2603,16 +2627,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2620,11 +2644,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2664,11 +2692,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2682,11 +2710,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Изрисуване"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "Ел.адрес"
 msgid "E-mail address missing!"
 msgstr "Липсва Ел.адрес!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3005,7 +3033,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Име на фирма"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3076,7 +3104,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3096,7 +3124,7 @@ msgstr "Винаги"
 msgid "Exch"
 msgstr "Курс"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Фев"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Февруари"
 
@@ -3221,7 +3249,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3388,11 +3416,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr "Номер на главната книга"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3431,7 +3459,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3443,7 +3471,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3451,7 +3479,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Създай"
@@ -3538,7 +3566,7 @@ msgstr ""
 msgid "HR"
 msgstr "Сътрудници"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3580,18 +3608,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3744,7 +3772,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3765,7 +3793,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3820,9 +3848,9 @@ msgstr "Ивентара е запазен!"
 msgid "Inventory transferred!"
 msgstr "Инвентара е преместен!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3851,7 +3879,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3866,10 +3894,10 @@ msgstr "Попусната дата на фактурата"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3962,7 +3990,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Яну"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Януари"
 
@@ -3994,7 +4022,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Юли"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Юли"
 
@@ -4002,7 +4030,7 @@ msgstr "Юли"
 msgid "Jun"
 msgstr "Юни"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Юни"
@@ -4035,7 +4063,7 @@ msgstr "Текущи разходи"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4263,7 +4291,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4352,11 +4380,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4377,7 +4405,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Мар"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Март"
 
@@ -4394,12 +4422,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Май"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4494,7 +4522,7 @@ msgstr "Месеци"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4528,15 +4556,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Име"
@@ -4596,7 +4623,7 @@ msgid "Next Number"
 msgstr "Следващ номер"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4648,7 +4675,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4680,7 +4707,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4751,9 +4778,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4793,7 +4820,7 @@ msgstr "Нищо не е преведено!"
 msgid "Nov"
 msgstr "Ное"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Ноември"
 
@@ -4838,8 +4865,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Номер"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4856,7 +4883,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Остарял"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4864,7 +4891,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Окт"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Октомври"
 
@@ -4939,7 +4966,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Поръчка"
@@ -4971,7 +4998,7 @@ msgstr "Липсва дата на поръчката!"
 msgid "Order Entry"
 msgstr "Поръчки"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5062,9 +5089,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5073,8 +5100,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5114,8 +5141,8 @@ msgstr "Липсва номер на опаковъчния лист!"
 msgid "Packing list"
 msgstr "Опъковачен лист"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5143,7 +5170,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5172,7 +5199,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5240,7 +5267,7 @@ msgstr "Подлежащи на плащане"
 msgid "Payment"
 msgstr "Разходен ордер"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5302,11 +5329,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5473,7 +5500,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5481,7 +5508,7 @@ msgstr ""
 msgid "Post"
 msgstr "Запази"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5603,7 +5630,7 @@ msgstr ""
 msgid "Print"
 msgstr "Печат"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5663,15 +5690,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5731,7 +5758,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5757,7 +5784,7 @@ msgid "Purchase Orders"
 msgstr "Поръчки за доставки"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5774,7 +5801,7 @@ msgstr "Поръчка за доставка"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5989,13 +6016,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Повтарящи се преводи"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6065,12 +6092,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6082,7 +6109,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6150,7 +6177,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Необходим е за"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6328,8 +6355,8 @@ msgstr "Номер на поръчка продажба със запазван�
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6507,7 +6534,7 @@ msgstr "Разписание"
 msgid "Scheduled"
 msgstr "Зададено разписание"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Екран"
@@ -6691,7 +6718,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Продажба"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6748,7 +6775,7 @@ msgstr "Сеп"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Септември"
 
@@ -6768,7 +6795,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Сериен номер"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6854,8 +6881,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6902,8 +6929,8 @@ msgstr "Липсва дата на доставка!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6974,8 +7001,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7021,14 +7048,14 @@ msgstr "Стандарт"
 msgid "Standard Industrial Codes"
 msgstr "БДС"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7052,7 +7079,7 @@ msgid "Startdate"
 msgstr "Начална дата"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7104,8 +7131,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7217,8 +7244,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7226,8 +7253,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7548,8 +7575,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7628,7 +7655,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7674,14 +7701,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7703,7 +7730,7 @@ msgstr ""
 msgid "Total"
 msgstr "Всичко"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,7 +7758,7 @@ msgstr "Превод"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7745,7 +7772,7 @@ msgstr "Липсва дата на превода"
 msgid "Transaction Dates"
 msgstr "Дата на превод"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7854,9 +7881,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7914,7 +7941,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7955,11 +7982,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8088,7 +8115,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8102,7 +8129,7 @@ msgstr "потребител"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8150,7 +8177,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Облагаема сделка"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8159,8 +8186,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8234,7 +8261,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Липсва доствчика в базата"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8248,7 +8275,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8377,13 +8404,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8622,7 +8649,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/ca.po
+++ b/locale/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transaccions de Despeses"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transaccions d'Ingressos"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaccions d'Ingressos"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Compta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -686,11 +686,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -708,11 +708,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -724,13 +724,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -794,9 +794,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -809,12 +809,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -830,16 +830,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr "Activat"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agost"
 
@@ -1079,13 +1079,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1171,12 +1171,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1256,15 +1256,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1280,7 +1280,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Núm. Negoci"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1315,9 +1315,9 @@ msgstr "Cost de Preu"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1333,7 +1333,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1465,11 +1465,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Taula de Comptes"
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1615,8 +1615,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1663,12 +1663,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1679,7 +1703,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1707,7 +1731,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1764,7 +1788,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1852,7 +1876,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1864,7 +1888,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1892,7 +1916,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1903,7 +1927,7 @@ msgstr "Crèdit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1930,22 +1954,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1964,7 +1988,7 @@ msgstr ""
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1980,8 +2004,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2044,7 +2068,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2121,17 +2145,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2161,8 +2185,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2241,7 +2265,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2256,7 +2280,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2267,7 +2291,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Des"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Desembre"
 
@@ -2352,11 +2376,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2369,7 +2393,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Esborrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2382,7 +2406,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Esborrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2405,21 +2429,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2427,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2453,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2474,15 +2498,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2499,13 +2523,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2573,7 +2597,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2599,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2616,11 +2640,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2652,6 +2676,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2660,11 +2688,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2678,11 +2706,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2691,9 +2719,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2723,7 +2751,7 @@ msgstr "Email"
 msgid "E-mail address missing!"
 msgstr "Falta Email!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2884,7 +2912,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2940,14 +2968,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2991,7 +3019,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3000,7 +3028,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3009,7 +3037,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3033,7 +3061,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3070,7 +3098,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3078,7 +3106,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Canvi"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3199,7 +3227,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrer"
 
@@ -3215,7 +3243,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3359,7 +3387,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3382,11 +3410,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3417,7 +3445,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3425,7 +3453,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3445,7 +3473,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3532,7 +3560,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3574,18 +3602,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3738,7 +3766,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3759,7 +3787,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3814,9 +3842,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3845,7 +3873,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3860,10 +3888,10 @@ msgstr "Falta Data Fra.!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3956,7 +3984,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Gen"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Gener"
 
@@ -3988,7 +4016,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juliol"
 
@@ -3996,7 +4024,7 @@ msgstr "Juliol"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juny"
@@ -4029,7 +4057,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4257,7 +4285,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4346,11 +4374,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4371,7 +4399,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Març"
 
@@ -4388,12 +4416,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4488,7 +4516,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4522,15 +4550,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nom"
@@ -4590,7 +4617,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4642,7 +4669,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4674,7 +4701,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4745,9 +4772,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4787,7 +4814,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembre"
 
@@ -4832,8 +4859,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4850,7 +4877,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsolet"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4858,7 +4885,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4933,7 +4960,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Ordre"
@@ -4965,7 +4992,7 @@ msgstr "Falta Data Ordre!"
 msgid "Order Entry"
 msgstr "Pressupostos i Comandes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5055,9 +5082,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5066,8 +5093,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5107,8 +5134,8 @@ msgstr "Falta Número Albarà!"
 msgid "Packing list"
 msgstr "Albarà"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5136,7 +5163,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5165,7 +5192,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5233,7 +5260,7 @@ msgstr "Pagables"
 msgid "Payment"
 msgstr "Pagament"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5295,11 +5322,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5465,7 +5492,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5473,7 +5500,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5595,7 +5622,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5655,15 +5682,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5723,7 +5750,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5749,7 +5776,7 @@ msgid "Purchase Orders"
 msgstr "Ordres de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5766,7 +5793,7 @@ msgstr "Ordre de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5980,13 +6007,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6056,12 +6083,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6073,7 +6100,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6140,7 +6167,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Soliciat per"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6317,8 +6344,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6496,7 +6523,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6680,7 +6707,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6737,7 +6764,7 @@ msgstr "Set"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Setembre"
 
@@ -6757,7 +6784,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6842,8 +6869,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6890,8 +6917,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6961,8 +6988,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7008,14 +7035,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7039,7 +7066,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7091,8 +7118,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7203,8 +7230,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7212,8 +7239,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7534,8 +7561,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7614,7 +7641,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7660,14 +7687,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7689,7 +7716,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7717,7 +7744,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7731,7 +7758,7 @@ msgstr "Falta Data Transacció!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7840,9 +7867,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7900,7 +7927,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7941,11 +7968,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8074,7 +8101,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8088,7 +8115,7 @@ msgstr "Usuari"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8136,7 +8163,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Imponible"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8145,8 +8172,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8220,7 +8247,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8234,7 +8261,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8362,13 +8389,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8607,7 +8634,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/cs.po
+++ b/locale/po/cs.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Czech (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= "
 "4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -111,7 +111,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Faktury přijaté"
 
@@ -146,7 +146,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -157,7 +157,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Faktury vydané"
 
@@ -174,8 +174,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Faktury vydané"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -183,8 +183,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -192,11 +192,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -221,22 +221,22 @@ msgstr "Účet"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Částka"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Dub"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Duben"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Aktiva"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Srp"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Srpen"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1257,15 +1257,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "IČO"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1316,9 +1316,9 @@ msgstr "Náklady na prodané zboží"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1466,11 +1466,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Účtový rozvrh"
 
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1616,8 +1616,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1664,12 +1664,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1680,7 +1704,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Podtvrďte!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1708,7 +1732,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1765,7 +1789,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1853,7 +1877,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1893,7 +1917,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1904,7 +1928,7 @@ msgstr "Dal"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1931,22 +1955,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Měna"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1965,7 +1989,7 @@ msgstr "Měna"
 msgid "Currency"
 msgstr "Měna"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1981,8 +2005,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2045,7 +2069,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2122,17 +2146,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2162,8 +2186,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2242,7 +2266,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2257,7 +2281,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2268,7 +2292,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Pro"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Prosinec"
 
@@ -2353,11 +2377,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2370,7 +2394,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Vymazat"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2383,7 +2407,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Vymazat"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2406,21 +2430,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2428,11 +2452,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2454,7 +2478,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2475,15 +2499,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2500,13 +2524,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2574,7 +2598,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2600,16 +2624,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2617,11 +2641,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2653,6 +2677,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2661,11 +2689,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2679,11 +2707,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2692,9 +2720,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2724,7 +2752,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Chybí E-mailová adresa!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2885,7 +2913,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2941,14 +2969,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2992,7 +3020,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3001,7 +3029,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3010,7 +3038,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3034,7 +3062,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3071,7 +3099,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3079,7 +3107,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3091,7 +3119,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurz"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3200,7 +3228,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Úno"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Únor"
 
@@ -3216,7 +3244,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3360,7 +3388,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3383,11 +3411,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3418,7 +3446,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3426,7 +3454,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3438,7 +3466,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3446,7 +3474,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3533,7 +3561,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3575,18 +3603,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3739,7 +3767,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3760,7 +3788,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3814,9 +3842,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3845,7 +3873,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3860,10 +3888,10 @@ msgstr "Chybí datum vystavení!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3956,7 +3984,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Led"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Leden"
 
@@ -3988,7 +4016,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Čec"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Červenec"
 
@@ -3996,7 +4024,7 @@ msgstr "Červenec"
 msgid "Jun"
 msgstr "Čer"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Červen"
@@ -4029,7 +4057,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4257,7 +4285,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4346,11 +4374,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4371,7 +4399,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Bře"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Březen"
 
@@ -4388,12 +4416,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Květen"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4488,7 +4516,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4522,15 +4550,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Jméno"
@@ -4590,7 +4617,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4642,7 +4669,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4674,7 +4701,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4745,9 +4772,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4787,7 +4814,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Lis"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Listopad"
 
@@ -4832,8 +4859,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Číslo"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4850,7 +4877,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Vyřazené"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4858,7 +4885,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Říj"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Říjen"
 
@@ -4933,7 +4960,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Objednávka"
@@ -4965,7 +4992,7 @@ msgstr "Chybí datum objednávky!"
 msgid "Order Entry"
 msgstr "Zadání objednávky"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5055,9 +5082,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5066,8 +5093,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5107,8 +5134,8 @@ msgstr "Chybí číslo dodacího listu"
 msgid "Packing list"
 msgstr "Dodací list"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5136,7 +5163,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5165,7 +5192,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5233,7 +5260,7 @@ msgstr "Závazky"
 msgid "Payment"
 msgstr "Platba"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5295,11 +5322,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5465,7 +5492,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5473,7 +5500,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5595,7 +5622,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5655,15 +5682,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5723,7 +5750,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5749,7 +5776,7 @@ msgid "Purchase Orders"
 msgstr "Vystavené objednávky"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5766,7 +5793,7 @@ msgstr "Vystavená objednávka"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5980,13 +6007,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6056,12 +6083,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6073,7 +6100,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6140,7 +6167,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Požadováno do"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6317,8 +6344,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6496,7 +6523,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Na obrazovku"
@@ -6680,7 +6707,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6737,7 +6764,7 @@ msgstr "Zář"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Září"
 
@@ -6757,7 +6784,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6842,8 +6869,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6890,8 +6917,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6961,8 +6988,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7008,14 +7035,14 @@ msgstr "Standardní"
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7039,7 +7066,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7091,8 +7118,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7203,8 +7230,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7212,8 +7239,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7534,8 +7561,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7614,7 +7641,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7660,14 +7687,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7689,7 +7716,7 @@ msgstr ""
 msgid "Total"
 msgstr "Celkem"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7717,7 +7744,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7731,7 +7758,7 @@ msgstr "Chybí datum!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7840,9 +7867,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7900,7 +7927,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7941,11 +7968,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8074,7 +8101,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8088,7 +8115,7 @@ msgstr "Uživatel"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8136,7 +8163,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Zdanitelné"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8145,8 +8172,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8220,7 +8247,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8234,7 +8261,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8362,13 +8389,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8607,7 +8634,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/da.po
+++ b/locale/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2022-01-09T21:20:18.950Z\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Danish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -21,7 +21,7 @@ msgstr ""
 "#-#-#-#-#  _da.po (i18next-conv)  #-#-#-#-#\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "Fakturaer"
 
@@ -108,7 +108,7 @@ msgstr "Kreditorfaktura"
 msgid "AP Invoices"
 msgstr "Kreditorfakturaer"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Udestående (Kreditor)"
@@ -120,7 +120,7 @@ msgstr "Udestående (Kreditor)"
 msgid "AP Transaction"
 msgstr "Kreditorpostering"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Kreditorposteringer"
 
@@ -155,7 +155,7 @@ msgstr "Debitorfaktura"
 msgid "AR Invoices"
 msgstr "Debitorfakturaer"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Udestående (Debitor)"
@@ -166,7 +166,7 @@ msgstr "Udestående (Debitor)"
 msgid "AR Transaction"
 msgstr "Debitorpostering"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Debitorposteringer"
 
@@ -183,8 +183,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Debitorpostering"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Debitor/Kreditor/Finans beløb"
 
@@ -192,8 +192,8 @@ msgstr "Debitor/Kreditor/Finans beløb"
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Ingen adgang"
 
@@ -201,11 +201,11 @@ msgstr "Ingen adgang"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -230,22 +230,22 @@ msgstr "Konto"
 msgid "Account Description"
 msgstr "Kontobeskrivelse"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Kontoetiket"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Kontonavn"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -326,7 +326,7 @@ msgstr "Periodisering"
 msgid "Accrual Basis:"
 msgstr "Periosdisering Basis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Udgået"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -697,11 +697,11 @@ msgstr "Allokeret"
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -719,11 +719,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Beløb"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -735,13 +735,13 @@ msgstr "Forfaldent"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -805,9 +805,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -820,12 +820,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -841,16 +841,16 @@ msgstr ""
 msgid "Apr"
 msgstr "apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "april"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -890,7 +890,7 @@ msgstr "Aktiv"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -915,7 +915,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Aug"
 msgstr "aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "august"
 
@@ -1090,13 +1090,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balance"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1182,12 +1182,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1268,15 +1268,15 @@ msgstr ""
 msgid "Budget"
 msgstr "Budget"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Budgetnummer"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgstr "Forretning"
 msgid "Business Number"
 msgstr "Forretningsnummer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1327,9 +1327,9 @@ msgstr "Kostpris"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1477,11 +1477,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Fakturerbar"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Kontoplan"
 
@@ -1541,7 +1541,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1627,8 +1627,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1675,12 +1675,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1691,7 +1715,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bekræft!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1719,7 +1743,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1776,7 +1800,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1864,7 +1888,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1876,7 +1900,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1904,7 +1928,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1915,7 +1939,7 @@ msgstr "Kredit"
 msgid "Credit Account"
 msgstr "Kreditkonto"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Kreditkontonummer"
 
@@ -1942,22 +1966,22 @@ msgstr "Kreditgrænse"
 msgid "Credit Note"
 msgstr "Kreditnota"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr "Kredit"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Val"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1976,7 +2000,7 @@ msgstr "Val"
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1992,8 +2016,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2056,7 +2080,7 @@ msgstr "Kunde ikke i databasen!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2133,17 +2157,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2173,8 +2197,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2253,7 +2277,7 @@ msgstr "Dag(e)"
 msgid "Days"
 msgstr "Dage"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2268,7 +2292,7 @@ msgstr "Debitor faktura"
 msgid "Debit Note"
 msgstr "Debitnota"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2279,7 +2303,7 @@ msgstr "Debit"
 msgid "Dec"
 msgstr "dec"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "december"
 
@@ -2364,11 +2388,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2381,7 +2405,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Fjern"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2394,7 +2418,7 @@ msgstr "Slet planlægning"
 msgid "Delete User"
 msgstr "Fjern"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2417,21 +2441,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leveringsdato"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2439,11 +2463,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2465,7 +2489,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2486,15 +2510,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2511,13 +2535,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2585,7 +2609,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2611,16 +2635,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2628,11 +2652,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2664,6 +2688,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2672,11 +2700,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2690,11 +2718,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Træk"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2703,9 +2731,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2735,7 +2763,7 @@ msgstr "E-post"
 msgid "E-mail address missing!"
 msgstr "E-post-adresse mangler!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2896,7 +2924,7 @@ msgstr "Elleve"
 msgid "Eleven-o"
 msgstr "Elleve"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2953,14 +2981,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3004,7 +3032,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3013,7 +3041,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3022,7 +3050,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3047,7 +3075,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Firmanavn"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3092,7 +3120,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3104,7 +3132,7 @@ msgstr "Hver"
 msgid "Exch"
 msgstr "Vxl"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3213,7 +3241,7 @@ msgstr ""
 msgid "Feb"
 msgstr "feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "februar"
 
@@ -3229,7 +3257,7 @@ msgstr "Halvtreds"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3373,7 +3401,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3396,11 +3424,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3431,7 +3459,7 @@ msgstr "Hovedbog referencenummer"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3439,7 +3467,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3451,7 +3479,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3459,7 +3487,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Generer"
@@ -3546,7 +3574,7 @@ msgstr ""
 msgid "HR"
 msgstr "HR"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3588,18 +3616,18 @@ msgid "Hundred"
 msgstr "Hundrede"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3752,7 +3780,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3773,7 +3801,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3827,9 +3855,9 @@ msgstr "Lagerbeholdning gemt!"
 msgid "Inventory transferred!"
 msgstr "Lagerbeholdning overført!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3858,7 +3886,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3873,10 +3901,10 @@ msgstr "Fakturadato mangler!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3969,7 +3997,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "januar"
 
@@ -4001,7 +4029,7 @@ msgstr ""
 msgid "Jul"
 msgstr "jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "juli"
 
@@ -4009,7 +4037,7 @@ msgstr "juli"
 msgid "Jun"
 msgstr "jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "juni"
@@ -4042,7 +4070,7 @@ msgstr "Tidsregistrering"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4270,7 +4298,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4359,11 +4387,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4384,7 +4412,7 @@ msgstr ""
 msgid "Mar"
 msgstr "mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "marts"
 
@@ -4401,12 +4429,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "maj"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4501,7 +4529,7 @@ msgstr "Måned(er)"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4535,15 +4563,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Navn"
@@ -4603,7 +4630,7 @@ msgid "Next Number"
 msgstr "Næste nummer"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4655,7 +4682,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4687,7 +4714,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4758,9 +4785,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4800,7 +4827,7 @@ msgstr "Intet at overføre!"
 msgid "Nov"
 msgstr "nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "november"
 
@@ -4845,8 +4872,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Nummer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Forældet"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4871,7 +4898,7 @@ msgstr ""
 msgid "Oct"
 msgstr "okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "oktober"
 
@@ -4946,7 +4973,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Ordre"
@@ -4978,7 +5005,7 @@ msgstr "Ordredato mangler"
 msgid "Order Entry"
 msgstr "Ordreindgang"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5069,9 +5096,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5080,8 +5107,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5121,8 +5148,8 @@ msgstr "Nummer for pakkeliste mangler!"
 msgid "Packing list"
 msgstr "Følgeseddel"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5150,7 +5177,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5179,7 +5206,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5247,7 +5274,7 @@ msgstr "Udeståender"
 msgid "Payment"
 msgstr "Betaling"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5309,11 +5336,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5488,7 +5515,7 @@ msgstr ""
 msgid "Post"
 msgstr "Bogfør"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5610,7 +5637,7 @@ msgstr ""
 msgid "Print"
 msgstr "Udskriv"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5670,15 +5697,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5738,7 +5765,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5764,7 +5791,7 @@ msgid "Purchase Orders"
 msgstr "Indkøbsordrer"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5781,7 +5808,7 @@ msgstr "Indkøbsordre"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5996,13 +6023,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Gentagne transaktioner"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6072,12 +6099,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr "Rapportnavn"
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6089,7 +6116,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6157,7 +6184,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Bestilt af"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6335,8 +6362,8 @@ msgstr "Salgstilbudsnummer"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6514,7 +6541,7 @@ msgstr "Planlæg"
 msgid "Scheduled"
 msgstr "Planlagt"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skærm"
@@ -6698,7 +6725,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Sælg"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6755,7 +6782,7 @@ msgstr "sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "september"
 
@@ -6775,7 +6802,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serienummer"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6861,8 +6888,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6909,8 +6936,8 @@ msgstr "Afsendelsesdato mangler!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6981,8 +7008,8 @@ msgstr "Solgt"
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7028,14 +7055,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Standard industrikoder (SIC)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7059,7 +7086,7 @@ msgid "Startdate"
 msgstr "Startdato"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7111,8 +7138,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7224,8 +7251,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7233,8 +7260,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7555,8 +7582,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7635,7 +7662,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7681,14 +7708,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7710,7 +7737,7 @@ msgstr ""
 msgid "Total"
 msgstr "I alt"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7738,7 +7765,7 @@ msgstr "Postering"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7752,7 +7779,7 @@ msgstr "Posteringsdato mangler!"
 msgid "Transaction Dates"
 msgstr "Posteringsdato"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7861,9 +7888,9 @@ msgid "Two"
 msgstr "To"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7921,7 +7948,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7962,11 +7989,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8095,7 +8122,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8109,7 +8136,7 @@ msgstr "Bruger"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8157,7 +8184,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Fakturerbar"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8166,8 +8193,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8241,7 +8268,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverandør ikke i databasen!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8255,7 +8282,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8384,13 +8411,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8629,7 +8656,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/de.po
+++ b/locale/po/de.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: German (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "# Rechnungen"
 
@@ -102,7 +102,7 @@ msgstr "Ausgehende Rechnung"
 msgid "AP Invoices"
 msgstr "Ausgehende Rechnungen"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Offene Verbindlichkeiten"
@@ -114,7 +114,7 @@ msgstr "Offene Verbindlichkeiten"
 msgid "AP Transaction"
 msgstr "Eingangsbuchung"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Ausgangsbuchungen"
 
@@ -149,7 +149,7 @@ msgstr "Ausstehende Rechnung"
 msgid "AR Invoices"
 msgstr "Ausstehende Rechnungen"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Offene Forderungen"
@@ -160,7 +160,7 @@ msgstr "Offene Forderungen"
 msgid "AR Transaction"
 msgstr "Ausgangsbuchung"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Ausgangsbuchungen"
 
@@ -177,8 +177,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Ausgangsbuchung"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Forderungen/Verbindlichkeiten/Hauptbuch Betrag"
 
@@ -186,8 +186,8 @@ msgstr "Forderungen/Verbindlichkeiten/Hauptbuch Betrag"
 msgid "Abandonment"
 msgstr "Verzicht"
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Zugriff verweigert"
 
@@ -195,11 +195,11 @@ msgstr "Zugriff verweigert"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -224,22 +224,22 @@ msgstr "Konto"
 msgid "Account Description"
 msgstr "Kontobezeichnung"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Kontobezeichnung"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Kontoname"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -320,7 +320,7 @@ msgstr "Rückstellung"
 msgid "Accrual Basis:"
 msgstr "Periodenabgrenzung:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr "Summierte Abschreibungen"
 
@@ -617,7 +617,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr "Angepasste Basis"
 
@@ -637,7 +637,7 @@ msgstr "Anpassungsdetails"
 msgid "Aged"
 msgstr "Gealtert"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Forderungenspiegel"
 
@@ -691,11 +691,11 @@ msgstr "Zugeteilt"
 msgid "Allow Input"
 msgstr "Erlaubte Eingabe"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -713,11 +713,11 @@ msgstr "Erlaubte Eingabe"
 msgid "Amount"
 msgstr "Betrag"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Betrag budgettiert"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -729,13 +729,13 @@ msgstr "Betrag fÃ¤llig"
 msgid "Amount From"
 msgstr "Betrag von"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr "Betrag grÃ¶sser als"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr "Betrag kleiner als"
 
@@ -799,9 +799,9 @@ msgid "Approval Status"
 msgstr "Freigabestatus"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Genehmigen"
@@ -814,12 +814,12 @@ msgstr "Genehmigen"
 msgid "Approved"
 msgstr "Genehmigt"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Genehmigt von"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Genehmigt am"
 
@@ -835,16 +835,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr "Kaufwert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr "Verbleibender Kaufwert"
 
@@ -884,7 +884,7 @@ msgstr "VermÃ¶gen"
 msgid "Asset Account"
 msgstr "Anlagen Konto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Anlagenklassen"
@@ -909,7 +909,7 @@ msgstr "Anlagenabschreibungsbericht"
 msgid "Asset Disposal Report"
 msgstr "Bericht zum Anlagenabgang"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr "Anlageklassauflistung"
 
@@ -1014,7 +1014,7 @@ msgstr "An: [_1]"
 msgid "Aug"
 msgstr "Aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "August"
 
@@ -1084,13 +1084,13 @@ msgstr "Datenbanksicherungen"
 msgid "Backup Roles"
 msgstr "Datensicherung der Rolle"
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1148,7 +1148,7 @@ msgstr "Basis"
 msgid "Batch"
 msgstr "Posten"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr "Postenklasse"
 
@@ -1164,7 +1164,7 @@ msgstr "Posten Datum"
 msgid "Batch Description"
 msgstr "Postenbeschreibung"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr "Posten Nr"
 
@@ -1176,12 +1176,12 @@ msgstr "Posten Nr. fehlt"
 msgid "Batch Name"
 msgstr "Postenname"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Stapelnummer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr "Postensuche"
 
@@ -1262,15 +1262,15 @@ msgstr "Bücher geschlossen bis"
 msgid "Budget"
 msgstr "Budget"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Budgetnummer"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr "Budget Suchergebnisse"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr "Bericht zu Budgetabweichungen"
 
@@ -1286,7 +1286,7 @@ msgstr "Gewerbe"
 msgid "Business Number"
 msgstr "Gewerbenummer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr "Gewerbe"
@@ -1321,9 +1321,9 @@ msgstr "Umsatzkosten"
 msgid "COGS Lots Report"
 msgstr "Umsatzkostenreport"
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Eine stornierte Rechnung kann nicht storniert werden!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1478,11 +1478,11 @@ msgstr "Passwort ändern"
 msgid "Chargeable"
 msgstr "Gebührenpflichtig"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr "Tabellen Nr"
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Kontenliste"
 
@@ -1542,7 +1542,7 @@ msgstr "Abstimmungsdatum ist [*,_1,day] in der Zukunft nach der Buchung"
 msgid "Clear date over [*,_1,day]"
 msgstr "Gelöschtes Datum über [*,_1,day]"
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1629,8 +1629,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1677,7 +1677,7 @@ msgstr "Vergleichsdaten"
 msgid "Comparison Periods"
 msgstr "Vergleichsperiode"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
@@ -1685,6 +1685,30 @@ msgstr ""
 #, fuzzy
 msgid "Compose e-mail"
 msgstr "An E-mail"
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:10
 msgid "Confirm Operation"
@@ -1694,7 +1718,7 @@ msgstr "Vorgang bestätigen"
 msgid "Confirm!"
 msgstr "BestÃ¤tigen!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 "Konflikt mit bestehenden Daten.  MÃ¶glicherweise haben Sie diese Angabe "
@@ -1724,7 +1748,7 @@ msgstr "Kontaktinformationen:"
 msgid "Contact Information"
 msgstr "Kontaktinformationen"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr "Kontaktsuche"
@@ -1781,7 +1805,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1869,7 +1893,7 @@ msgstr "Land:"
 msgid "Create"
 msgstr "Erstellen"
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1881,7 +1905,7 @@ msgstr "Batch erstellen"
 msgid "Create Database?"
 msgstr "Datenbank erstellen?"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1909,7 +1933,7 @@ msgstr "Erstellt von"
 msgid "Created On"
 msgstr "Erstellt am"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1920,7 +1944,7 @@ msgstr "Haben"
 msgid "Credit Account"
 msgstr "Kreditkonto"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Kontonummer"
 
@@ -1947,22 +1971,22 @@ msgstr "Kreditlinie"
 msgid "Credit Note"
 msgstr "Gutschrift"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr "Haben"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "WÃ¤hrung"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1981,7 +2005,7 @@ msgstr "WÃ¤hrung"
 msgid "Currency"
 msgstr "WÃ¤hrung"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1997,8 +2021,8 @@ msgstr "Aktuelles Ergebnis"
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2061,7 +2085,7 @@ msgstr "Kunde nicht in der Datei!"
 msgid "Customer/Vendor Accounts"
 msgstr "Kunden/Lieferant Konto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr "D M"
 
@@ -2138,17 +2162,17 @@ msgstr "Datenbank existiert."
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2178,8 +2202,8 @@ msgstr "Datumformat"
 msgid "Date From"
 msgstr "Datum vom"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2258,7 +2282,7 @@ msgstr "Tag(e)"
 msgid "Days"
 msgstr "Tage"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2273,7 +2297,7 @@ msgstr "Debit-Rechnung"
 msgid "Debit Note"
 msgstr "Lastschrift"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2284,7 +2308,7 @@ msgstr "Soll"
 msgid "Dec"
 msgstr "Dez"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Dezember"
 
@@ -2369,11 +2393,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2386,7 +2410,7 @@ msgstr ""
 msgid "Delete"
 msgstr "LÃ¶schen"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr "Posten lÃ¶schen"
 
@@ -2399,7 +2423,7 @@ msgstr "Plan lÃ¶schen"
 msgid "Delete User"
 msgstr "Benutzer anlegen"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr "Gutscheine lÃ¶schen"
 
@@ -2422,21 +2446,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Lieferung"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Lieferdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr "Abschreibungsbasis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr "Abschreibungsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr "Abschreibungsbeginn"
 
@@ -2444,11 +2468,11 @@ msgstr "Abschreibungsbeginn"
 msgid "Dep. Through"
 msgstr "Abschreiben bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr "Abschreibungen YTD"
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr "Abschreibungen in dieser Periode"
 
@@ -2470,7 +2494,7 @@ msgstr "Abschreibung"
 msgid "Depreciate Through"
 msgstr "Abschreiben bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Abschreibung"
@@ -2491,15 +2515,15 @@ msgstr "Abschreibungsmethode"
 msgid "Depreciation Starts"
 msgstr "Abschreibungsbeginn"
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2516,13 +2540,13 @@ msgstr "Abschreibungsbeginn"
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2590,7 +2614,7 @@ msgstr "Details"
 msgid "Disable Back Button"
 msgstr "Deaktivieren Rücktaste"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr "Disc"
 
@@ -2616,16 +2640,16 @@ msgstr "Rabatt (%)"
 msgid "Discount:"
 msgstr "Rabatt:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr "Durch AbgÃ¤nge erzielte Werte"
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Abgabe"
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr "Zeitpunkt der VerÃ¤usserung"
 
@@ -2633,11 +2657,11 @@ msgstr "Zeitpunkt der VerÃ¤usserung"
 msgid "Disposal Method"
 msgstr "VerÃ¤usserungsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr "Division durch 0 Fehler"
 
@@ -2669,6 +2693,10 @@ msgstr "Doppelte Kundennummer"
 msgid "Double vendornumbers"
 msgstr "Doppelte Lieferantennummer"
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr "Dr."
@@ -2677,11 +2705,11 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Entwurf gebucht"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr "Suche in EntwÃ¼rfen"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr "Entwurfsart"
 
@@ -2695,11 +2723,11 @@ msgstr "Entwurf"
 msgid "Drawing"
 msgstr "Zeichnung"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr "AufklappmenÃ¼s"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2708,9 +2736,9 @@ msgstr "AufklappmenÃ¼s"
 msgid "Due"
 msgstr "FÃ¤llig"
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2740,7 +2768,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "E-mail Adresse fehlt!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2901,7 +2929,7 @@ msgstr "elf"
 msgid "Eleven-o"
 msgstr "elf-o"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr "E-mail"
 
@@ -2960,14 +2988,14 @@ msgstr "Leere Kundennummer"
 msgid "Empty vendornumbers"
 msgstr "Leere Lieferantennummern"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3011,7 +3039,7 @@ msgstr "Gebe Benutzer ein"
 msgid "Enter employee numbers where they are missing"
 msgstr "Geben Sie die Personalnummern ein, wo sie fehlen"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr "Bearbeitet von"
@@ -3020,7 +3048,7 @@ msgstr "Bearbeitet von"
 msgid "Entered For"
 msgstr "Bearbeitet für"
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr "Eingegeben am"
 
@@ -3029,7 +3057,7 @@ msgid "Entered at: [_1]"
 msgstr "Eingegeben am: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr "EntitÃ¤t"
 
@@ -3054,7 +3082,7 @@ msgstr "Entitätscode Kreditkonto"
 msgid "Entity Name"
 msgstr "EntitÃ¤t Kode"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr "Eintragungs ID"
 
@@ -3091,7 +3119,7 @@ msgstr "Fehler beim erstellen der Sicherungsdatei"
 msgid "Error creating batch.  Please try again."
 msgstr "Fehler bei erstellen von Posten.  Bitte versuchen Sie es erneut."
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr "Fehler aus Funktion:"
 
@@ -3100,7 +3128,7 @@ msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 "Fehler: Saldenzusammenfassung konnte nicht ins AufklappmenÃ¼ eingefÃ¼gt werden"
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr "GeschÃ¤tzte Lebensdauer"
 
@@ -3112,7 +3140,7 @@ msgstr "Jede"
 msgid "Exch"
 msgstr "Wechselkurs"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3221,7 +3249,7 @@ msgstr "Fax: [_1]"
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Februar"
 
@@ -3237,7 +3265,7 @@ msgstr "fünfzig"
 msgid "File"
 msgstr "Datei"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr "Datei importiert"
 
@@ -3381,7 +3409,7 @@ msgstr "Vom Betrag"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr "Datum vom"
@@ -3404,11 +3432,11 @@ msgstr "Von Datum"
 msgid "Full"
 msgstr "Voll"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Volle Rechte"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3439,7 +3467,7 @@ msgstr "Grundbuch Referenznummer"
 msgid "Gain"
 msgstr "Gewinn"
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr "Gewinn (Verlust)"
 
@@ -3447,7 +3475,7 @@ msgstr "Gewinn (Verlust)"
 msgid "Gain Account"
 msgstr "Gewinnkonto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Gewinn (Verlust)"
@@ -3460,7 +3488,7 @@ msgstr "Lückenlose Debitorenbuchhaltung"
 msgid "General Journal"
 msgstr "Sammeljournal"
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr "Hauptbuch Berichte"
 
@@ -3468,7 +3496,7 @@ msgstr "Hauptbuch Berichte"
 msgid "General Ledger Reports"
 msgstr "Hauptbuch Berichte"
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Generieren"
@@ -3555,7 +3583,7 @@ msgstr "Gtalk"
 msgid "HR"
 msgstr "Personal"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3597,18 +3625,18 @@ msgid "Hundred"
 msgstr "hundert"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3761,7 +3789,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr "Interner Datenbankenfehler"
 
@@ -3782,7 +3810,7 @@ msgstr "UngÃ¼ltige Berichtsgrundlage"
 msgid "Invalid backup request"
 msgstr "UngÃ¼ltige Sicherungsanfrage"
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr "UngÃ¼ltiges Datum/Zeit eingegeben"
 
@@ -3839,9 +3867,9 @@ msgstr "Inventar gespeichert!"
 msgid "Inventory transferred!"
 msgstr "Inventar Ã¼bertragen!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3870,7 +3898,7 @@ msgstr "Rechnung erstellt"
 msgid "Invoice Created Date missing!"
 msgstr "Rechnungserstellt"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3885,10 +3913,10 @@ msgstr "Rechnungsdatum fehlt!"
 msgid "Invoice No."
 msgstr "Rechnungsnr."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3987,7 +4015,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Januar"
 
@@ -4019,7 +4047,7 @@ msgstr "Journallinien"
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juli"
 
@@ -4027,7 +4055,7 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
@@ -4060,7 +4088,7 @@ msgstr "Gestehungskosten"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4291,7 +4319,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4380,11 +4408,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Benutzer verwalten"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4405,7 +4433,7 @@ msgstr "Manuell"
 msgid "Mar"
 msgstr "Mrz"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "MÃ¤rz"
 
@@ -4422,12 +4450,12 @@ msgstr "Maximale Rechnungen per Scheckavis"
 msgid "Max per dropdown"
 msgstr "Max per AufklappmenÃ¼"
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4522,7 +4550,7 @@ msgstr "Monat(e)"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr "Weitere Informationen im Fehlerprotokoll"
 
@@ -4556,15 +4584,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Name"
@@ -4624,7 +4651,7 @@ msgid "Next Number"
 msgstr "NÃ¤chste Nummer"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr "NÃ¤chster in der Reihe"
 
@@ -4676,7 +4703,7 @@ msgstr "Keine Null Mitarbeiternummer"
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4710,7 +4737,7 @@ msgstr ""
 msgid "No report specified"
 msgstr "Kein Bericht festgelegt"
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4781,9 +4808,9 @@ msgstr "Notiz Klasse"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4823,7 +4850,7 @@ msgstr "Nichts zu Ã¼bertragen!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4868,8 +4895,8 @@ msgstr "Nummer fehlt in Reihe [_1]"
 msgid "Number:"
 msgstr "Nummer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4886,7 +4913,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsolet"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr "HinfÃ¤llig ab"
 
@@ -4894,7 +4921,7 @@ msgstr "HinfÃ¤llig ab"
 msgid "Oct"
 msgstr "Okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktober"
 
@@ -4970,7 +4997,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Bestellung"
@@ -5002,7 +5029,7 @@ msgstr "Bestelldatum fehlt!"
 msgid "Order Entry"
 msgstr "Bestellungen"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5093,9 +5120,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5104,8 +5131,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5145,8 +5172,8 @@ msgstr "Verpackungslistennummer fehlt!"
 msgid "Packing list"
 msgstr "Packliste"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5174,7 +5201,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5205,7 +5232,7 @@ msgstr "Details"
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 
@@ -5273,7 +5300,7 @@ msgstr "Verbindlichkeiten"
 msgid "Payment"
 msgstr "Zahlung"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr "Zahlungsbetrag"
 
@@ -5337,11 +5364,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Prozent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr "VerÃ¤usserungen in Prozent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr "Prozent verbleibend"
 
@@ -5508,7 +5535,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5516,7 +5543,7 @@ msgstr ""
 msgid "Post"
 msgstr "Buchen"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr "Posten buchen"
 
@@ -5638,7 +5665,7 @@ msgstr ""
 msgid "Print"
 msgstr "Drucken"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5698,15 +5725,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr "GetÃ¤tigte Abschreibungen"
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr "Bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr "ErtrÃ¤ge"
 
@@ -5767,7 +5794,7 @@ msgstr "Kaufdatum"
 msgid "Purchase Date:"
 msgstr "Kaufdatum:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr "Kaufhistorie"
@@ -5793,7 +5820,7 @@ msgid "Purchase Orders"
 msgstr "Einkaufsbestellungen"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "Kaufwert"
 
@@ -5810,7 +5837,7 @@ msgstr "Einkaufsauftrag"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -6025,13 +6052,13 @@ msgstr "Wiederkehrende Transaktion fÃ¼r [_1]"
 msgid "Recurring Transactions"
 msgstr "Wiederkehrende Transaktionen"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6101,12 +6128,12 @@ msgstr "Bericht genehmigt"
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr "Berichtsname"
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "Berichtsergebnisse"
 
@@ -6118,7 +6145,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "Berichtstyp"
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr "Bericht [_1] am [_2]"
 
@@ -6186,7 +6213,7 @@ msgstr "Bedarfstermin"
 msgid "Required by"
 msgstr "BenÃ¶tigt von"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr "BenÃ¶tigte Eingabe nicht erbracht"
 
@@ -6364,8 +6391,8 @@ msgstr "Anrede"
 msgid "Sales:"
 msgstr "Verkauf:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6543,7 +6570,7 @@ msgstr "Planen"
 msgid "Scheduled"
 msgstr "Geplant"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Bildschirm"
@@ -6727,7 +6754,7 @@ msgstr "GewÃ¤hlt"
 msgid "Sell"
 msgstr "Verkaufen"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6784,7 +6811,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr "Aufgaben teilen"
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "September"
 
@@ -6804,7 +6831,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serien Nr."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6890,8 +6917,8 @@ msgstr "Lieferadresse"
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6938,8 +6965,8 @@ msgstr "Versanddatum fehlt!"
 msgid "Shipping Label"
 msgstr "Versandaufkleber"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -7011,8 +7038,8 @@ msgstr "Verkauft"
 msgid "Some"
 msgstr "Einige"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7058,14 +7085,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Branchenklassifikation SIC"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7090,7 +7117,7 @@ msgid "Startdate"
 msgstr "Anfangsdatum"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr "Anfangsbilanz"
 
@@ -7142,8 +7169,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7255,8 +7282,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr "Kennzeichen"
 
@@ -7264,8 +7291,8 @@ msgstr "Kennzeichen"
 msgid "Tag:"
 msgstr "Etikett:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7588,8 +7615,8 @@ msgstr ""
 msgid "Thu"
 msgstr "Don"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7668,7 +7695,7 @@ msgstr "Zu Betrag"
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr "Bis Datum"
@@ -7714,14 +7741,14 @@ msgstr "Alle Kontrollkästchen zum Entfernen umschalten"
 msgid "Top-level"
 msgstr "Höchststufe"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7743,7 +7770,7 @@ msgstr "Höchststufe"
 msgid "Total"
 msgstr "Gesamtsumme"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr "Summe Gesamtabschreibungen"
 
@@ -7771,7 +7798,7 @@ msgstr "Transaktion"
 msgid "Transaction Approval"
 msgstr " Transaktionsbestätigung"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7785,7 +7812,7 @@ msgstr "Datum der Transaktion fehlt!"
 msgid "Transaction Dates"
 msgstr "Transaktionsdatum"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7894,9 +7921,9 @@ msgid "Two"
 msgstr "zwei"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7954,7 +7981,7 @@ msgstr "Einzigartige Lieferantennummer"
 msgid "Unique nonobsolete partnumbers"
 msgstr "Einzigartige nicht veraltete Teilnummer"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7995,11 +8022,11 @@ msgstr "Unbekannte Datenbank gefunden."
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr "Freischalten"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr "Stapel freischalten"
 
@@ -8128,7 +8155,7 @@ msgstr "Ãœberzahlung/Anzahlung nutzen"
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Gebraucht"
@@ -8142,7 +8169,7 @@ msgstr "Benutzer"
 msgid "User Name"
 msgstr "Benutzername"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr "Benutzer besteht bereits. Importieren?"
 
@@ -8190,7 +8217,7 @@ msgstr "Bewertung"
 msgid "Variable"
 msgstr "Abweichung"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr "Abweichung"
@@ -8199,8 +8226,8 @@ msgstr "Abweichung"
 msgid "Variance:"
 msgstr "Unterschied:"
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8274,7 +8301,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Lieferant nicht in der Datei!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8288,7 +8315,7 @@ msgstr ""
 msgid "Void"
 msgstr "Stornieren"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr "Belegliste"
 
@@ -8422,13 +8449,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr "XLS"
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8669,7 +8696,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr "teilweisige Entsorgung"
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr "Permalink"
 

--- a/locale/po/de_CH.po
+++ b/locale/po/de_CH.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: German (Switzerland) (http://www.transifex.com/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Offene Verbindlichkeiten"
@@ -110,7 +110,7 @@ msgstr "Offene Verbindlichkeiten"
 msgid "AP Transaction"
 msgstr "Eingangsbuchung"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Eingangsbuchungen"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Offene Forderungen"
@@ -156,7 +156,7 @@ msgstr "Offene Forderungen"
 msgid "AR Transaction"
 msgstr "Ausgangsbuchung"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Ausgangsbuchungen"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Ausgangsbuchung"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Konto"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Veraltet"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr "Zugeteilt"
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Betrag"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Betrag fällig"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Aktiva/Mittelverwendung"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "August"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Bilanz"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Branche"
 msgid "Business Number"
 msgstr "Firmennummer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Aufwand"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1473,11 +1473,11 @@ msgstr "Passwort ändern"
 msgid "Chargeable"
 msgstr "Verrechenbar"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Kontenübersicht"
 
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1623,8 +1623,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1671,12 +1671,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1687,7 +1711,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bestätigen Sie!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1715,7 +1739,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1772,7 +1796,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1860,7 +1884,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1872,7 +1896,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1900,7 +1924,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1911,7 +1935,7 @@ msgstr "Haben"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1938,22 +1962,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Währung"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1972,7 +1996,7 @@ msgstr "Währung"
 msgid "Currency"
 msgstr "Währung"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1988,8 +2012,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2052,7 +2076,7 @@ msgstr "Kunde ist nicht in der Datenbank!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2129,17 +2153,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2169,8 +2193,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2249,7 +2273,7 @@ msgstr "Tage"
 msgid "Days"
 msgstr "Tage"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2264,7 +2288,7 @@ msgstr "Debit Invoice"
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2275,7 +2299,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dez"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Dezember"
 
@@ -2360,11 +2384,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2377,7 +2401,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2390,7 +2414,7 @@ msgstr "Zeitplan löschen"
 msgid "Delete User"
 msgstr "Löschen"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2413,21 +2437,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Lieferdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2435,11 +2459,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2461,7 +2485,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2482,15 +2506,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2507,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2581,7 +2605,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2607,16 +2631,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2624,11 +2648,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2660,6 +2684,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2668,11 +2696,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2686,11 +2714,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Zeichnung"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2699,9 +2727,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2731,7 +2759,7 @@ msgstr "E-Mail"
 msgid "E-mail address missing!"
 msgstr "E-Mail-Adresse fehlt!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2892,7 +2920,7 @@ msgstr "elf"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr "E-Mail"
 
@@ -2949,14 +2977,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3000,7 +3028,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3009,7 +3037,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3018,7 +3046,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3043,7 +3071,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Firmenname"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3080,7 +3108,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3088,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3100,7 +3128,7 @@ msgstr "Jeden"
 msgid "Exch"
 msgstr "Wkurs."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3209,7 +3237,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Februar"
 
@@ -3225,7 +3253,7 @@ msgstr "fünfzig"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3369,7 +3397,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3392,11 +3420,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3427,7 +3455,7 @@ msgstr "Hauptbuchreferenz"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3435,7 +3463,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3447,7 +3475,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3455,7 +3483,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Erzeugen"
@@ -3542,7 +3570,7 @@ msgstr ""
 msgid "HR"
 msgstr "Personal"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3584,18 +3612,18 @@ msgid "Hundred"
 msgstr "hundert"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3748,7 +3776,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3769,7 +3797,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3825,9 +3853,9 @@ msgstr "Inventar gespeichert!"
 msgid "Inventory transferred!"
 msgstr "Inventar übertragen"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3856,7 +3884,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3871,10 +3899,10 @@ msgstr "Rechnungsdatum fehlt!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3967,7 +3995,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Januar"
 
@@ -3999,7 +4027,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juli"
 
@@ -4007,7 +4035,7 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
@@ -4040,7 +4068,7 @@ msgstr "Gestehungskosten"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4268,7 +4296,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4357,11 +4385,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4382,7 +4410,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mär"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "März"
 
@@ -4399,12 +4427,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4499,7 +4527,7 @@ msgstr "Monat(e)"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4533,15 +4561,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Name"
@@ -4601,7 +4628,7 @@ msgid "Next Number"
 msgstr "Nächste Nummer"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4653,7 +4680,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4685,7 +4712,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4756,9 +4783,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4798,7 +4825,7 @@ msgstr "Es gibt nichts zu übertragen!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4843,8 +4870,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Artikelnummer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4861,7 +4888,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Ungültig"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4869,7 +4896,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktober"
 
@@ -4944,7 +4971,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Bestellung"
@@ -4976,7 +5003,7 @@ msgstr "Bestelldatum fehlt!"
 msgid "Order Entry"
 msgstr "Bestellungen"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5067,9 +5094,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5078,8 +5105,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5119,8 +5146,8 @@ msgstr "Verpackungslistennummer fehlt!"
 msgid "Packing list"
 msgstr "Packliste"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5148,7 +5175,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5177,7 +5204,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5245,7 +5272,7 @@ msgstr "Verbindlichkeiten"
 msgid "Payment"
 msgstr "Belastung"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5307,11 +5334,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5478,7 +5505,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5486,7 +5513,7 @@ msgstr ""
 msgid "Post"
 msgstr "Buchen"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5608,7 +5635,7 @@ msgstr ""
 msgid "Print"
 msgstr "Drucken"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5668,15 +5695,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5736,7 +5763,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5762,7 +5789,7 @@ msgid "Purchase Orders"
 msgstr "Einkaufsbestellungen"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5779,7 +5806,7 @@ msgstr "Einkaufsbestellung"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5994,13 +6021,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Wiederkehrende Buchungen"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6070,12 +6097,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6087,7 +6114,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,7 +6182,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Erforderlich bis am"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6333,8 +6360,8 @@ msgstr "Offertennummer"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6512,7 +6539,7 @@ msgstr "Buchungstermine"
 msgid "Scheduled"
 msgstr "geplant"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Bildschirm"
@@ -6696,7 +6723,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Verkaufspreis"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6753,7 +6780,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "September"
 
@@ -6773,7 +6800,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Seriennummer"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6859,8 +6886,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6907,8 +6934,8 @@ msgstr "Versanddatum fehlt!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6979,8 +7006,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7026,14 +7053,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Standard Industrie Norm"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7057,7 +7084,7 @@ msgid "Startdate"
 msgstr "Eintrittsdatum"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7109,8 +7136,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7222,8 +7249,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7231,8 +7258,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7553,8 +7580,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7633,7 +7660,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7679,14 +7706,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7708,7 +7735,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7736,7 +7763,7 @@ msgstr "Buchung"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7750,7 +7777,7 @@ msgstr "Buchungsdatum fehlt!"
 msgid "Transaction Dates"
 msgstr "Buchungsdaten"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7859,9 +7886,9 @@ msgid "Two"
 msgstr "zwei"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7919,7 +7946,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7960,11 +7987,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8093,7 +8120,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8107,7 +8134,7 @@ msgstr "Datenbankbenutzer"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8155,7 +8182,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Verrechenbar"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8164,8 +8191,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8239,7 +8266,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Lieferant ist nicht in der Datenbank!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8253,7 +8280,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8382,13 +8409,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8627,7 +8654,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/el.po
+++ b/locale/po/el.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Greek (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Κινήση Αγοράς"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Κινήσεις Αγορών"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Κινήσεις Πωλήσεων"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Κινήσεις Πωλήσεων"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Κινήσεις Πωλήσεων"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Λογαριασμός"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr "Αύξηση"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -685,11 +685,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -707,11 +707,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Ποσό"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -723,13 +723,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -793,9 +793,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -808,12 +808,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -829,16 +829,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Απρ"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Απρίλιος"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr "Πάγιο"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Αυγ"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Αύγουστος"
 
@@ -1077,13 +1077,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Ισοζύγιο"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1169,12 +1169,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1254,15 +1254,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1278,7 +1278,7 @@ msgstr "Επιχείρηση"
 msgid "Business Number"
 msgstr "Κωδικός Επιχείρησης"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1313,9 +1313,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1463,11 +1463,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Γράφημα των Κωδικών"
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1613,8 +1613,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1661,12 +1661,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1677,7 +1701,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Επιβεβαίωση!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1705,7 +1729,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1762,7 +1786,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1850,7 +1874,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1862,7 +1886,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1890,7 +1914,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1901,7 +1925,7 @@ msgstr "Πίστωση"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1928,22 +1952,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1962,7 +1986,7 @@ msgstr ""
 msgid "Currency"
 msgstr "Συνάλλαγμα"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1978,8 +2002,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2042,7 +2066,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2119,17 +2143,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2159,8 +2183,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2239,7 +2263,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2254,7 +2278,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2265,7 +2289,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Δεκ"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Δεκέμβριος"
 
@@ -2350,11 +2374,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2367,7 +2391,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2380,7 +2404,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Διαγραφή"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2403,21 +2427,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2425,11 +2449,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2451,7 +2475,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2472,15 +2496,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2497,13 +2521,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2571,7 +2595,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2597,16 +2621,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2614,11 +2638,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2650,6 +2674,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2658,11 +2686,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2676,11 +2704,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Σχέδιο"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2689,9 +2717,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2721,7 +2749,7 @@ msgstr ""
 msgid "E-mail address missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2882,7 +2910,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2939,14 +2967,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2990,7 +3018,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -2999,7 +3027,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3008,7 +3036,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3033,7 +3061,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Όνομα εταιρίας"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3070,7 +3098,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3078,7 +3106,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Συναλλ"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3199,7 +3227,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Φεβ"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Φεβρουάριος"
 
@@ -3215,7 +3243,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3359,7 +3387,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3382,11 +3410,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3417,7 +3445,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3425,7 +3453,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3445,7 +3473,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3532,7 +3560,7 @@ msgstr ""
 msgid "HR"
 msgstr "ΔΠ"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3574,18 +3602,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3737,7 +3765,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3758,7 +3786,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3812,9 +3840,9 @@ msgstr "Η Απογραφή αποθηκεύτηκε"
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3843,7 +3871,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3858,10 +3886,10 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3954,7 +3982,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ιάν"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Ιανουάριος"
 
@@ -3986,7 +4014,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Ιούλ"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Ιούλιος"
 
@@ -3994,7 +4022,7 @@ msgstr "Ιούλιος"
 msgid "Jun"
 msgstr "Ιούν"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Ιούνιος"
@@ -4027,7 +4055,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4255,7 +4283,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4344,11 +4372,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4369,7 +4397,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Μαρ"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Μάρτιος"
 
@@ -4386,12 +4414,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Μάϊος"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4486,7 +4514,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4520,15 +4548,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Όνομα"
@@ -4588,7 +4615,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4640,7 +4667,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4672,7 +4699,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4743,9 +4770,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4785,7 +4812,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Νοέ"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Νοέμβριος"
 
@@ -4830,8 +4857,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Αριθμός"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4848,7 +4875,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Απαρχαιωμένος"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4856,7 +4883,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Οκτ"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Οκτώβριος"
 
@@ -4931,7 +4958,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Παραγγελία"
@@ -4963,7 +4990,7 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5053,9 +5080,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5064,8 +5091,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5104,8 +5131,8 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5133,7 +5160,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5162,7 +5189,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5229,7 +5256,7 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5290,11 +5317,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5460,7 +5487,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5468,7 +5495,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5590,7 +5617,7 @@ msgstr ""
 msgid "Print"
 msgstr "Εκτύπωση"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5650,15 +5677,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5718,7 +5745,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5744,7 +5771,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5760,7 +5787,7 @@ msgstr ""
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5973,13 +6000,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6049,12 +6076,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6066,7 +6093,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6133,7 +6160,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6311,8 +6338,8 @@ msgstr "Προσθήκη προσφοράς"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6490,7 +6517,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Οθόνη"
@@ -6674,7 +6701,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6731,7 +6758,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6751,7 +6778,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6836,8 +6863,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6884,8 +6911,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6955,8 +6982,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7002,14 +7029,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7033,7 +7060,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7085,8 +7112,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7197,8 +7224,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7206,8 +7233,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7527,8 +7554,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7607,7 +7634,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7653,14 +7680,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7682,7 +7709,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7710,7 +7737,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7724,7 +7751,7 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7833,9 +7860,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7893,7 +7920,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7934,11 +7961,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8067,7 +8094,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8081,7 +8108,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8128,7 +8155,7 @@ msgstr ""
 msgid "Variable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8137,8 +8164,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8212,7 +8239,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Creditor not on file!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8226,7 +8253,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8354,13 +8381,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8599,7 +8626,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/en.po
+++ b/locale/po/en.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2022-01-09T21:20:15.970Z\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
@@ -13,7 +13,7 @@ msgstr ""
 "#-#-#-#-#  _en.po (i18next-conv)  #-#-#-#-#\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -108,7 +108,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -142,7 +142,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -153,7 +153,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr ""
 
@@ -169,8 +169,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -178,8 +178,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -187,11 +187,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -216,22 +216,22 @@ msgstr ""
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -312,7 +312,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -628,7 +628,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -703,11 +703,11 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -719,13 +719,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -789,9 +789,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -804,12 +804,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -825,16 +825,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr ""
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr ""
 
@@ -1073,13 +1073,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1136,7 +1136,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1164,12 +1164,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1249,15 +1249,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "Business Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1308,9 +1308,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1458,11 +1458,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1607,8 +1607,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1655,12 +1655,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1671,7 +1695,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1699,7 +1723,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1756,7 +1780,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1844,7 +1868,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1856,7 +1880,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1884,7 +1908,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1895,7 +1919,7 @@ msgstr ""
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1922,22 +1946,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1956,7 +1980,7 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1972,8 +1996,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2035,7 +2059,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2112,17 +2136,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2152,8 +2176,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2232,7 +2256,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2247,7 +2271,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr ""
 
@@ -2343,11 +2367,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2360,7 +2384,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2372,7 +2396,7 @@ msgstr ""
 msgid "Delete User"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2395,21 +2419,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2417,11 +2441,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2443,7 +2467,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2464,15 +2488,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2489,13 +2513,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2563,7 +2587,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2589,16 +2613,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2606,11 +2630,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2642,6 +2666,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2650,11 +2678,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2668,11 +2696,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2681,9 +2709,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2713,7 +2741,7 @@ msgstr ""
 msgid "E-mail address missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2874,7 +2902,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2930,14 +2958,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -2990,7 +3018,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -2999,7 +3027,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3023,7 +3051,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3060,7 +3088,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3068,7 +3096,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3080,7 +3108,7 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3189,7 +3217,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr ""
 
@@ -3205,7 +3233,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3349,7 +3377,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3372,11 +3400,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3407,7 +3435,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3415,7 +3443,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3427,7 +3455,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3435,7 +3463,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3522,7 +3550,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3564,18 +3592,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3727,7 +3755,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3748,7 +3776,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3802,9 +3830,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3833,7 +3861,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3848,10 +3876,10 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3944,7 +3972,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr ""
 
@@ -3976,7 +4004,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr ""
 
@@ -3984,7 +4012,7 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
@@ -4017,7 +4045,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4245,7 +4273,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4334,11 +4362,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4359,7 +4387,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr ""
 
@@ -4376,12 +4404,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4476,7 +4504,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4510,15 +4538,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr ""
@@ -4578,7 +4605,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4630,7 +4657,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4662,7 +4689,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4733,9 +4760,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4775,7 +4802,7 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr ""
 
@@ -4819,8 +4846,8 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4837,7 +4864,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4845,7 +4872,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr ""
 
@@ -4919,7 +4946,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4951,7 +4978,7 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5041,9 +5068,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5052,8 +5079,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5092,8 +5119,8 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5121,7 +5148,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5150,7 +5177,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5217,7 +5244,7 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5278,11 +5305,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5448,7 +5475,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5456,7 +5483,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5577,7 +5604,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5637,15 +5664,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5705,7 +5732,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5731,7 +5758,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5747,7 +5774,7 @@ msgstr ""
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5959,13 +5986,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6035,12 +6062,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6052,7 +6079,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6119,7 +6146,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6295,8 +6322,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6474,7 +6501,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
@@ -6658,7 +6685,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6715,7 +6742,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6735,7 +6762,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6819,8 +6846,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6867,8 +6894,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6938,8 +6965,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -6985,14 +7012,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7016,7 +7043,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7068,8 +7095,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7180,8 +7207,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7189,8 +7216,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7510,8 +7537,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7590,7 +7617,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7636,14 +7663,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7665,7 +7692,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7693,7 +7720,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7707,7 +7734,7 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7816,9 +7843,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7876,7 +7903,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7917,11 +7944,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8050,7 +8077,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8064,7 +8091,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8111,7 +8138,7 @@ msgstr ""
 msgid "Variable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8120,8 +8147,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8195,7 +8222,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
 msgstr ""
@@ -8208,7 +8235,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8336,13 +8363,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8581,7 +8608,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/en_CA.po
+++ b/locale/po/en_CA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: English (Canada) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -155,7 +155,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr ""
 
@@ -171,8 +171,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -180,8 +180,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -189,11 +189,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -218,22 +218,22 @@ msgstr ""
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -630,7 +630,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -683,11 +683,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -705,11 +705,11 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -721,13 +721,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -791,9 +791,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -806,12 +806,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -827,16 +827,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1005,7 +1005,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr ""
 
@@ -1075,13 +1075,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1166,12 +1166,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1251,15 +1251,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "Business Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1310,9 +1310,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1460,11 +1460,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1609,8 +1609,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1657,12 +1657,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1673,7 +1697,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1701,7 +1725,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1758,7 +1782,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1846,7 +1870,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1858,7 +1882,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1886,7 +1910,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1897,7 +1921,7 @@ msgstr ""
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1924,22 +1948,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1958,7 +1982,7 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1974,8 +1998,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2037,7 +2061,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2114,17 +2138,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2154,8 +2178,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2234,7 +2258,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2249,7 +2273,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2260,7 +2284,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr ""
 
@@ -2345,11 +2369,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2362,7 +2386,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2374,7 +2398,7 @@ msgstr ""
 msgid "Delete User"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2397,21 +2421,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2419,11 +2443,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2445,7 +2469,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2466,15 +2490,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2491,13 +2515,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2565,7 +2589,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2591,16 +2615,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2608,11 +2632,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2644,6 +2668,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2652,11 +2680,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2670,11 +2698,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2683,9 +2711,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2715,7 +2743,7 @@ msgstr "Email"
 msgid "E-mail address missing!"
 msgstr "Email address missing"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2876,7 +2904,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2932,14 +2960,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2983,7 +3011,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -2992,7 +3020,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3001,7 +3029,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3025,7 +3053,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3062,7 +3090,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3070,7 +3098,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3191,7 +3219,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr ""
 
@@ -3207,7 +3235,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3351,7 +3379,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3374,11 +3402,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3409,7 +3437,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3417,7 +3445,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3524,7 +3552,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3566,18 +3594,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3729,7 +3757,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3750,7 +3778,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3804,9 +3832,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3835,7 +3863,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3850,10 +3878,10 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3946,7 +3974,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr ""
 
@@ -3978,7 +4006,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr ""
 
@@ -3986,7 +4014,7 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
@@ -4019,7 +4047,7 @@ msgstr "Labour/Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4247,7 +4275,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4336,11 +4364,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4361,7 +4389,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr ""
 
@@ -4378,12 +4406,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4478,7 +4506,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4512,15 +4540,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr ""
@@ -4580,7 +4607,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4632,7 +4659,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4664,7 +4691,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4735,9 +4762,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4777,7 +4804,7 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr ""
 
@@ -4821,8 +4848,8 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4839,7 +4866,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4847,7 +4874,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr ""
 
@@ -4921,7 +4948,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4953,7 +4980,7 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5044,9 +5071,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5055,8 +5082,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5095,8 +5122,8 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5124,7 +5151,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5153,7 +5180,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5220,7 +5247,7 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5281,11 +5308,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5451,7 +5478,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5459,7 +5486,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5580,7 +5607,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5640,15 +5667,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5708,7 +5735,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5734,7 +5761,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5750,7 +5777,7 @@ msgstr ""
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5962,13 +5989,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6038,12 +6065,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6055,7 +6082,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6122,7 +6149,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6298,8 +6325,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6477,7 +6504,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
@@ -6661,7 +6688,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6718,7 +6745,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6738,7 +6765,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6822,8 +6849,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6870,8 +6897,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6941,8 +6968,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -6988,14 +7015,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7019,7 +7046,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7071,8 +7098,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7183,8 +7210,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7192,8 +7219,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7513,8 +7540,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7593,7 +7620,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7639,14 +7666,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7668,7 +7695,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7696,7 +7723,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7710,7 +7737,7 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7819,9 +7846,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7879,7 +7906,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7920,11 +7947,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8053,7 +8080,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8067,7 +8094,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8114,7 +8141,7 @@ msgstr ""
 msgid "Variable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8123,8 +8150,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8198,7 +8225,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
 msgstr ""
@@ -8211,7 +8238,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8339,13 +8366,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8584,7 +8611,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/en_GB.po
+++ b/locale/po/en_GB.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/ledgersmb/"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -111,7 +111,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Purchase Transaction"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -146,7 +146,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -157,7 +157,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Sales Transaction"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr ""
 
@@ -174,8 +174,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Sales Transaction"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -183,8 +183,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -192,11 +192,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -221,22 +221,22 @@ msgstr ""
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -686,11 +686,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -708,11 +708,11 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -724,13 +724,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -794,9 +794,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -809,12 +809,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -830,16 +830,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -878,7 +878,7 @@ msgstr ""
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -903,7 +903,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr ""
 
@@ -1078,13 +1078,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1169,12 +1169,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1254,15 +1254,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Business Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1313,9 +1313,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1463,11 +1463,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1612,8 +1612,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1660,12 +1660,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1676,7 +1700,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1704,7 +1728,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1761,7 +1785,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1849,7 +1873,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1861,7 +1885,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1889,7 +1913,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1900,7 +1924,7 @@ msgstr ""
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1927,22 +1951,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1961,7 +1985,7 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1977,8 +2001,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2041,7 +2065,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2118,17 +2142,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2158,8 +2182,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2238,7 +2262,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2253,7 +2277,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2264,7 +2288,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr ""
 
@@ -2349,11 +2373,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2366,7 +2390,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2379,7 +2403,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Edit User"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2402,21 +2426,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2424,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2450,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2471,15 +2495,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2496,13 +2520,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2570,7 +2594,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2596,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2613,11 +2637,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2649,6 +2673,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2657,11 +2685,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2675,11 +2703,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2688,9 +2716,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2720,7 +2748,7 @@ msgstr "Email"
 msgid "E-mail address missing!"
 msgstr "Email address missing!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2881,7 +2909,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2937,14 +2965,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2988,7 +3016,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -2997,7 +3025,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3006,7 +3034,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3030,7 +3058,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3067,7 +3095,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3075,7 +3103,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3087,7 +3115,7 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3196,7 +3224,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr ""
 
@@ -3212,7 +3240,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3356,7 +3384,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3379,11 +3407,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3414,7 +3442,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3422,7 +3450,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3434,7 +3462,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3442,7 +3470,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3529,7 +3557,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3571,18 +3599,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3734,7 +3762,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3755,7 +3783,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3809,9 +3837,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3840,7 +3868,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3855,10 +3883,10 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3951,7 +3979,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr ""
 
@@ -3983,7 +4011,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr ""
 
@@ -3991,7 +4019,7 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
@@ -4024,7 +4052,7 @@ msgstr "Labour/Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4252,7 +4280,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4341,11 +4369,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4366,7 +4394,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr ""
 
@@ -4383,12 +4411,12 @@ msgstr "Max Invoices per Cheque Stub"
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4483,7 +4511,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4517,15 +4545,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr ""
@@ -4585,7 +4612,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4637,7 +4664,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4669,7 +4696,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4740,9 +4767,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4782,7 +4809,7 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr ""
 
@@ -4827,8 +4854,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Creditor Number"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4845,7 +4872,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4853,7 +4880,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr ""
 
@@ -4927,7 +4954,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4959,7 +4986,7 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5050,9 +5077,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5061,8 +5088,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5101,8 +5128,8 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5130,7 +5157,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5159,7 +5186,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5226,7 +5253,7 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5287,11 +5314,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5457,7 +5484,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5465,7 +5492,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5586,7 +5613,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5646,15 +5673,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5714,7 +5741,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5740,7 +5767,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5756,7 +5783,7 @@ msgstr ""
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5968,13 +5995,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6044,12 +6071,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6061,7 +6088,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6128,7 +6155,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6304,8 +6331,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6483,7 +6510,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
@@ -6667,7 +6694,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6724,7 +6751,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6744,7 +6771,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6828,8 +6855,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6876,8 +6903,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6947,8 +6974,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -6994,14 +7021,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7025,7 +7052,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7077,8 +7104,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7189,8 +7216,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7198,8 +7225,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7519,8 +7546,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7599,7 +7626,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7645,14 +7672,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7674,7 +7701,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7702,7 +7729,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7716,7 +7743,7 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7825,9 +7852,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7885,7 +7912,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7926,11 +7953,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8059,7 +8086,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8073,7 +8100,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8120,7 +8147,7 @@ msgstr ""
 msgid "Variable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8129,8 +8156,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8204,7 +8231,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Creditor not on file!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8218,7 +8245,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8346,13 +8373,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8591,7 +8618,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/en_NZ.po
+++ b/locale/po/en_NZ.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: English (New Zealand) (http://www.transifex.com/ledgersmb/"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -114,7 +114,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -159,7 +159,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr ""
 
@@ -175,8 +175,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -184,8 +184,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -193,11 +193,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -222,22 +222,22 @@ msgstr ""
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Amount Budgeted"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr ""
 
@@ -1079,13 +1079,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1170,12 +1170,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1255,15 +1255,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "Business Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1314,9 +1314,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1464,11 +1464,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1613,8 +1613,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1661,12 +1661,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1677,7 +1701,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1705,7 +1729,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1762,7 +1786,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1850,7 +1874,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1862,7 +1886,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1890,7 +1914,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1901,7 +1925,7 @@ msgstr ""
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1928,22 +1952,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1962,7 +1986,7 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1978,8 +2002,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2041,7 +2065,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2118,17 +2142,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2158,8 +2182,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2238,7 +2262,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2253,7 +2277,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2264,7 +2288,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr ""
 
@@ -2349,11 +2373,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2366,7 +2390,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2378,7 +2402,7 @@ msgstr ""
 msgid "Delete User"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2401,21 +2425,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2423,11 +2447,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2449,7 +2473,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2470,15 +2494,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2495,13 +2519,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2569,7 +2593,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2595,16 +2619,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2612,11 +2636,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2648,6 +2672,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2656,11 +2684,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2674,11 +2702,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2687,9 +2715,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2719,7 +2747,7 @@ msgstr ""
 msgid "E-mail address missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2880,7 +2908,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2936,14 +2964,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2987,7 +3015,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -2996,7 +3024,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3005,7 +3033,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3029,7 +3057,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3066,7 +3094,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3086,7 +3114,7 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3195,7 +3223,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr ""
 
@@ -3211,7 +3239,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3355,7 +3383,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3378,11 +3406,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3413,7 +3441,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3433,7 +3461,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3528,7 +3556,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3570,18 +3598,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3733,7 +3761,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3754,7 +3782,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3808,9 +3836,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3839,7 +3867,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3854,10 +3882,10 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3950,7 +3978,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr ""
 
@@ -3982,7 +4010,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr ""
 
@@ -3990,7 +4018,7 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
@@ -4023,7 +4051,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4251,7 +4279,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4340,11 +4368,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4365,7 +4393,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr ""
 
@@ -4382,12 +4410,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4482,7 +4510,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4516,15 +4544,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr ""
@@ -4584,7 +4611,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4636,7 +4663,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4668,7 +4695,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4739,9 +4766,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4781,7 +4808,7 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr ""
 
@@ -4825,8 +4852,8 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4843,7 +4870,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4851,7 +4878,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr ""
 
@@ -4925,7 +4952,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4957,7 +4984,7 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5047,9 +5074,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5058,8 +5085,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5098,8 +5125,8 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5127,7 +5154,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5156,7 +5183,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5223,7 +5250,7 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5284,11 +5311,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5454,7 +5481,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5462,7 +5489,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5583,7 +5610,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5643,15 +5670,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5711,7 +5738,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5737,7 +5764,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5753,7 +5780,7 @@ msgstr ""
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5965,13 +5992,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6041,12 +6068,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6058,7 +6085,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6125,7 +6152,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6301,8 +6328,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6480,7 +6507,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
@@ -6664,7 +6691,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6721,7 +6748,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6741,7 +6768,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6825,8 +6852,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6873,8 +6900,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6944,8 +6971,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -6991,14 +7018,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7022,7 +7049,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7074,8 +7101,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7186,8 +7213,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7195,8 +7222,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7516,8 +7543,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7596,7 +7623,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7642,14 +7669,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7671,7 +7698,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7699,7 +7726,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7713,7 +7740,7 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7822,9 +7849,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7882,7 +7909,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7923,11 +7950,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8056,7 +8083,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8070,7 +8097,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8117,7 +8144,7 @@ msgstr ""
 msgid "Variable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8126,8 +8153,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8201,7 +8228,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
 msgstr ""
@@ -8214,7 +8241,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8342,13 +8369,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8587,7 +8614,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es.po
+++ b/locale/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -111,7 +111,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Gestión se pago"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Gestiones de pagos"
 
@@ -146,7 +146,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -157,7 +157,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Gestión de cobro"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Gestiones de cobros"
 
@@ -174,8 +174,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Gestión de cobro"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -183,8 +183,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -192,11 +192,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -221,22 +221,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -688,11 +688,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -710,11 +710,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -726,13 +726,13 @@ msgstr "Cantidad adeudada"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -796,9 +796,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -811,12 +811,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -832,16 +832,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1081,13 +1081,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balance"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1173,12 +1173,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Numero de negocio"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de los artículos"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Cuadro de cuentas"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Mon."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr "Resultado"
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Reintegro"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "Correo electrónico"
 msgid "E-mail address missing!"
 msgstr "No se ha definido el correo electrónico"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2942,14 +2970,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2993,7 +3021,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3002,7 +3030,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3011,7 +3039,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3035,7 +3063,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3072,7 +3100,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3080,7 +3108,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3092,7 +3120,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3201,7 +3229,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3217,7 +3245,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3361,7 +3389,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3384,11 +3412,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3419,7 +3447,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3427,7 +3455,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3439,7 +3467,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3447,7 +3475,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3534,7 +3562,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3576,18 +3604,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3740,7 +3768,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3761,7 +3789,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3817,9 +3845,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3848,7 +3876,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3863,10 +3891,10 @@ msgstr "No se ha definido la fecha de la factura"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3959,7 +3987,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3991,7 +4019,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -3999,7 +4027,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4032,7 +4060,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4260,7 +4288,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4349,11 +4377,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4374,7 +4402,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4391,12 +4419,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "May"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4491,7 +4519,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4525,15 +4553,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4593,7 +4620,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4645,7 +4672,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4677,7 +4704,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4748,9 +4775,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4790,7 +4817,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4835,8 +4862,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4853,7 +4880,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4861,7 +4888,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4936,7 +4963,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4968,7 +4995,7 @@ msgstr "No se ha definido la fecha de la elaboración"
 msgid "Order Entry"
 msgstr "Presupuestos y pedidos"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5058,9 +5085,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5069,8 +5096,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5110,8 +5137,8 @@ msgstr "No se ha definido el número del albarán"
 msgid "Packing list"
 msgstr "Albarán"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5139,7 +5166,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5168,7 +5195,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5236,7 +5263,7 @@ msgstr "Pagos"
 msgid "Payment"
 msgstr "Pago"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5298,11 +5325,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5468,7 +5495,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5476,7 +5503,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5598,7 +5625,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5658,15 +5685,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5726,7 +5753,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5752,7 +5779,7 @@ msgid "Purchase Orders"
 msgstr "Pedidos"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5769,7 +5796,7 @@ msgstr "Pedido"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5984,13 +6011,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6060,12 +6087,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6077,7 +6104,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6144,7 +6171,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Aceptado el"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6321,8 +6348,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6500,7 +6527,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6684,7 +6711,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6741,7 +6768,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6761,7 +6788,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6846,8 +6873,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6894,8 +6921,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6965,8 +6992,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7012,14 +7039,14 @@ msgstr "Estándard"
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7043,7 +7070,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7095,8 +7122,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7207,8 +7234,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7216,8 +7243,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7538,8 +7565,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7618,7 +7645,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7664,14 +7691,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7693,7 +7720,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7721,7 +7748,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7735,7 +7762,7 @@ msgstr "No se ha definido la fecha de la transacción"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7844,9 +7871,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7904,7 +7931,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7945,11 +7972,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8078,7 +8105,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8092,7 +8119,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8140,7 +8167,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Impuestos gravables"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8149,8 +8176,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8224,7 +8251,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡No se encuentra el proveedor en la base de datos!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8238,7 +8265,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8366,13 +8393,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8611,7 +8638,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_AR.po
+++ b/locale/po/es_AR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Transaccion de Egreso"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Transaccion de Ingreso"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr ""
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaccion de Ingreso"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Acceso Denegado"
 
@@ -191,11 +191,11 @@ msgstr "Acceso Denegado"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Antiguedad"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr "Alocado"
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Cantidad"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Monto Adeudado"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Aprobar"
@@ -810,12 +810,12 @@ msgstr "Aprobar"
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Aprovado en"
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr "Cuenta de Activos"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Clase de Activo"
@@ -905,7 +905,7 @@ msgstr "Reporte de Depreciacion de Activos"
 msgid "Asset Disposal Report"
 msgstr "Reporte de Disposicion"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr ""
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr "Basico"
 msgid "Batch"
 msgstr "Lote"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr "Descripcion del Lote"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Negocio"
 msgid "Business Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de Bienes Vendidos"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1471,11 +1471,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Cobrable"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1535,7 +1535,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1621,8 +1621,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1669,12 +1669,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1685,7 +1709,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1713,7 +1737,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1770,7 +1794,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1858,7 +1882,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1870,7 +1894,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr "Crear Base de Datos?"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1898,7 +1922,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1909,7 +1933,7 @@ msgstr "Haber"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1936,22 +1960,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Nota de Credito"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr "Creditos"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1970,7 +1994,7 @@ msgstr "Moneda"
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1986,8 +2010,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2050,7 +2074,7 @@ msgstr "Archivo sin cliente!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2127,17 +2151,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2167,8 +2191,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2247,7 +2271,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2262,7 +2286,7 @@ msgstr "Factura de Debito"
 msgid "Debit Note"
 msgstr "Nota de Debito"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2273,7 +2297,7 @@ msgstr "Debitos"
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr ""
 
@@ -2358,11 +2382,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2375,7 +2399,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Eliminar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr "Eliminar Lote"
 
@@ -2388,7 +2412,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Eliminar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr "Eliminar Cupones"
 
@@ -2411,21 +2435,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha Entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2433,11 +2457,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2459,7 +2483,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2480,15 +2504,15 @@ msgstr "Metodo de Depreciacion"
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2505,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2579,7 +2603,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2605,16 +2629,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2622,11 +2646,11 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2658,6 +2682,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2666,11 +2694,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2684,11 +2712,11 @@ msgstr "Borradores"
 msgid "Drawing"
 msgstr "Dibujo"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2697,9 +2725,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2729,7 +2757,7 @@ msgstr ""
 msgid "E-mail address missing!"
 msgstr "Falta la direccion del correo electronico!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2890,7 +2918,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2947,14 +2975,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2998,7 +3026,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3007,7 +3035,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr "Ingresado en"
 
@@ -3016,7 +3044,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3041,7 +3069,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3078,7 +3106,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr "Error creando lote recurrente. Por favor intente nuevamente."
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3086,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3098,7 +3126,7 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Inter"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3207,7 +3235,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr ""
 
@@ -3223,7 +3251,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3367,7 +3395,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3390,11 +3418,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Todos los Permisos"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3425,7 +3453,7 @@ msgstr "Numero de Referencia para Libro Mayor"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3433,7 +3461,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Ganancia (Perdida)"
@@ -3446,7 +3474,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Libro Diario"
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3454,7 +3482,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Generar"
@@ -3541,7 +3569,7 @@ msgstr ""
 msgid "HR"
 msgstr "Recursos Humanos"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3583,18 +3611,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3747,7 +3775,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3768,7 +3796,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3822,9 +3850,9 @@ msgstr "Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3853,7 +3881,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3868,10 +3896,10 @@ msgstr "Falta la fecha de factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3964,7 +3992,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr ""
 
@@ -3996,7 +4024,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr ""
 
@@ -4004,7 +4032,7 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
@@ -4037,7 +4065,7 @@ msgstr "Tarea/Costos Generales"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4265,7 +4293,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4354,11 +4382,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Administrar Usuarios"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4379,7 +4407,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr ""
 
@@ -4396,12 +4424,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr "Maximo por menu desplegable"
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4496,7 +4524,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4530,15 +4558,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4598,7 +4625,7 @@ msgid "Next Number"
 msgstr "Proximo Numero"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4650,7 +4677,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4682,7 +4709,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4753,9 +4780,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4795,7 +4822,7 @@ msgstr "Nada para transferir!"
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr ""
 
@@ -4840,8 +4867,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numero"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4858,7 +4885,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4866,7 +4893,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr ""
 
@@ -4942,7 +4969,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4974,7 +5001,7 @@ msgstr "Falta la Fecha de Orden!"
 msgid "Order Entry"
 msgstr "Entrada de Orden"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5065,9 +5092,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5076,8 +5103,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5117,8 +5144,8 @@ msgstr ""
 msgid "Packing list"
 msgstr "Lista de Envios"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5146,7 +5173,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5175,7 +5202,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5243,7 +5270,7 @@ msgstr ""
 msgid "Payment"
 msgstr "Pago"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5305,11 +5332,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5476,7 +5503,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5484,7 +5511,7 @@ msgstr ""
 msgid "Post"
 msgstr "Anunciar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr "Anunciar Lote"
 
@@ -5606,7 +5633,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5666,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5734,7 +5761,7 @@ msgstr "Fecha de Compra"
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5760,7 +5787,7 @@ msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "Valor de Compra"
 
@@ -5777,7 +5804,7 @@ msgstr "Orden de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5992,13 +6019,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Trans. Recurrentes"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6068,12 +6095,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6085,7 +6112,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,7 +6180,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6331,8 +6358,8 @@ msgstr "Numero de Presupuesto para Ventas"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6510,7 +6537,7 @@ msgstr "Temporizar"
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6694,7 +6721,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Venta"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6751,7 +6778,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6771,7 +6798,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Numero de Serie"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6856,8 +6883,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6904,8 +6931,8 @@ msgstr "Falta la Fecha de Envio!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6976,8 +7003,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7023,14 +7050,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr "Codigo de Actividad (SIC)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7054,7 +7081,7 @@ msgid "Startdate"
 msgstr "Fecha de Inicio"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7106,8 +7133,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7218,8 +7245,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7227,8 +7254,8 @@ msgstr "Etiqueta"
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7552,8 +7579,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7632,7 +7659,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7678,14 +7705,14 @@ msgstr ""
 msgid "Top-level"
 msgstr "Nivel Raiz"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7707,7 +7734,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7735,7 +7762,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr "Aprobaciones"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7749,7 +7776,7 @@ msgstr "Falta la fecha en la transaccion!"
 msgid "Transaction Dates"
 msgstr "Fecha de Traduccion"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7858,9 +7885,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7918,7 +7945,7 @@ msgstr "Numero Unico de Proveedor"
 msgid "Unique nonobsolete partnumbers"
 msgstr "Numero Unico de Parte no obsoleta"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7959,11 +7986,11 @@ msgstr "Se encontro una base de datos desconocida."
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8092,7 +8119,7 @@ msgstr "Usar sobrepago/prepago"
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8106,7 +8133,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr "Usuario existe. Importar?"
 
@@ -8154,7 +8181,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Cobrable"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8163,8 +8190,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8238,7 +8265,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Archivo sin proveedor!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8252,7 +8279,7 @@ msgstr ""
 msgid "Void"
 msgstr "Vacio"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8381,13 +8408,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8626,7 +8653,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_CO.po
+++ b/locale/po/es_CO.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Colombia) (http://www.transifex.com/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "# Factura"
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Impagados Proveedores"
@@ -110,7 +110,7 @@ msgstr "Impagados Proveedores"
 msgid "AP Transaction"
 msgstr "Transaccion Proveedor"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Gestiones de pagos"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Impagados Cartera"
@@ -156,7 +156,7 @@ msgstr "Impagados Cartera"
 msgid "AR Transaction"
 msgstr "Cuentas por Cobrar"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Cuentas por Cobrar"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Cuentas por Cobrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
@@ -191,11 +191,11 @@ msgstr "Acceso restringido"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Por Pagar"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Aprobar"
@@ -810,12 +810,12 @@ msgstr "Aprobar"
 msgid "Approved"
 msgstr "Aprobada"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Aprobada por"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balance"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Empresa"
 msgid "Business Number"
 msgstr "Numero de negocio"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de los artículos"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan de cuentas"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Mon."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr "Dias"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr "Borrar Programación"
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Reintegro"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "Correo electrónico"
 msgid "E-mail address missing!"
 msgstr "No se ha definido el correo electrónico"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de la empresa"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Cambio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3219,7 +3247,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Elaborar"
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "Recursos Humanos"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3819,9 +3847,9 @@ msgstr "Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3850,7 +3878,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3865,10 +3893,10 @@ msgstr "No se ha definido la fecha de la factura"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3961,7 +3989,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3993,7 +4021,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -4001,7 +4029,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4034,7 +4062,7 @@ msgstr "Honorarios"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4262,7 +4290,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4351,11 +4379,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4376,7 +4404,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4393,12 +4421,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mayo"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4493,7 +4521,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4527,15 +4555,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4595,7 +4622,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4647,7 +4674,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4679,7 +4706,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4750,9 +4777,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4792,7 +4819,7 @@ msgstr "Nada para transferir"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4837,8 +4864,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4855,7 +4882,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4938,7 +4965,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4970,7 +4997,7 @@ msgstr "No se ha definido la fecha de la elaboración"
 msgid "Order Entry"
 msgstr "Cotizaciones y pedidos"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5061,9 +5088,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5072,8 +5099,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5113,8 +5140,8 @@ msgstr "No se ha definido el número del albarán"
 msgid "Packing list"
 msgstr "Albarán"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5142,7 +5169,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5171,7 +5198,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5239,7 +5266,7 @@ msgstr "Por Pagar"
 msgid "Payment"
 msgstr "Comprobante de Egreso"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5301,11 +5328,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5602,7 +5629,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5662,15 +5689,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5757,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5756,7 +5783,7 @@ msgid "Purchase Orders"
 msgstr "Pedidos"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5773,7 +5800,7 @@ msgstr "Pedido"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5988,13 +6015,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transacciones Recurrentes"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6064,12 +6091,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6081,7 +6108,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,7 +6176,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Aceptado el"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6327,8 +6354,8 @@ msgstr "N°de Cotización de Venta"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6506,7 +6533,7 @@ msgstr "Programar Recurrencia"
 msgid "Scheduled"
 msgstr "Programado"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6690,7 +6717,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6747,7 +6774,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6767,7 +6794,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "No de Serial"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6853,8 +6880,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6901,8 +6928,8 @@ msgstr "Falta Fecha del Envio"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6973,8 +7000,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7020,14 +7047,14 @@ msgstr "Estándard"
 msgid "Standard Industrial Codes"
 msgstr "Standard Industrial Codes (Código Industrial)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7051,7 +7078,7 @@ msgid "Startdate"
 msgstr "Fecha inicial"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7103,8 +7130,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7216,8 +7243,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7225,8 +7252,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7547,8 +7574,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7627,7 +7654,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7673,14 +7700,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7702,7 +7729,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7730,7 +7757,7 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7744,7 +7771,7 @@ msgstr "No se ha definido la fecha de la transacción"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7853,9 +7880,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7913,7 +7940,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7954,11 +7981,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8087,7 +8114,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8101,7 +8128,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr "Nombre de usuario"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8149,7 +8176,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Disponible"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8158,8 +8185,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8233,7 +8260,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡No se encuentra el proveedor en la base de datos!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8247,7 +8274,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8376,13 +8403,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8621,7 +8648,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_EC.po
+++ b/locale/po/es_EC.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Ecuador) (http://www.transifex.com/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Impagados Proveedores"
@@ -110,7 +110,7 @@ msgstr "Impagados Proveedores"
 msgid "AP Transaction"
 msgstr "Transaccion Proveedor"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Impagados Cartera"
@@ -156,7 +156,7 @@ msgstr "Impagados Cartera"
 msgid "AR Transaction"
 msgstr "Gestión de cobro"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Gestiones de cobros"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Gestión de cobro"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Cantidad adeudada"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balance"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Numero de negocio"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de los artículos"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan de cuentas"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Mon."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Reintegro"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "Correo electrónico"
 msgid "E-mail address missing!"
 msgstr "No se ha definido el correo electrónico"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de Compañía"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3219,7 +3247,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Notas de Contabilidad"
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "Recursos Humanos"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3819,9 +3847,9 @@ msgstr "¡Inventario salvado!"
 msgid "Inventory transferred!"
 msgstr "¡Inventario transferido!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3850,7 +3878,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3865,10 +3893,10 @@ msgstr "No se ha definido la fecha de la factura"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3961,7 +3989,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3993,7 +4021,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -4001,7 +4029,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4034,7 +4062,7 @@ msgstr "Mano de Obra"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4262,7 +4290,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4351,11 +4379,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4376,7 +4404,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4393,12 +4421,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4493,7 +4521,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4527,15 +4555,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4595,7 +4622,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4647,7 +4674,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4679,7 +4706,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4750,9 +4777,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4792,7 +4819,7 @@ msgstr "¡Nada para Transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4837,8 +4864,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4855,7 +4882,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4938,7 +4965,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4970,7 +4997,7 @@ msgstr "No se ha definido la fecha de la elaboración"
 msgid "Order Entry"
 msgstr "Cotizaciones y pedidos"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5061,9 +5088,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5072,8 +5099,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5113,8 +5140,8 @@ msgstr "No se ha definido el número del albarán"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5142,7 +5169,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5171,7 +5198,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5239,7 +5266,7 @@ msgstr "Pagos"
 msgid "Payment"
 msgstr "Comprobante de Egreso"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5301,11 +5328,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5602,7 +5629,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5662,15 +5689,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5757,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5756,7 +5783,7 @@ msgid "Purchase Orders"
 msgstr "Pedidos"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5773,7 +5800,7 @@ msgstr "Pedido"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5986,13 +6013,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6062,12 +6089,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6079,7 +6106,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6147,7 +6174,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6325,8 +6352,8 @@ msgstr "N°de Cotización de Venta"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6504,7 +6531,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6688,7 +6715,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Venta"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6745,7 +6772,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6765,7 +6792,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Nº de Serie"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6851,8 +6878,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6899,8 +6926,8 @@ msgstr "¡Falta Fecha de Embarque!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6971,8 +6998,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7018,14 +7045,14 @@ msgstr "Estándard"
 msgid "Standard Industrial Codes"
 msgstr "Códigos Standart Industriales"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7049,7 +7076,7 @@ msgid "Startdate"
 msgstr "FechaInicio"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7101,8 +7128,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7214,8 +7241,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7223,8 +7250,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7545,8 +7572,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7625,7 +7652,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7671,14 +7698,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7700,7 +7727,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,7 +7755,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7742,7 +7769,7 @@ msgstr "No se ha definido la fecha de la transacción"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7851,9 +7878,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7911,7 +7938,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7952,11 +7979,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8085,7 +8112,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8099,7 +8126,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8147,7 +8174,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Impuestos gravables"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8156,8 +8183,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8231,7 +8258,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡No se encuentra el proveedor en la base de datos!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8245,7 +8272,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8374,13 +8401,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8619,7 +8646,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_MX.po
+++ b/locale/po/es_MX.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "CxP pendientes"
@@ -110,7 +110,7 @@ msgstr "CxP pendientes"
 msgid "AP Transaction"
 msgstr "Movimiento CxP"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Movimientos de CxP"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "CxC pendientes"
@@ -156,7 +156,7 @@ msgstr "CxC pendientes"
 msgid "AR Transaction"
 msgstr "Movimiento CxC"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Movimientos de Ctas. x cobrar"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Movimiento CxC"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Saldo"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Negocio"
 msgid "Business Number"
 msgstr "RFC"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de Ventas"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Catálogo de cuentas"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Abono"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Mon."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "¡El cliente no está registrado!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Plano"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "Correo-e"
 msgid "E-mail address missing!"
 msgstr "¡Falta la dirección de correo-e!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de la empresa"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr ""
 msgid "Exch"
 msgstr "T. de C."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3219,7 +3247,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "RH"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3819,9 +3847,9 @@ msgstr "¡Existencias guardadas!"
 msgid "Inventory transferred!"
 msgstr "¡Existencias transferidas!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3850,7 +3878,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3865,10 +3893,10 @@ msgstr "¡Falta la fecha de la factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3961,7 +3989,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3993,7 +4021,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -4001,7 +4029,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4034,7 +4062,7 @@ msgstr "Mano de obra/Indirecto"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4262,7 +4290,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4351,11 +4379,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4376,7 +4404,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4393,12 +4421,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "May"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4493,7 +4521,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4527,15 +4555,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4595,7 +4622,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4647,7 +4674,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4679,7 +4706,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4750,9 +4777,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4792,7 +4819,7 @@ msgstr "¡Nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4837,8 +4864,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4855,7 +4882,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4938,7 +4965,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4970,7 +4997,7 @@ msgstr "¡Falta la fecha de la orden!"
 msgid "Order Entry"
 msgstr "Ordenes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5061,9 +5088,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5072,8 +5099,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5113,8 +5140,8 @@ msgstr "¡Falta le número en la lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de empaque"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5142,7 +5169,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5171,7 +5198,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5239,7 +5266,7 @@ msgstr "Por Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5301,11 +5328,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5602,7 +5629,7 @@ msgstr ""
 msgid "Print"
 msgstr "Vista Preliminar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5662,15 +5689,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5757,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5756,7 +5783,7 @@ msgid "Purchase Orders"
 msgstr "Ordenes de compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5773,7 +5800,7 @@ msgstr "Orden de compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5988,13 +6015,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6064,12 +6091,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6081,7 +6108,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,7 +6176,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Vencimiento"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6327,8 +6354,8 @@ msgstr "N°de Cotización de venta"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6506,7 +6533,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6690,7 +6717,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6747,7 +6774,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6767,7 +6794,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Núm. de serie"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6853,8 +6880,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6901,8 +6928,8 @@ msgstr "¡Falta la fecha de envío!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6973,8 +7000,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7020,14 +7047,14 @@ msgstr "Estándar"
 msgid "Standard Industrial Codes"
 msgstr "Standard Industrial Codes"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7051,7 +7078,7 @@ msgid "Startdate"
 msgstr "Fecha inicial"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7103,8 +7130,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7216,8 +7243,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7225,8 +7252,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7547,8 +7574,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7627,7 +7654,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7673,14 +7700,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7702,7 +7729,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7730,7 +7757,7 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7744,7 +7771,7 @@ msgstr "¡Falta la fecha del movimiento!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7853,9 +7880,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7913,7 +7940,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7954,11 +7981,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8087,7 +8114,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8101,7 +8128,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8149,7 +8176,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Gravable"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8158,8 +8185,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8233,7 +8260,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no registrado!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8247,7 +8274,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8376,13 +8403,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8621,7 +8648,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_PA.po
+++ b/locale/po/es_PA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Panama) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Cuentas por Pagar pendientes"
@@ -110,7 +110,7 @@ msgstr "Cuentas por Pagar pendientes"
 msgid "AP Transaction"
 msgstr "Movimiento de Cuentas por Pagar"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Movimientos de Cuentas por Pagar"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Cuentas por Cobrar pendientes"
@@ -156,7 +156,7 @@ msgstr "Cuentas por Cobrar pendientes"
 msgid "AR Transaction"
 msgstr "Movimiento de Cuentas por Cobrar"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Movimientos de Cuentas por Cobrar"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Movimiento de Cuentas por Cobrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Importe Adeudado"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Negocio"
 msgid "Business Number"
 msgstr "RUC"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de Ventas"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Div"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Div"
 msgid "Currency"
 msgstr "Divisa"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Plano"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "Correo electrónico"
 msgid "E-mail address missing!"
 msgstr "¡Falta dirección E-mail!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Razón Social"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3219,7 +3247,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "Recursos Humanos"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3818,9 +3846,9 @@ msgstr "¡Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "¡Inventario transferido!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3849,7 +3877,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3864,10 +3892,10 @@ msgstr "¡Falta la fecha de la factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3960,7 +3988,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3992,7 +4020,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -4000,7 +4028,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4033,7 +4061,7 @@ msgstr "Mano de Obra"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4261,7 +4289,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4350,11 +4378,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4375,7 +4403,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4392,12 +4420,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mayo"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4492,7 +4520,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4526,15 +4554,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4594,7 +4621,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4646,7 +4673,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4678,7 +4705,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4749,9 +4776,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4791,7 +4818,7 @@ msgstr "¡Nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4836,8 +4863,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4854,7 +4881,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4862,7 +4889,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4937,7 +4964,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4969,7 +4996,7 @@ msgstr "¡Falta la fecha de la orden!"
 msgid "Order Entry"
 msgstr "Carga de Ordenes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5060,9 +5087,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5071,8 +5098,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5112,8 +5139,8 @@ msgstr "¡Falta el número en la lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5141,7 +5168,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5170,7 +5197,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5238,7 +5265,7 @@ msgstr "Cuentas por Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5300,11 +5327,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5471,7 +5498,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5479,7 +5506,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5601,7 +5628,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5661,15 +5688,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5729,7 +5756,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5755,7 +5782,7 @@ msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5772,7 +5799,7 @@ msgstr "Orden de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5987,13 +6014,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6063,12 +6090,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6080,7 +6107,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,7 +6175,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido para el"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6326,8 +6353,8 @@ msgstr "Número de Cotización"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6505,7 +6532,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6689,7 +6716,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6746,7 +6773,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6766,7 +6793,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Núm. de serie"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6852,8 +6879,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6900,8 +6927,8 @@ msgstr "¡Falta la fecha de envío!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6972,8 +6999,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7019,14 +7046,14 @@ msgstr "Estándard"
 msgid "Standard Industrial Codes"
 msgstr "Código Industrial Estandardizado (CIS)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7050,7 +7077,7 @@ msgid "Startdate"
 msgstr "Fecha de inicio"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7102,8 +7129,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7215,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7224,8 +7251,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7546,8 +7573,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7626,7 +7653,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7672,14 +7699,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7701,7 +7728,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7729,7 +7756,7 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7743,7 +7770,7 @@ msgstr "¡Falta la fecha del Asiento!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7852,9 +7879,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7912,7 +7939,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7953,11 +7980,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8086,7 +8113,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8100,7 +8127,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8148,7 +8175,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Gravado"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8157,8 +8184,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8232,7 +8259,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no registrado!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8246,7 +8273,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8375,13 +8402,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8620,7 +8647,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_PY.po
+++ b/locale/po/es_PY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Paraguay) (http://www.transifex.com/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Cuentas a Pagar pendientes"
@@ -110,7 +110,7 @@ msgstr "Cuentas a Pagar pendientes"
 msgid "AP Transaction"
 msgstr "Movimiento de Cuentas a Pagar"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Movimientos de Cuentas a Pagar"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Cuentas a Cobrar pendientes"
@@ -156,7 +156,7 @@ msgstr "Cuentas a Cobrar pendientes"
 msgid "AR Transaction"
 msgstr "Movimiento de Cuentas a Cobrar"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Movimientos de Cuentas a Cobrar"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Movimiento de Cuentas a Cobrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Importe"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Importe Adeudado"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Negocio"
 msgid "Business Number"
 msgstr "RUC"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de Artículos Vendidos"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Div"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Div"
 msgid "Currency"
 msgstr "Divisa"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Plano"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "Correo electrónico"
 msgid "E-mail address missing!"
 msgstr "¡Falta dirección E-mail!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Razón Social"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Cambio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3219,7 +3247,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "Recursos Humanos"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3818,9 +3846,9 @@ msgstr "¡Existencias guardadas!"
 msgid "Inventory transferred!"
 msgstr "¡Existencias transferidas!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3849,7 +3877,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3864,10 +3892,10 @@ msgstr "¡Falta la fecha de la factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3960,7 +3988,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3992,7 +4020,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -4000,7 +4028,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4033,7 +4061,7 @@ msgstr "Mano de Obra"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4261,7 +4289,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4350,11 +4378,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4375,7 +4403,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4392,12 +4420,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mayo"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4492,7 +4520,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4526,15 +4554,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4594,7 +4621,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4646,7 +4673,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4678,7 +4705,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4749,9 +4776,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4791,7 +4818,7 @@ msgstr "¡Nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4836,8 +4863,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4854,7 +4881,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4862,7 +4889,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4937,7 +4964,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4969,7 +4996,7 @@ msgstr "¡Falta la fecha de la orden!"
 msgid "Order Entry"
 msgstr "Carga de Ordenes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5060,9 +5087,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5071,8 +5098,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5112,8 +5139,8 @@ msgstr "¡Falta el número en la lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5141,7 +5168,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5170,7 +5197,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5238,7 +5265,7 @@ msgstr "Cuentas a Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5300,11 +5327,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5471,7 +5498,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5479,7 +5506,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5601,7 +5628,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5661,15 +5688,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5729,7 +5756,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5755,7 +5782,7 @@ msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5772,7 +5799,7 @@ msgstr "Orden de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5987,13 +6014,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6063,12 +6090,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6080,7 +6107,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,7 +6175,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido para el"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6326,8 +6353,8 @@ msgstr "Número de Cotización"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6505,7 +6532,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6689,7 +6716,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6746,7 +6773,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6766,7 +6793,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Núm. de serie"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6852,8 +6879,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6900,8 +6927,8 @@ msgstr "¡Falta la fecha de envío!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6972,8 +6999,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7019,14 +7046,14 @@ msgstr "Estándard"
 msgid "Standard Industrial Codes"
 msgstr "Código Industrial Estandardizado (CIS)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7050,7 +7077,7 @@ msgid "Startdate"
 msgstr "Fecha de inicio"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7102,8 +7129,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7215,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7224,8 +7251,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7546,8 +7573,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7626,7 +7653,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7672,14 +7699,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7701,7 +7728,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7729,7 +7756,7 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7743,7 +7770,7 @@ msgstr "¡Falta la fecha del Asiento!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7852,9 +7879,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7912,7 +7939,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7953,11 +7980,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8086,7 +8113,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8100,7 +8127,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8148,7 +8175,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Gravado"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8157,8 +8184,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8232,7 +8259,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no registrado!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8246,7 +8273,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8375,13 +8402,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8620,7 +8647,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_SV.po
+++ b/locale/po/es_SV.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (El Salvador) (http://www.transifex.com/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "CxP Extraordinarias"
@@ -110,7 +110,7 @@ msgstr "CxP Extraordinarias"
 msgid "AP Transaction"
 msgstr "Transaccion - CxP"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transacciones - Cuentas por Pagar"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "CxC Extraordinarias"
@@ -156,7 +156,7 @@ msgstr "CxC Extraordinarias"
 msgid "AR Transaction"
 msgstr "Transaccion - CxC"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transacciones - CxC"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaccion - CxC"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Monto Vencido"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balance"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1257,15 +1257,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Numero de Negocio"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1316,9 +1316,9 @@ msgstr "Costo de Ventas"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1466,11 +1466,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Catálogo Contable"
 
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1616,8 +1616,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1664,12 +1664,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1680,7 +1704,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1708,7 +1732,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1765,7 +1789,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1853,7 +1877,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1893,7 +1917,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1904,7 +1928,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1931,22 +1955,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Mon."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1965,7 +1989,7 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1981,8 +2005,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2045,7 +2069,7 @@ msgstr "Cliente no existe en archivo!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2122,17 +2146,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2162,8 +2186,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2242,7 +2266,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2257,7 +2281,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2268,7 +2292,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2353,11 +2377,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2370,7 +2394,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2383,7 +2407,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2406,21 +2430,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de Entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2428,11 +2452,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2454,7 +2478,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2475,15 +2499,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2500,13 +2524,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2574,7 +2598,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2600,16 +2624,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2617,11 +2641,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2653,6 +2677,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2661,11 +2689,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2679,11 +2707,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Retiro"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2692,9 +2720,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2724,7 +2752,7 @@ msgstr "Correo Electrónico"
 msgid "E-mail address missing!"
 msgstr "Falta E-mail!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2885,7 +2913,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2941,14 +2969,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2992,7 +3020,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3001,7 +3029,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3010,7 +3038,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3034,7 +3062,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3071,7 +3099,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3079,7 +3107,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3091,7 +3119,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Interc."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3200,7 +3228,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3216,7 +3244,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3360,7 +3388,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3383,11 +3411,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3418,7 +3446,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3426,7 +3454,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3438,7 +3466,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3446,7 +3474,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3533,7 +3561,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3575,18 +3603,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3739,7 +3767,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3760,7 +3788,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3816,9 +3844,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3847,7 +3875,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3862,10 +3890,10 @@ msgstr "Falta la Fecha de la Factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3958,7 +3986,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3990,7 +4018,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -3998,7 +4026,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4031,7 +4059,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4259,7 +4287,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4348,11 +4376,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4373,7 +4401,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4390,12 +4418,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "May"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4490,7 +4518,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4524,15 +4552,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4592,7 +4619,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4644,7 +4671,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4676,7 +4703,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4747,9 +4774,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4789,7 +4816,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4834,8 +4861,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4852,7 +4879,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4860,7 +4887,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4935,7 +4962,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4967,7 +4994,7 @@ msgstr "No se encuentra la fecha de orden!"
 msgid "Order Entry"
 msgstr "Orden de Entrada"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5057,9 +5084,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5068,8 +5095,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5109,8 +5136,8 @@ msgstr "!Falta nzmero en lista de empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5138,7 +5165,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5167,7 +5194,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5235,7 +5262,7 @@ msgstr "Por Pagar"
 msgid "Payment"
 msgstr "Pago"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5297,11 +5324,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5467,7 +5494,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5475,7 +5502,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5597,7 +5624,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5657,15 +5684,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5752,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5751,7 +5778,7 @@ msgid "Purchase Orders"
 msgstr "Ordenes de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5768,7 +5795,7 @@ msgstr "Orden de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5983,13 +6010,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6059,12 +6086,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6076,7 +6103,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6143,7 +6170,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6320,8 +6347,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6499,7 +6526,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6683,7 +6710,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6740,7 +6767,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6760,7 +6787,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6845,8 +6872,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6893,8 +6920,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6964,8 +6991,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7011,14 +7038,14 @@ msgstr "Estandar"
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7042,7 +7069,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7094,8 +7121,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7206,8 +7233,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7215,8 +7242,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7537,8 +7564,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7617,7 +7644,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7663,14 +7690,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7692,7 +7719,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7720,7 +7747,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7734,7 +7761,7 @@ msgstr "Falta la fecha de la transacción!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7843,9 +7870,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7903,7 +7930,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7944,11 +7971,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8077,7 +8104,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8091,7 +8118,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8139,7 +8166,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Gravable de Impuesto"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8148,8 +8175,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8223,7 +8250,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Proveedor no está en archivo!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8237,7 +8264,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8365,13 +8392,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8610,7 +8637,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/es_VE.po
+++ b/locale/po/es_VE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Pendientes de CxP"
@@ -110,7 +110,7 @@ msgstr "Pendientes de CxP"
 msgid "AP Transaction"
 msgstr "Asiento de CxP"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Asientos de CxP"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Pendientes de CxC"
@@ -156,7 +156,7 @@ msgstr "Pendientes de CxC"
 msgid "AR Transaction"
 msgstr "Asiento de CxC"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Asiento de CxC"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Asiento de CxC"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Cuenta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Monto"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Cantidad Adeudada"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balance"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Negocio"
 msgid "Business Number"
 msgstr "N° de Registro Fiscal"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Costo de Ventas"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1469,11 +1469,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan de Cuentas"
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1619,8 +1619,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1667,12 +1667,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1683,7 +1707,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "¡Favor Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1711,7 +1735,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1934,22 +1958,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Mon."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Mon."
 msgid "Currency"
 msgstr "Moneda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "¡El cliente no existe en la base datos!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2125,17 +2149,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr "Día(s)"
 msgid "Days"
 msgstr "Días"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Diciembre"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2386,7 +2410,7 @@ msgstr "Eliminar Programación"
 msgid "Delete User"
 msgstr "Borrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2431,11 +2455,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2478,15 +2502,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2603,16 +2627,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2620,11 +2644,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2664,11 +2692,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2682,11 +2710,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Dibujo"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Falta dirección de E-mail"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr "once"
 msgid "Eleven-o"
 msgstr "once"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3005,7 +3033,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nombre de la Compañía"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3076,7 +3104,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3096,7 +3124,7 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Cambio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febrero"
 
@@ -3221,7 +3249,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3388,11 +3416,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3431,7 +3459,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3443,7 +3471,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3451,7 +3479,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Generar"
@@ -3538,7 +3566,7 @@ msgstr ""
 msgid "HR"
 msgstr "Recursos Humanos"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3580,18 +3608,18 @@ msgid "Hundred"
 msgstr "ciento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3744,7 +3772,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3765,7 +3793,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3821,9 +3849,9 @@ msgstr "Inventario guardado!"
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3852,7 +3880,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3867,10 +3895,10 @@ msgstr "¡Falta Fecha de Factura!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3963,7 +3991,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Ene"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Enero"
 
@@ -3995,7 +4023,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julio"
 
@@ -4003,7 +4031,7 @@ msgstr "Julio"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junio"
@@ -4036,7 +4064,7 @@ msgstr "Mano de Obra/Costo Operativo"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4264,7 +4292,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4353,11 +4381,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4378,7 +4406,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4395,12 +4423,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "May"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4495,7 +4523,7 @@ msgstr "Mes(es)"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4529,15 +4557,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nombre"
@@ -4597,7 +4624,7 @@ msgid "Next Number"
 msgstr "Siguiente Número"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4649,7 +4676,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4681,7 +4708,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4752,9 +4779,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4794,7 +4821,7 @@ msgstr "¡No hay nada que transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Noviembre"
 
@@ -4839,8 +4866,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Código"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4857,7 +4884,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4865,7 +4892,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octubre"
 
@@ -4940,7 +4967,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orden"
@@ -4972,7 +4999,7 @@ msgstr "¡Falta fecha de la Orden!"
 msgid "Order Entry"
 msgstr "Órdenes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5063,9 +5090,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5074,8 +5101,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5115,8 +5142,8 @@ msgstr "¡Falta Código de Lista de Empaque!"
 msgid "Packing list"
 msgstr "Lista de Empaque"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5144,7 +5171,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5173,7 +5200,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5241,7 +5268,7 @@ msgstr "CxP"
 msgid "Payment"
 msgstr "Pago"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5303,11 +5330,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5474,7 +5501,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5482,7 +5509,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registrar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5604,7 +5631,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5664,15 +5691,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5732,7 +5759,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5758,7 +5785,7 @@ msgid "Purchase Orders"
 msgstr "Órdenes de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5775,7 +5802,7 @@ msgstr "Orden de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5990,13 +6017,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transacciones Recurrentes"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6066,12 +6093,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6083,7 +6110,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6151,7 +6178,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido para el"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6329,8 +6356,8 @@ msgstr "N° de Cotización de Venta"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6508,7 +6535,7 @@ msgstr "Programar"
 msgid "Scheduled"
 msgstr "Programada"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Pantalla"
@@ -6692,7 +6719,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6749,7 +6776,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septiembre"
 
@@ -6769,7 +6796,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serial"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6855,8 +6882,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6903,8 +6930,8 @@ msgstr "Falta Fecha de Envío"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6975,8 +7002,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7022,14 +7049,14 @@ msgstr "Estándard"
 msgid "Standard Industrial Codes"
 msgstr "Códigos Industriales Estandarizados (CIE)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7053,7 +7080,7 @@ msgid "Startdate"
 msgstr "Fecha de Inicio"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7105,8 +7132,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7218,8 +7245,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7227,8 +7254,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7549,8 +7576,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7629,7 +7656,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7675,14 +7702,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7704,7 +7731,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7732,7 +7759,7 @@ msgstr "Asiento"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7746,7 +7773,7 @@ msgstr "¡Falta Fecha de Asiento"
 msgid "Transaction Dates"
 msgstr "Fecha de transacciones"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7855,9 +7882,9 @@ msgid "Two"
 msgstr "dos"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7915,7 +7942,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7956,11 +7983,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8089,7 +8116,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8103,7 +8130,7 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8151,7 +8178,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Gravable"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8160,8 +8187,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8235,7 +8262,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "¡Proveedor no se encuentra en la Base de Datos!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8249,7 +8276,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8378,13 +8405,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8623,7 +8650,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/et.po
+++ b/locale/po/et.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Estonian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "Arveid kokku"
 
@@ -99,7 +99,7 @@ msgstr "Ostuarve"
 msgid "AP Invoices"
 msgstr "Ostuarved"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "OR Laekumata"
@@ -111,7 +111,7 @@ msgstr "OR Laekumata"
 msgid "AP Transaction"
 msgstr "OR Tehing"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "OR Tehingud"
 
@@ -146,7 +146,7 @@ msgstr "Müügiarve"
 msgid "AR Invoices"
 msgstr "Müügiarved"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "MR Laekumata"
@@ -157,7 +157,7 @@ msgstr "MR Laekumata"
 msgid "AR Transaction"
 msgstr "MR Tehing"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "MR Tehingud"
 
@@ -174,8 +174,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "MR Tehing"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Müügi/ostu/pearaamatu summa"
 
@@ -183,8 +183,8 @@ msgstr "Müügi/ostu/pearaamatu summa"
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Ligipääs keelatud"
 
@@ -192,11 +192,11 @@ msgstr "Ligipääs keelatud"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -221,22 +221,22 @@ msgstr "Konto"
 msgid "Account Description"
 msgstr "Konto kirjeldus"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Konto silt"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Konto nimi"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -317,7 +317,7 @@ msgstr "Tekkepõhine"
 msgid "Accrual Basis:"
 msgstr "Tekkepõhine:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr "Korrigeerimise üksikasjad"
 msgid "Aged"
 msgstr "Aegunud"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Hilinenute aruanne"
 
@@ -688,11 +688,11 @@ msgstr "Reserveeritud"
 msgid "Allow Input"
 msgstr "Luba sisestus"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -710,11 +710,11 @@ msgstr "Luba sisestus"
 msgid "Amount"
 msgstr "Summa"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -726,13 +726,13 @@ msgstr "Maksmisele kuuluv summa"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -796,9 +796,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Kiida heaks"
@@ -811,12 +811,12 @@ msgstr "Kiida heaks"
 msgid "Approved"
 msgstr "Heaks kiidetud"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -832,16 +832,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Aprill"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr "Vara"
 msgid "Asset Account"
 msgstr "Vara konto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Varaklass"
@@ -906,7 +906,7 @@ msgstr "Vara amortisatsiooni aruanne"
 msgid "Asset Disposal Report"
 msgstr "Vara realiseerimise aruanne"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr "Vara nimekiri"
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "August"
 
@@ -1081,13 +1081,13 @@ msgstr "Varunda andmebaas"
 msgid "Backup Roles"
 msgstr "Varundus rollid"
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Bilanss"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1173,12 +1173,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1259,15 +1259,15 @@ msgstr ""
 msgid "Budget"
 msgstr "Eelarve"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Eelarve number"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr "Eelarve otsingu tulemused"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr "Eelarve lahknevuse aruanne"
 
@@ -1283,7 +1283,7 @@ msgstr "Ettevõte"
 msgid "Business Number"
 msgstr "Ettevõtte Registrinumber"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr "Ettevõtte tüüp"
@@ -1318,9 +1318,9 @@ msgstr "Müügikulud"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Tühistatud arvet ei saa tühistada!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1468,11 +1468,11 @@ msgstr "Muuda salasõna"
 msgid "Chargeable"
 msgstr "Maksustatav"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr "Konto ID"
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Kontoplaan"
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1619,8 +1619,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1667,12 +1667,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1683,7 +1707,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Kinnita!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1711,7 +1735,7 @@ msgstr "Kontakti info:"
 msgid "Contact Information"
 msgstr "Kontakti info"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr "Kontakti otsing"
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr "Riik:"
 msgid "Create"
 msgstr "Loo"
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr "Lisame andmebaasi?"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Kreedit"
 msgid "Credit Account"
 msgstr "Kreeditkonto"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Kreeditkonto number"
 
@@ -1934,22 +1958,22 @@ msgstr "Krediidilimiit:"
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Val."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valuuta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr "Käesoleva aasta kasum (kahjum)"
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "Klient puudub failis!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2125,17 +2149,17 @@ msgstr "Andmebaas eksisteerib."
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr "Kuupäeva formaat"
 msgid "Date From"
 msgstr "Kuupäev alates"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr "Päev(a)"
 msgid "Days"
 msgstr "Päeva"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr "Deebitarve"
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dets"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Detsember"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Kustuta"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2386,7 +2410,7 @@ msgstr "Kustutata Ajakava"
 msgid "Delete User"
 msgstr "Lisa kasutaja"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Üleandmine"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Tarnetähtaeg"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2431,11 +2455,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2478,15 +2502,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr "Keela tagasi nupp"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr "Allahindlus"
 
@@ -2603,16 +2627,16 @@ msgstr "Allahindluse %"
 msgid "Discount:"
 msgstr "Allahindlus:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr "Näita soetusmaksumust"
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Realiseerimine"
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr "Realiseerimise kuupäev"
 
@@ -2620,11 +2644,11 @@ msgstr "Realiseerimise kuupäev"
 msgid "Disposal Method"
 msgstr "Realiseerimise meetod"
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Realiseerimise aruanne [_1] kuupäeval [_2]"
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr "Viga nulliga jagamisel"
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr "Doktor"
@@ -2664,11 +2692,11 @@ msgstr "Doktor"
 msgid "Draft Posted"
 msgstr "Mustand salvestatud"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr "Mustandi otsing"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr "Mustandi tüüp"
 
@@ -2682,11 +2710,11 @@ msgstr "Mustandid"
 msgid "Drawing"
 msgstr "Joonis"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr "Rippmenüüd"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr "Rippmenüüd"
 msgid "Due"
 msgstr "Tähtaeg"
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "E-post"
 msgid "E-mail address missing!"
 msgstr "E-posti aadress puudub"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr "üksteist"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr "E-posti aadress"
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr "Sisesta kasutaja"
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3005,7 +3033,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Riigi nimi"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3076,7 +3104,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3096,7 +3124,7 @@ msgstr "Iga"
 msgid "Exch"
 msgstr "Kurss"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr "Faks: [_1]"
 msgid "Feb"
 msgstr "Veebr"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Veebruar"
 
@@ -3221,7 +3249,7 @@ msgstr "viiskümmend"
 msgid "File"
 msgstr "Fail"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr "Fail imporditud"
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr "Alates"
@@ -3388,11 +3416,11 @@ msgstr "Alates"
 msgid "Full"
 msgstr "Kõik"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Kõik õigused"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr "Pearaamatu Viitenumber"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3431,7 +3459,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Kahjum"
@@ -3444,7 +3472,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr "Pearaamatu aruanne"
 
@@ -3452,7 +3480,7 @@ msgstr "Pearaamatu aruanne"
 msgid "General Ledger Reports"
 msgstr "Pearaamatu aruanded"
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Genereeri"
@@ -3539,7 +3567,7 @@ msgstr "Gtalk"
 msgid "HR"
 msgstr "Personal"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3581,18 +3609,18 @@ msgid "Hundred"
 msgstr "sada"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3745,7 +3773,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr "Andmebaasi sisene viga"
 
@@ -3766,7 +3794,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3820,9 +3848,9 @@ msgstr "Laoseis salvestatud!"
 msgid "Inventory transferred!"
 msgstr "Laoseis üle kantud!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3851,7 +3879,7 @@ msgstr "Arve loonud"
 msgid "Invoice Created Date missing!"
 msgstr "Arve koostamise kuupäev puudub!"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3866,10 +3894,10 @@ msgstr "Kaubaarvel Kuupäev puudu!"
 msgid "Invoice No."
 msgstr "Arve nr"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3962,7 +3990,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jaan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Jaanuar"
 
@@ -3994,7 +4022,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juuli"
 
@@ -4002,7 +4030,7 @@ msgstr "Juuli"
 msgid "Jun"
 msgstr "Juun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juuni"
@@ -4035,7 +4063,7 @@ msgstr "Tööjõud/Kulud"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4266,7 +4294,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4355,11 +4383,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Kasutajate haldamine"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4380,7 +4408,7 @@ msgstr "Manuaalne"
 msgid "Mar"
 msgstr "Mär"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Märts"
 
@@ -4397,12 +4425,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr "Hüppikmenüü max valikute arv"
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4497,7 +4525,7 @@ msgstr "Kuu(d)"
 msgid "Months"
 msgstr "kuud"
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4532,15 +4560,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nimi"
@@ -4600,7 +4627,7 @@ msgid "Next Number"
 msgstr "Järgmine Number"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr "Järgmine järjekorras"
 
@@ -4652,7 +4679,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4684,7 +4711,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr "Maksuvormi pole valitud"
 
@@ -4755,9 +4782,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4797,7 +4824,7 @@ msgstr "Pole midagi ümber paigutada!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4842,8 +4869,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Number"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr "ODS"
 
@@ -4860,7 +4887,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Aegunud"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4868,7 +4895,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktoober"
 
@@ -4943,7 +4970,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Tellimus"
@@ -4975,7 +5002,7 @@ msgstr "Tellimuse Kuupäev puudub!"
 msgid "Order Entry"
 msgstr "Tellimuse Sisestus"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5066,9 +5093,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5077,8 +5104,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "Ostutellimus"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5118,8 +5145,8 @@ msgstr "Saateelehe Number puudu!"
 msgid "Packing list"
 msgstr "Saateleht"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5147,7 +5174,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5176,7 +5203,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5271,7 @@ msgstr "Kreditoorne võlgnevus"
 msgid "Payment"
 msgstr "Makse"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5306,11 +5333,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5477,7 +5504,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5485,7 +5512,7 @@ msgstr ""
 msgid "Post"
 msgstr "Postita"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5607,7 +5634,7 @@ msgstr "Peamine telefon"
 msgid "Print"
 msgstr "Trüki"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5667,15 +5694,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5735,7 +5762,7 @@ msgstr "Ostu kuupäev"
 msgid "Purchase Date:"
 msgstr "Ostu kuupäev:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr "Ostu ajalugu"
@@ -5761,7 +5788,7 @@ msgid "Purchase Orders"
 msgstr "Hanketellimused"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5778,7 +5805,7 @@ msgstr "Hanketellimus"
 msgid "Purchased"
 msgstr "Ostetud"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5993,13 +6020,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Korduvad Tehingud"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6069,12 +6096,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr "Aruande nimi"
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6086,7 +6113,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "Aruande tüüp"
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6154,7 +6181,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Tarnetähtaeg"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6332,8 +6359,8 @@ msgstr "Tervitus"
 msgid "Sales:"
 msgstr "Müük:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6511,7 +6538,7 @@ msgstr "Ajakava"
 msgid "Scheduled"
 msgstr "Planeeritud"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekraan"
@@ -6695,7 +6722,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Müüma"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6752,7 +6779,7 @@ msgstr "Sept"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "September"
 
@@ -6772,7 +6799,7 @@ msgstr "Seeria #"
 msgid "Serial No."
 msgstr "Seerianr."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6858,8 +6885,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6906,8 +6933,8 @@ msgstr "Saatmise Kuupäev puudub"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6978,8 +7005,8 @@ msgstr "Müüdud"
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7025,14 +7052,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Standardiseeritud Tööstuskood"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7057,7 +7084,7 @@ msgid "Startdate"
 msgstr "Alguskuupäev"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7109,8 +7136,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7222,8 +7249,8 @@ msgstr "KOKKU"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7231,8 +7258,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7555,8 +7582,8 @@ msgstr ""
 msgid "Thu"
 msgstr "Neljapäev"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7635,7 +7662,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7681,14 +7708,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7710,7 +7737,7 @@ msgstr ""
 msgid "Total"
 msgstr "Kokku"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7738,7 +7765,7 @@ msgstr "Tehing"
 msgid "Transaction Approval"
 msgstr "Tehingu kinnitamine"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7752,7 +7779,7 @@ msgstr "Tehingu Kuupäev puudu!"
 msgid "Transaction Dates"
 msgstr "Tehingte Kuupäevad"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7861,9 +7888,9 @@ msgid "Two"
 msgstr "kaks"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7921,7 +7948,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7962,11 +7989,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8095,7 +8122,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Kasutatud"
@@ -8109,7 +8136,7 @@ msgstr "Kasutaja"
 msgid "User Name"
 msgstr "Kasutajanimi"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8157,7 +8184,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Kasutatav"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8166,8 +8193,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8241,7 +8268,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Tarnija pole failis!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8255,7 +8282,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr "Vautšerite nimekiri"
 
@@ -8389,13 +8416,13 @@ msgstr "Kas soovite migreerida andmebaasi?"
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr "XLS"
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8636,7 +8663,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr "püsiviide"
 

--- a/locale/po/fa_IR.po
+++ b/locale/po/fa_IR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "فاکتور"
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr ""
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -155,7 +155,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr ""
 
@@ -171,8 +171,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -180,8 +180,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -189,11 +189,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -218,22 +218,22 @@ msgstr ""
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -630,7 +630,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -683,11 +683,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -705,11 +705,11 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -721,13 +721,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -791,9 +791,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -806,12 +806,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -827,16 +827,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1005,7 +1005,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr ""
 
@@ -1075,13 +1075,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1166,12 +1166,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1251,15 +1251,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "Business Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1310,9 +1310,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1460,11 +1460,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr ""
 
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1609,8 +1609,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1657,12 +1657,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1673,7 +1697,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr ""
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1701,7 +1725,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1758,7 +1782,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1846,7 +1870,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1858,7 +1882,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1886,7 +1910,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1897,7 +1921,7 @@ msgstr ""
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1924,22 +1948,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1958,7 +1982,7 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1974,8 +1998,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2038,7 +2062,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2115,17 +2139,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2155,8 +2179,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2235,7 +2259,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2250,7 +2274,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2261,7 +2285,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr ""
 
@@ -2346,11 +2370,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2363,7 +2387,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2375,7 +2399,7 @@ msgstr ""
 msgid "Delete User"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2398,21 +2422,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2420,11 +2444,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2446,7 +2470,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2467,15 +2491,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2492,13 +2516,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2566,7 +2590,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2592,16 +2616,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2609,11 +2633,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2645,6 +2669,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2653,11 +2681,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2671,11 +2699,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2684,9 +2712,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2716,7 +2744,7 @@ msgstr ""
 msgid "E-mail address missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2877,7 +2905,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2933,14 +2961,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2984,7 +3012,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -2993,7 +3021,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3002,7 +3030,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3026,7 +3054,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3063,7 +3091,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3071,7 +3099,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3083,7 +3111,7 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3192,7 +3220,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr ""
 
@@ -3208,7 +3236,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3352,7 +3380,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3375,11 +3403,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3410,7 +3438,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3418,7 +3446,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3430,7 +3458,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3438,7 +3466,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3525,7 +3553,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3567,18 +3595,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3730,7 +3758,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3751,7 +3779,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3805,9 +3833,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3836,7 +3864,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3851,10 +3879,10 @@ msgstr ""
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3947,7 +3975,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr ""
 
@@ -3979,7 +4007,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr ""
 
@@ -3987,7 +4015,7 @@ msgstr ""
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr ""
@@ -4020,7 +4048,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4248,7 +4276,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4337,11 +4365,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4362,7 +4390,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr ""
 
@@ -4379,12 +4407,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4479,7 +4507,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4513,15 +4541,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr ""
@@ -4581,7 +4608,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4633,7 +4660,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4665,7 +4692,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4736,9 +4763,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4778,7 +4805,7 @@ msgstr ""
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr ""
 
@@ -4822,8 +4849,8 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4840,7 +4867,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4848,7 +4875,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr ""
 
@@ -4922,7 +4949,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4954,7 +4981,7 @@ msgstr ""
 msgid "Order Entry"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5044,9 +5071,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5055,8 +5082,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5095,8 +5122,8 @@ msgstr ""
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5124,7 +5151,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5153,7 +5180,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5220,7 +5247,7 @@ msgstr ""
 msgid "Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5281,11 +5308,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5451,7 +5478,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5459,7 +5486,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5580,7 +5607,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5640,15 +5667,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5708,7 +5735,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5734,7 +5761,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5750,7 +5777,7 @@ msgstr ""
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5962,13 +5989,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6038,12 +6065,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6055,7 +6082,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6122,7 +6149,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6298,8 +6325,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6477,7 +6504,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
@@ -6661,7 +6688,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6718,7 +6745,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6738,7 +6765,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6822,8 +6849,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6870,8 +6897,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6941,8 +6968,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -6988,14 +7015,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7019,7 +7046,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7071,8 +7098,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7183,8 +7210,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7192,8 +7219,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7513,8 +7540,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7593,7 +7620,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7639,14 +7666,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7668,7 +7695,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7696,7 +7723,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7710,7 +7737,7 @@ msgstr ""
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7819,9 +7846,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7879,7 +7906,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7920,11 +7947,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8053,7 +8080,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8067,7 +8094,7 @@ msgstr ""
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8114,7 +8141,7 @@ msgstr ""
 msgid "Variable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8123,8 +8150,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8198,7 +8225,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 msgid "Vendor/Customer"
 msgstr ""
@@ -8211,7 +8238,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8339,13 +8366,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8584,7 +8611,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/fi.po
+++ b/locale/po/fi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -100,7 +100,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Ei maksetut ostolaskut"
@@ -112,7 +112,7 @@ msgstr "Ei maksetut ostolaskut"
 msgid "AP Transaction"
 msgstr "Ostotapahtuma"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Ostotapahtumat"
 
@@ -147,7 +147,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Ei maksetut myyntilaskut"
@@ -158,7 +158,7 @@ msgstr "Ei maksetut myyntilaskut"
 msgid "AR Transaction"
 msgstr "Myyntitapahtuma"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Myyntitapahtumat"
 
@@ -175,8 +175,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Myyntitapahtuma"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -184,8 +184,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -193,11 +193,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -222,22 +222,22 @@ msgstr "Tili"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -318,7 +318,7 @@ msgstr "Varaukset"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Vanhat"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -689,11 +689,11 @@ msgstr "Allokoitu"
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -711,11 +711,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Summa"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -727,13 +727,13 @@ msgstr "Erääntyvä summa"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -797,9 +797,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Hyväksy"
@@ -812,12 +812,12 @@ msgstr "Hyväksy"
 msgid "Approved"
 msgstr "Hyväksytty"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Hyväksyjä"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -833,16 +833,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Huh"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Huhtikuu"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgstr "Vastaavaa"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Elo"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Elokuu"
 
@@ -1082,13 +1082,13 @@ msgstr "Varmuuskopioi tietokanta"
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Tase"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1174,12 +1174,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1260,15 +1260,15 @@ msgstr ""
 msgid "Budget"
 msgstr "Budjetti"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1284,7 +1284,7 @@ msgstr "Yritys"
 msgid "Business Number"
 msgstr "Y-numero"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1319,9 +1319,9 @@ msgstr "Myydyn tuotteen kulut"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1469,11 +1469,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Laskutettavissa"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Tilikartta"
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1619,8 +1619,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1667,12 +1667,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1683,7 +1707,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Vahvista!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1711,7 +1735,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr "Maa:"
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr "Luo tietokanta?"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Kredit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1934,22 +1958,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Valuutta"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Valuutta"
 msgid "Currency"
 msgstr "Valuutta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "Asiakas ei järjestelmässä!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2125,17 +2149,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr "Päivä(t)"
 msgid "Days"
 msgstr "Päivät"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr "Lasku"
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Jou"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Joulukuu"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Poista"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2386,7 +2410,7 @@ msgstr "Poista aikataulu"
 msgid "Delete User"
 msgstr "Luo käyttäjä"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Toimituspäivä"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2431,11 +2455,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr "Poisto"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2478,15 +2502,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2603,16 +2627,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2620,11 +2644,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2664,11 +2692,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2682,11 +2710,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Piirros"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "Sähköposti"
 msgid "E-mail address missing!"
 msgstr "Sähköpostiosoite puuttuu!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3005,7 +3033,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Maan nimi"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3076,7 +3104,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3096,7 +3124,7 @@ msgstr "Jokainen"
 msgid "Exch"
 msgstr "Vaihtokurssi"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr "Faksi: [_1]"
 msgid "Feb"
 msgstr "Hel"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Helmikuu"
 
@@ -3221,7 +3249,7 @@ msgstr ""
 msgid "File"
 msgstr "Tiedosto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3388,11 +3416,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Täydet oikeudet"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr "Pääkirjan viitenumero"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3431,7 +3459,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3443,7 +3471,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3451,7 +3479,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Luo"
@@ -3538,7 +3566,7 @@ msgstr ""
 msgid "HR"
 msgstr "Henkilöstöhallinta"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3580,18 +3608,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3744,7 +3772,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3765,7 +3793,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3819,9 +3847,9 @@ msgstr "Varasto tallennettu!"
 msgid "Inventory transferred!"
 msgstr "Varasto siirretty!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3850,7 +3878,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3865,10 +3893,10 @@ msgstr "Laskun päiväys puuttuu!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3961,7 +3989,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Tam"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Tammikuu"
 
@@ -3993,7 +4021,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Hei"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Heinäkuu"
 
@@ -4001,7 +4029,7 @@ msgstr "Heinäkuu"
 msgid "Jun"
 msgstr "Kes"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Kesäkuu"
@@ -4034,7 +4062,7 @@ msgstr "Työ/overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4262,7 +4290,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4351,11 +4379,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4376,7 +4404,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Maa"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Maaliskuu"
 
@@ -4393,12 +4421,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Tou"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4493,7 +4521,7 @@ msgstr "Kuukausi(det)"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4527,15 +4555,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nimi"
@@ -4595,7 +4622,7 @@ msgid "Next Number"
 msgstr "Seuraava numero"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4647,7 +4674,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4679,7 +4706,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4750,9 +4777,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4792,7 +4819,7 @@ msgstr "Ei siirrettävää!"
 msgid "Nov"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Marraskuu"
 
@@ -4837,8 +4864,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numero"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4855,7 +4882,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Vanhentunut"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Lok"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Lokakuu"
 
@@ -4938,7 +4965,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Tilaus"
@@ -4970,7 +4997,7 @@ msgstr "Tilauspäivämäärä puuttuu!"
 msgid "Order Entry"
 msgstr "Tilauksen kirjaus"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5061,9 +5088,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5072,8 +5099,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5113,8 +5140,8 @@ msgstr "Pakkauslistan numero puuttuu!"
 msgid "Packing list"
 msgstr "Pakkauslista"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5142,7 +5169,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5171,7 +5198,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5239,7 +5266,7 @@ msgstr "Erääntyvät"
 msgid "Payment"
 msgstr "Maksu"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5301,11 +5328,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Post"
 msgstr "Kirjaa"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5602,7 +5629,7 @@ msgstr ""
 msgid "Print"
 msgstr "Tulosta"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5662,15 +5689,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5757,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5756,7 +5783,7 @@ msgid "Purchase Orders"
 msgstr "Ostotilaukset"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5773,7 +5800,7 @@ msgstr "Ostotilaus"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5988,13 +6015,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Toistuvat siirrit"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6064,12 +6091,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6081,7 +6108,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,7 +6176,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Toimituspäivä"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6327,8 +6354,8 @@ msgstr "Myynnntitarjousnumero"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6506,7 +6533,7 @@ msgstr "Aikataulu"
 msgid "Scheduled"
 msgstr "Aikataulutettu"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Näyttö"
@@ -6690,7 +6717,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Myynti"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6747,7 +6774,7 @@ msgstr "Syy"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Syyskuu"
 
@@ -6767,7 +6794,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Sarjan:o"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6853,8 +6880,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6901,8 +6928,8 @@ msgstr "Toimituspvm puuttuu"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6973,8 +7000,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7020,14 +7047,14 @@ msgstr "Vakio"
 msgid "Standard Industrial Codes"
 msgstr "Teollisuusluokitteet"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7051,7 +7078,7 @@ msgid "Startdate"
 msgstr "Aloituspäivä"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7103,8 +7130,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7216,8 +7243,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7225,8 +7252,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7547,8 +7574,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7627,7 +7654,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7673,14 +7700,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7702,7 +7729,7 @@ msgstr ""
 msgid "Total"
 msgstr "Yhteensä"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7730,7 +7757,7 @@ msgstr "Vienti"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7744,7 +7771,7 @@ msgstr "Viennin päiväys puuttuu!"
 msgid "Transaction Dates"
 msgstr "Vientipvm"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7853,9 +7880,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7913,7 +7940,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7954,11 +7981,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8087,7 +8114,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8101,7 +8128,7 @@ msgstr "Käyttäjä"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8149,7 +8176,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Laskutettavissa"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8158,8 +8185,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8233,7 +8260,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Toimittajaa ei järjestelmässä!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8247,7 +8274,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8376,13 +8403,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8621,7 +8648,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/fr.po
+++ b/locale/po/fr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: French (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Dépenses en retard"
@@ -110,7 +110,7 @@ msgstr "Dépenses en retard"
 msgid "AP Transaction"
 msgstr "Écriture dépenses"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Mouvements - Dépenses"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
@@ -156,7 +156,7 @@ msgstr "Recettes en retard"
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Mouvements - Recettes"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Écriture recettes"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Compte"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Montant"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Montant dû"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Avril"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Actif"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Août"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Août"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Solde"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Type d'affaire"
 msgid "Business Number"
 msgstr "Numéro d'enregistrement société"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Coût des produits vendus"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan Comptable"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmer!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Crédit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Dev."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Dev."
 msgid "Currency"
 msgstr "Devise"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr "Jours"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Déc."
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Décembre"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Supprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr "Effacer transaction planifiée"
 msgid "Delete User"
 msgstr "Supprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Dessin"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Adresse e-mail manquante!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "Onze"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nom de société"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr "Chaque"
 msgid "Exch"
 msgstr "Change"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fév."
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Février"
 
@@ -3219,7 +3247,7 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "Ressources humaines"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr "Cent"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3818,9 +3846,9 @@ msgstr "Inventaire enregistré!"
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3849,7 +3877,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3864,10 +3892,10 @@ msgstr "Date de facture manquante!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3960,7 +3988,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Janvier"
 
@@ -3992,7 +4020,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juill."
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juillet"
 
@@ -4000,7 +4028,7 @@ msgstr "Juillet"
 msgid "Jun"
 msgstr "Juin"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juin"
@@ -4033,7 +4061,7 @@ msgstr "Coût de production"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4261,7 +4289,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4350,11 +4378,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4375,7 +4403,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mars"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Mars"
 
@@ -4392,12 +4420,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4492,7 +4520,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4526,15 +4554,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nom"
@@ -4594,7 +4621,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4646,7 +4673,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4678,7 +4705,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4749,9 +4776,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4791,7 +4818,7 @@ msgstr "Rien à transférer!"
 msgid "Nov"
 msgstr "Nov."
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembre"
 
@@ -4836,8 +4863,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numéro"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4854,7 +4881,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsolète"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4862,7 +4889,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct."
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octobre"
 
@@ -4937,7 +4964,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Commande"
@@ -4969,7 +4996,7 @@ msgstr "Date de commande manquante!"
 msgid "Order Entry"
 msgstr "Commandes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5060,9 +5087,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5071,8 +5098,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5112,8 +5139,8 @@ msgstr "Le numéro de la liste d'envoi est manquant!"
 msgid "Packing list"
 msgstr "Liste d'envoi"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5141,7 +5168,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5170,7 +5197,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5238,7 +5265,7 @@ msgstr "À payer"
 msgid "Payment"
 msgstr "Paiement"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5300,11 +5327,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5471,7 +5498,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5479,7 +5506,7 @@ msgstr ""
 msgid "Post"
 msgstr "Enregistrer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5601,7 +5628,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5661,15 +5688,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5729,7 +5756,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5755,7 +5782,7 @@ msgid "Purchase Orders"
 msgstr "Commandes d'achat"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5772,7 +5799,7 @@ msgstr "Commande d'achat"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5987,13 +6014,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transactions périodiques"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6063,12 +6090,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6080,7 +6107,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,7 +6175,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requis pour"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6326,8 +6353,8 @@ msgstr "Numéro de devis de vente"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6505,7 +6532,7 @@ msgstr "Planification"
 msgid "Scheduled"
 msgstr "Planifié"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Écran"
@@ -6689,7 +6716,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vente"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6746,7 +6773,7 @@ msgstr "Sept."
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septembre"
 
@@ -6766,7 +6793,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "N° série"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6852,8 +6879,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6900,8 +6927,8 @@ msgstr "Date d'expédition manquante!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6972,8 +6999,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7019,14 +7046,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Code secteur économique"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7050,7 +7077,7 @@ msgid "Startdate"
 msgstr "Date de début"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7102,8 +7129,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7215,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7224,8 +7251,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7546,8 +7573,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7626,7 +7653,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7672,14 +7699,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7701,7 +7728,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7729,7 +7756,7 @@ msgstr "Écriture"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7743,7 +7770,7 @@ msgstr "Date d'écriture manquante!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7852,9 +7879,9 @@ msgid "Two"
 msgstr "Deux"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7912,7 +7939,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7953,11 +7980,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8086,7 +8113,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8100,7 +8127,7 @@ msgstr "Utilisateur"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8148,7 +8175,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Imposable"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8157,8 +8184,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8232,7 +8259,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fournisseur absent du fichier!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8246,7 +8273,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8375,13 +8402,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8620,7 +8647,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/fr_BE.po
+++ b/locale/po/fr_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: French (Belgium) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Dépenses en retard"
@@ -110,7 +110,7 @@ msgstr "Dépenses en retard"
 msgid "AP Transaction"
 msgstr "Écriture dépenses"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Mouvements - Dépenses"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
@@ -156,7 +156,7 @@ msgstr "Recettes en retard"
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Mouvements - Recettes"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Écriture recettes"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Compte"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Âgé"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr "Attribué"
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Montant"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Montant dû"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Avril"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Actif"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Août"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Août"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Solde"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Type d'affaire"
 msgid "Business Number"
 msgstr "Numéro d'enregistrement société"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Coût des produits vendus"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1469,11 +1469,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "À facturer"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan Comptable"
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1619,8 +1619,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1667,12 +1667,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1683,7 +1707,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmer!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1711,7 +1735,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Crédit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1934,22 +1958,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Dev."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Dev."
 msgid "Currency"
 msgstr "Devise"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2125,17 +2149,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr "Jour(s)"
 msgid "Days"
 msgstr "Jours"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Déc."
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Décembre"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Supprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2386,7 +2410,7 @@ msgstr "Effacer transaction planifiée"
 msgid "Delete User"
 msgstr "Supprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2431,11 +2455,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2478,15 +2502,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2603,16 +2627,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2620,11 +2644,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2664,11 +2692,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2682,11 +2710,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Dessin"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Adresse e-mail manquante!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr "Onze"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3005,7 +3033,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nom de société"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3076,7 +3104,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3096,7 +3124,7 @@ msgstr "Chaque"
 msgid "Exch"
 msgstr "Change"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fév."
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Février"
 
@@ -3221,7 +3249,7 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3388,11 +3416,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr "Numéro de réf. Grand-livre"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3431,7 +3459,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3443,7 +3471,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3451,7 +3479,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Générer"
@@ -3538,7 +3566,7 @@ msgstr ""
 msgid "HR"
 msgstr "Ressources humaines"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3580,18 +3608,18 @@ msgid "Hundred"
 msgstr "Cent"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3744,7 +3772,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3765,7 +3793,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3820,9 +3848,9 @@ msgstr "Inventaire enregistré!"
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3851,7 +3879,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3866,10 +3894,10 @@ msgstr "Date de facture manquante!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3962,7 +3990,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Janvier"
 
@@ -3994,7 +4022,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juill."
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juillet"
 
@@ -4002,7 +4030,7 @@ msgstr "Juillet"
 msgid "Jun"
 msgstr "Juin"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juin"
@@ -4035,7 +4063,7 @@ msgstr "Coût de production"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4263,7 +4291,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4352,11 +4380,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4377,7 +4405,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mars"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Mars"
 
@@ -4394,12 +4422,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4494,7 +4522,7 @@ msgstr "Mois"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4528,15 +4556,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nom"
@@ -4596,7 +4623,7 @@ msgid "Next Number"
 msgstr "Prochain numéro"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4648,7 +4675,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4680,7 +4707,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4751,9 +4778,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4793,7 +4820,7 @@ msgstr "Rien à transférer!"
 msgid "Nov"
 msgstr "Nov."
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembre"
 
@@ -4838,8 +4865,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numéro"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4856,7 +4883,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsolète"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4864,7 +4891,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct."
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octobre"
 
@@ -4939,7 +4966,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Commande"
@@ -4971,7 +4998,7 @@ msgstr "Date de commande manquante!"
 msgid "Order Entry"
 msgstr "Commandes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5062,9 +5089,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5073,8 +5100,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5114,8 +5141,8 @@ msgstr "Le numéro de la liste d'envoi est manquant!"
 msgid "Packing list"
 msgstr "Liste d'envoi"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5143,7 +5170,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5172,7 +5199,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5240,7 +5267,7 @@ msgstr "À payer"
 msgid "Payment"
 msgstr "Paiement"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5302,11 +5329,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5473,7 +5500,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5481,7 +5508,7 @@ msgstr ""
 msgid "Post"
 msgstr "Enregistrer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5603,7 +5630,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5663,15 +5690,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5731,7 +5758,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5757,7 +5784,7 @@ msgid "Purchase Orders"
 msgstr "Commandes d'achat"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5774,7 +5801,7 @@ msgstr "Commande d'achat"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5989,13 +6016,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transactions périodiques"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6065,12 +6092,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6082,7 +6109,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6150,7 +6177,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requis pour"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6328,8 +6355,8 @@ msgstr "Numéro de devis de vente"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6507,7 +6534,7 @@ msgstr "Planification"
 msgid "Scheduled"
 msgstr "Planifié"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Écran"
@@ -6691,7 +6718,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vente"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6748,7 +6775,7 @@ msgstr "Sept."
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septembre"
 
@@ -6768,7 +6795,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "N° série"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6854,8 +6881,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6902,8 +6929,8 @@ msgstr "Date d'expédition manquante!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6974,8 +7001,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7021,14 +7048,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Code secteur économique"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7052,7 +7079,7 @@ msgid "Startdate"
 msgstr "Date de début"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7104,8 +7131,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7217,8 +7244,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7226,8 +7253,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7548,8 +7575,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7628,7 +7655,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7674,14 +7701,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7703,7 +7730,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,7 +7758,7 @@ msgstr "Écriture"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7745,7 +7772,7 @@ msgstr "Date d'écriture manquante!"
 msgid "Transaction Dates"
 msgstr "Dates de transactions"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7854,9 +7881,9 @@ msgid "Two"
 msgstr "Deux"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7914,7 +7941,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7955,11 +7982,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8088,7 +8115,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8102,7 +8129,7 @@ msgstr "Utilisateur"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8150,7 +8177,7 @@ msgstr ""
 msgid "Variable"
 msgstr "À facturer"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8159,8 +8186,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8234,7 +8261,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fournisseur absent du fichier!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8248,7 +8275,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8377,13 +8404,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8622,7 +8649,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/fr_CA.po
+++ b/locale/po/fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2022-01-09T21:20:27.139Z\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: French (Canada) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -21,7 +21,7 @@ msgstr ""
 "#-#-#-#-#  _fr_CA.po (i18next-conv)  #-#-#-#-#\n"
 "Plural-Forms: nplurals=2; plural=(n >= 2)\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "# Factures"
 
@@ -104,7 +104,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Dépenses en retard"
@@ -116,7 +116,7 @@ msgstr "Dépenses en retard"
 msgid "AP Transaction"
 msgstr "Écriture dépenses"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Mouvements - Dépenses"
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
@@ -162,7 +162,7 @@ msgstr "Recettes en retard"
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Mouvements - Recettes"
 
@@ -179,8 +179,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Écriture recettes"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -188,8 +188,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Accès refusé"
 
@@ -197,11 +197,11 @@ msgstr "Accès refusé"
 msgid "Access denied: Bad username or password"
 msgstr "Accès refusé: nom d'utilisateur ou mot de passe invalide"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -226,22 +226,22 @@ msgstr "Compte"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -322,7 +322,7 @@ msgstr "Accumulation"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -639,7 +639,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -693,11 +693,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -715,11 +715,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Montant"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -731,13 +731,13 @@ msgstr "Montant dû"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -801,9 +801,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -816,12 +816,12 @@ msgstr ""
 msgid "Approved"
 msgstr "Approuvé"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Approuvé par"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -837,16 +837,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Avril"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -886,7 +886,7 @@ msgstr "Actif"
 msgid "Asset Account"
 msgstr "Compte d'actif"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Classe d'actif"
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Août"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Août"
 
@@ -1086,13 +1086,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Solde"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1178,12 +1178,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Budget"
 msgstr "Budget"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1288,7 +1288,7 @@ msgstr "Type d'affaire"
 msgid "Business Number"
 msgstr "Numéro d'enregistrement société"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1323,9 +1323,9 @@ msgstr "Coût des produits vendus"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1341,7 +1341,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1475,11 +1475,11 @@ msgstr "Modifier mot de passe"
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan Comptable"
 
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1625,8 +1625,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1673,12 +1673,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1689,7 +1713,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmer!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1717,7 +1741,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1774,7 +1798,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1862,7 +1886,7 @@ msgstr "Pays:"
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1874,7 +1898,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1902,7 +1926,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1913,7 +1937,7 @@ msgstr "Crédit"
 msgid "Credit Account"
 msgstr "Compte de crédit"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Numéro de compte de crédit"
 
@@ -1940,22 +1964,22 @@ msgstr "Encours autorisé:"
 msgid "Credit Note"
 msgstr "Note de crédit"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Dev."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1974,7 +1998,7 @@ msgstr "Dev."
 msgid "Currency"
 msgstr "Devise"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1990,8 +2014,8 @@ msgstr "Bénéfice de l'exercice"
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2054,7 +2078,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr "Comptes Clients/Fournisseurs"
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2131,17 +2155,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr "Version incorrecte de la banque de données"
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2171,8 +2195,8 @@ msgstr "Format de date"
 msgid "Date From"
 msgstr "De"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2251,7 +2275,7 @@ msgstr "JOur(s)"
 msgid "Days"
 msgstr "Jours"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2266,7 +2290,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr "Note de débit"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2277,7 +2301,7 @@ msgstr "Débits"
 msgid "Dec"
 msgstr "Déc."
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Décembre"
 
@@ -2362,11 +2386,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2379,7 +2403,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Supprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2392,7 +2416,7 @@ msgstr "Effacer transaction planifiée"
 msgid "Delete User"
 msgstr "Supprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2415,21 +2439,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Livraison"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2437,11 +2461,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2463,7 +2487,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2484,15 +2508,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2509,13 +2533,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2583,7 +2607,7 @@ msgstr "Détails"
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2609,16 +2633,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2626,11 +2650,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2662,6 +2686,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2670,11 +2698,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2688,11 +2716,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Dessin"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2701,9 +2729,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2733,7 +2761,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Adresse e-mail manquante!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2894,7 +2922,7 @@ msgstr "Onze"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2951,14 +2979,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3002,7 +3030,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3011,7 +3039,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3020,7 +3048,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3045,7 +3073,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nom du pays"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3102,7 +3130,7 @@ msgstr "Chaque"
 msgid "Exch"
 msgstr "Change"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3211,7 +3239,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fév."
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Février"
 
@@ -3227,7 +3255,7 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3371,7 +3399,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3394,11 +3422,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3544,7 +3572,7 @@ msgstr ""
 msgid "HR"
 msgstr "Ressources humaines"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3586,18 +3614,18 @@ msgid "Hundred"
 msgstr "Cent"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3750,7 +3778,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3771,7 +3799,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3827,9 +3855,9 @@ msgstr "Inventaire enregistré!"
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3858,7 +3886,7 @@ msgstr "Facture créée"
 msgid "Invoice Created Date missing!"
 msgstr "Date de création de facture manquante!"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3873,10 +3901,10 @@ msgstr "Date de facture manquante!"
 msgid "Invoice No."
 msgstr "N° de Facture"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3969,7 +3997,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Janvier"
 
@@ -4001,7 +4029,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Juill."
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juillet"
 
@@ -4009,7 +4037,7 @@ msgstr "Juillet"
 msgid "Jun"
 msgstr "Juin"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juin"
@@ -4042,7 +4070,7 @@ msgstr "Coût de production"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4270,7 +4298,7 @@ msgid "Loaded"
 msgstr "Chargé"
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr "Chargement..."
 
@@ -4359,11 +4387,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4384,7 +4412,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mars"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Mars"
 
@@ -4401,12 +4429,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4501,7 +4529,7 @@ msgstr "Mois"
 msgid "Months"
 msgstr "Mois"
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4535,15 +4563,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nom"
@@ -4603,7 +4630,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4655,7 +4682,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4687,7 +4714,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4758,9 +4785,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4800,7 +4827,7 @@ msgstr "Rien à transférer!"
 msgid "Nov"
 msgstr "Nov."
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembre"
 
@@ -4845,8 +4872,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numéro"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsolète"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4871,7 +4898,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Oct."
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Octobre"
 
@@ -4946,7 +4973,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Commande"
@@ -4978,7 +5005,7 @@ msgstr "Date de commande manquante!"
 msgid "Order Entry"
 msgstr "Commandes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5069,9 +5096,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5080,8 +5107,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5121,8 +5148,8 @@ msgstr "Le numéro de la liste d'envoi est manquant!"
 msgid "Packing list"
 msgstr "Liste d'envoi"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5150,7 +5177,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5180,7 +5207,7 @@ msgstr "Détails"
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5248,7 +5275,7 @@ msgstr "À payer"
 msgid "Payment"
 msgstr "Paiement"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5310,11 +5337,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5481,7 +5508,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5489,7 +5516,7 @@ msgstr ""
 msgid "Post"
 msgstr "Enregistrer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5611,7 +5638,7 @@ msgstr "Téléphone principal"
 msgid "Print"
 msgstr "Imprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5671,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5739,7 +5766,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5765,7 +5792,7 @@ msgid "Purchase Orders"
 msgstr "Commandes d'achat"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5782,7 +5809,7 @@ msgstr "Commande d'achat"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5997,13 +6024,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transactions périodiques"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6073,12 +6100,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6090,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6158,7 +6185,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requis pour"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6336,8 +6363,8 @@ msgstr "Numéro de devis de vente"
 msgid "Sales:"
 msgstr "Ventes:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6515,7 +6542,7 @@ msgstr "Planification"
 msgid "Scheduled"
 msgstr "Planifié"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Écran"
@@ -6699,7 +6726,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vente"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6756,7 +6783,7 @@ msgstr "Sept."
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septembre"
 
@@ -6776,7 +6803,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "N° série"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6862,8 +6889,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr "Expédier à:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6910,8 +6937,8 @@ msgstr "Date d'expédition manquante!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6982,8 +7009,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7029,14 +7056,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Code secteur économique"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7060,7 +7087,7 @@ msgid "Startdate"
 msgstr "Date de début"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7112,8 +7139,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7225,8 +7252,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7234,8 +7261,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7556,8 +7583,8 @@ msgstr ""
 msgid "Thu"
 msgstr "Jeu."
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7636,7 +7663,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7682,14 +7709,14 @@ msgstr ""
 msgid "Top-level"
 msgstr "Description principale"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7711,7 +7738,7 @@ msgstr "Description principale"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7739,7 +7766,7 @@ msgstr "Écriture"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7753,7 +7780,7 @@ msgstr "Date d'écriture manquante!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7862,9 +7889,9 @@ msgid "Two"
 msgstr "Deux"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7922,7 +7949,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7963,11 +7990,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr "Erreur inconnue lors de la connexion"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8096,7 +8123,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8110,7 +8137,7 @@ msgstr "Utilisateur"
 msgid "User Name"
 msgstr "Nom d'utilisateur"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8158,7 +8185,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Disponible"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8167,8 +8194,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8242,7 +8269,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fournisseur absent du fichier!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8256,7 +8283,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8390,13 +8417,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr "XLS"
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8635,7 +8662,7 @@ msgstr "commandes"
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr "lien permanent"
 

--- a/locale/po/hu.po
+++ b/locale/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "#Számlák"
 
@@ -98,7 +98,7 @@ msgstr "Szállító számla"
 msgid "AP Invoices"
 msgstr "Szállító számlák"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Kifizetetlen szállítószámlák"
@@ -110,7 +110,7 @@ msgstr "Kifizetetlen szállítószámlák"
 msgid "AP Transaction"
 msgstr "Szállító tranzakció"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Szállító tranzakciók"
 
@@ -145,7 +145,7 @@ msgstr "Vevőszámla"
 msgid "AR Invoices"
 msgstr "Vevőszámlák"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Kifizetetlen vevőszámlák"
@@ -156,7 +156,7 @@ msgstr "Kifizetetlen vevőszámlák"
 msgid "AR Transaction"
 msgstr "Vevő tranzakció"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Vevő tranzakciók"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Vevő tranzakció"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Vevő/Szállító/Vegyes könyvelés összege"
 
@@ -182,8 +182,8 @@ msgstr "Vevő/Szállító/Vegyes könyvelés összege"
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Hozzáférés megtagadva"
 
@@ -191,11 +191,11 @@ msgstr "Hozzáférés megtagadva"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Számla"
 msgid "Account Description"
 msgstr "Számla leírása"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Számla címke"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Számla neve"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr "Teljesítés alapján"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr "Összesített értékcsökkenés"
 
@@ -613,7 +613,7 @@ msgstr "Igazítás"
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr "Korrigált alap"
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Lejárt"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Lejárati lista"
 
@@ -687,11 +687,11 @@ msgstr "Lefoglalva"
 msgid "Allow Input"
 msgstr "Felülírható"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr "Felülírható"
 msgid "Amount"
 msgstr "Összeg"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Költségvetés összege"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Esedékes összeg"
 msgid "Amount From"
 msgstr "Összegtől"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr "Az összeg nagyobb mint"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr "Az összeg kisebb mint"
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr "Jóváhagyás állapota"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Jóváhagy"
@@ -810,12 +810,12 @@ msgstr "Jóváhagy"
 msgid "Approved"
 msgstr "Jóváhagyva"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Jóváhagyta"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Jóváhagyva"
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Ápr."
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Április"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr "Megszerzett érték"
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Eszköz"
 msgid "Asset Account"
 msgstr "Eszköz számla"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Eszközosztály"
@@ -905,7 +905,7 @@ msgstr "Eszköz értékcsökkenés"
 msgid "Asset Disposal Report"
 msgstr "Eszköz selejtezés jelentés"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug."
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Augusztus"
 
@@ -1080,13 +1080,13 @@ msgstr "Adatbázis mentése"
 msgid "Backup Roles"
 msgstr "Biztonsági mentés szabályok"
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Egyenleg"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr "Alap"
 msgid "Batch"
 msgstr "Köteg"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr "Köteg osztály"
 
@@ -1160,7 +1160,7 @@ msgstr "Köteg dátuma"
 msgid "Batch Description"
 msgstr "Köteg leírása"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr "Köteg ID"
 
@@ -1172,12 +1172,12 @@ msgstr "Köteg azonosító hiányzik"
 msgid "Batch Name"
 msgstr "Köteg neve"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Köteg azonosító"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr "Köteg keresése"
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Költségvetés azonosító"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr "Büdzsé keresés eredményei"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr "Költségvetés eltérés riport"
 
@@ -1282,7 +1282,7 @@ msgstr "Partnercsoport"
 msgid "Business Number"
 msgstr "Adószám"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr "Partnercsoport"
@@ -1317,9 +1317,9 @@ msgstr "ELÁBÉ"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Érvénytelenített számlát nem lehet még egyszer érvényteleníteni!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr "Jelszó megváltoztatása"
 msgid "Chargeable"
 msgstr "Számlázandó"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr "Táblázat ID"
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Számlatükör"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1618,8 +1618,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1666,7 +1666,7 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
@@ -1674,6 +1674,30 @@ msgstr ""
 #, fuzzy
 msgid "Compose e-mail"
 msgstr "Email küldés"
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:10
 msgid "Confirm Operation"
@@ -1683,7 +1707,7 @@ msgstr "Erősítse meg a műveletet"
 msgid "Confirm!"
 msgstr "Erősítse meg!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Meglévő adattal való ütközés. Elképzelhető, hogy már megadta korábban?"
 
@@ -1711,7 +1735,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr "Kapcsolat információk"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr "Kapcsolat keresése"
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr "Ország:"
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr "Köteg készítése"
 msgid "Create Database?"
 msgstr "Új cégadatbázis létrehozása?"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr "Létrehozta"
 msgid "Created On"
 msgstr "Létrehozva"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Követel"
 msgid "Credit Account"
 msgstr "Hitel számla"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Hitel számlaszám"
 
@@ -1934,22 +1958,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Új kéziszámla korrekció"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr "Követel"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Pénznem"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Pénznem"
 msgid "Currency"
 msgstr "Pénznem"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "A vevő hiányzik az adatbázisból!"
 msgid "Customer/Vendor Accounts"
 msgstr "Vevő/Szállító számlák"
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr "Écs."
 
@@ -2125,17 +2149,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr "Dátumformátum"
 msgid "Date From"
 msgstr "Mettől"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr "Nap"
 msgid "Days"
 msgstr "Napok"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr "Új számlakorrekció"
 msgid "Debit Note"
 msgstr "Új kéziszámla korrekció"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr "Tartozik"
 msgid "Dec"
 msgstr "Dec."
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "December"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Törlés"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr "Köteg törlése"
 
@@ -2386,7 +2410,7 @@ msgstr "Ütemezés törlése"
 msgid "Delete User"
 msgstr "Új felhasználó"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr "Utalványok törlése"
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Szállítás"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Szállítás dátuma"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr "Écs. alapja"
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr "Écs. módja"
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr "Écs. indul"
 
@@ -2431,11 +2455,11 @@ msgstr "Écs. indul"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr "Értékcsökkenés"
 msgid "Depreciate Through"
 msgstr "Értékcsökkentés ezen keresztül"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Értékcsökkenés"
@@ -2478,15 +2502,15 @@ msgstr "Értékcsökkentés módszere"
 msgid "Depreciation Starts"
 msgstr "Értékcsökkenés kezdete"
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr "Értékcsökkenés kezdete"
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr "Részletek"
 msgid "Disable Back Button"
 msgstr "Vissza gomb letiltása"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr "Árk"
 
@@ -2603,16 +2627,16 @@ msgstr "Engedmény (%)"
 msgid "Discount:"
 msgstr "Engedmény:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Selejtezés"
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr "Selejtezés dátuma"
 
@@ -2620,11 +2644,11 @@ msgstr "Selejtezés dátuma"
 msgid "Disposal Method"
 msgstr "Selejtezés módja"
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr "Nullával osztás probléma"
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr "Dr."
@@ -2664,11 +2692,11 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "A vázlat rögzítve"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr "Vázlat keresése"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr "Vázlat típusa"
 
@@ -2682,11 +2710,11 @@ msgstr "Vázlatok"
 msgid "Drawing"
 msgstr "Rajz"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr "Legördülők"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr "Legördülők"
 msgid "Due"
 msgstr "Esedékes"
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Hiányzik az e-mail cím!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr "tizenegy"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr "Email"
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr "Felhasználó bevitel"
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr "Rögzítette"
@@ -3005,7 +3033,7 @@ msgstr "Rögzítette"
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr "Felrögzítve"
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr "Egyed"
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Egység kódja"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr "Bejegyzés ID"
 
@@ -3076,7 +3104,7 @@ msgstr "Hiba történt a biztonsági mentés fájl létrehozása során"
 msgid "Error creating batch.  Please try again."
 msgstr "Hiba történt a köteg létrehozásakor. Kérem próbálja újra."
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr "Hiba a funkcióban:"
 
@@ -3084,7 +3112,7 @@ msgstr "Hiba a funkcióban:"
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Hiba: Más legördülő menü nem tartalmazhatja a gyűjtőszámlát"
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr "Becsült élettartam"
 
@@ -3096,7 +3124,7 @@ msgstr "Minden"
 msgid "Exch"
 msgstr "Árf"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb."
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Február"
 
@@ -3221,7 +3249,7 @@ msgstr "ötven"
 msgid "File"
 msgstr "Fájl"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr "Importált fájl"
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr "Kezdő dátum"
@@ -3388,11 +3416,11 @@ msgstr "Kezdő dátum"
 msgid "Full"
 msgstr "Teljes"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Teljes jogosultság"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr "Vegyes könyvelés referenciaszám"
 msgid "Gain"
 msgstr "Nyereség"
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr "Nyereség (veszteség)"
 
@@ -3431,7 +3459,7 @@ msgstr "Nyereség (veszteség)"
 msgid "Gain Account"
 msgstr "Nyereség számla"
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Nyereség (veszteség)"
@@ -3444,7 +3472,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Főkönyv"
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr "Főkönyvi jelentés"
 
@@ -3452,7 +3480,7 @@ msgstr "Főkönyvi jelentés"
 msgid "General Ledger Reports"
 msgstr "Főkönyvi jelentés"
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Generálás"
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "HR"
 msgstr "Személyügy"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3581,18 +3609,18 @@ msgid "Hundred"
 msgstr "száz"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3745,7 +3773,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr "Belső adatbázis hiba"
 
@@ -3766,7 +3794,7 @@ msgstr "Valótlan jelentés alap"
 msgid "Invalid backup request"
 msgstr "Érvénytelen biztonsági mentés kérés"
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr "Érvénytelen dátum/idő lett megadva"
 
@@ -3824,9 +3852,9 @@ msgstr "Készlet elmentve!"
 msgid "Inventory transferred!"
 msgstr "Készlet áthelyezve!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3855,7 +3883,7 @@ msgstr "Számla kelte"
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3870,10 +3898,10 @@ msgstr "A teljesítés dátuma hiányzik!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3966,7 +3994,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan."
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Január"
 
@@ -3998,7 +4026,7 @@ msgstr "Napló sorok"
 msgid "Jul"
 msgstr "Júl."
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Július"
 
@@ -4006,7 +4034,7 @@ msgstr "Július"
 msgid "Jun"
 msgstr "Jún."
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Június"
@@ -4039,7 +4067,7 @@ msgstr "Művelet"
 msgid "Labor/Service Code"
 msgstr "Művelet/Szolgáltatáskód"
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4267,7 +4295,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4356,11 +4384,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Felhasználók kezelése"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4381,7 +4409,7 @@ msgstr "Kézi"
 msgid "Mar"
 msgstr "Márc."
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Március"
 
@@ -4398,12 +4426,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr "Max. bejegyzés a legördülő listában"
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Máj."
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4499,7 +4527,7 @@ msgstr "Hónap"
 msgid "Months"
 msgstr "Hónapok"
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr "További információk találhatók a hibanaplóban"
 
@@ -4533,15 +4561,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Név"
@@ -4601,7 +4628,7 @@ msgid "Next Number"
 msgstr "Következő azonosító"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4653,7 +4680,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4687,7 +4714,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4758,9 +4785,9 @@ msgstr "Megjegyzés osztálya"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4800,7 +4827,7 @@ msgstr "Nincs mit áthelyezni!"
 msgid "Nov"
 msgstr "Nov."
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4845,8 +4872,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Azonosító"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Elavult"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr "Elavultatta"
 
@@ -4871,7 +4898,7 @@ msgstr "Elavultatta"
 msgid "Oct"
 msgstr "Okt."
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Október"
 
@@ -4947,7 +4974,7 @@ msgid "Or Add To Batch"
 msgstr "Vagy hozzáadás köteghez"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Sorrend"
@@ -4979,7 +5006,7 @@ msgstr "A rendelés dátuma hiányzik!"
 msgid "Order Entry"
 msgstr "Rendelések"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5070,9 +5097,9 @@ msgstr "Túlfizetés számla"
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5081,8 +5108,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "BR #"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5122,8 +5149,8 @@ msgstr "Szállítólevél száma hiányzik!"
 msgid "Packing list"
 msgstr "Szállítólevél"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5151,7 +5178,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5182,7 +5209,7 @@ msgstr "Részletek"
 msgid "Partial"
 msgstr "Részleges"
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5250,7 +5277,7 @@ msgstr "Kötelezettségek"
 msgid "Payment"
 msgstr "Kifizetés"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr "Kifizetés értéke"
 
@@ -5314,11 +5341,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Százalék"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr "Selejtezés százaléka"
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr "Maradék százalék"
 
@@ -5485,7 +5512,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5493,7 +5520,7 @@ msgstr ""
 msgid "Post"
 msgstr "Rögzítés"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr "Köteg rögzítése"
 
@@ -5615,7 +5642,7 @@ msgstr ""
 msgid "Print"
 msgstr "Nyomtatás"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5675,15 +5702,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr "Bevételek"
 
@@ -5743,7 +5770,7 @@ msgstr "Vásárlás dátuma"
 msgid "Purchase Date:"
 msgstr "Vásárlás dátuma:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr "Beszerzési napló"
@@ -5769,7 +5796,7 @@ msgid "Purchase Orders"
 msgstr "Beszerzési rendelések"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "Beszerzési érték"
 
@@ -5786,7 +5813,7 @@ msgstr "Beszerzési rendelés"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -6001,13 +6028,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Ismétlődő tranzakciók"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6077,12 +6104,12 @@ msgstr "Jelentés jóváhagyva"
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "Eredmények listája"
 
@@ -6094,7 +6121,7 @@ msgstr "Jelentés elküldve"
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6162,7 +6189,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Kért kiszállítás"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr "Nincs megadva elegendő adat"
 
@@ -6340,8 +6367,8 @@ msgstr "Megszólítás"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6519,7 +6546,7 @@ msgstr "Beütemez"
 msgid "Scheduled"
 msgstr "Ütemezve"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Képernyő"
@@ -6703,7 +6730,7 @@ msgstr "Kiválasztott"
 msgid "Sell"
 msgstr "Eladás"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6760,7 +6787,7 @@ msgstr "Szept."
 msgid "Separate Duties"
 msgstr "Jogok elkülönítése"
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Szeptember"
 
@@ -6780,7 +6807,7 @@ msgstr "Sorozatszám"
 msgid "Serial No."
 msgstr "Sorozatszám"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6866,8 +6893,8 @@ msgstr "Szállítási cím"
 msgid "Ship To:"
 msgstr "Szállítási cím:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6914,8 +6941,8 @@ msgstr "A szállítás dátuma hiányzik!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6987,8 +7014,8 @@ msgstr "Eladva"
 msgid "Some"
 msgstr "Néhány"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7034,14 +7061,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "TEÁOR/SZJ kód (SIC)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7066,7 +7093,7 @@ msgid "Startdate"
 msgstr "Kezdő dátum"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr "Nyitó egyenleg"
 
@@ -7118,8 +7145,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7231,8 +7258,8 @@ msgstr "Végösszeg"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr "Címke"
 
@@ -7240,8 +7267,8 @@ msgstr "Címke"
 msgid "Tag:"
 msgstr "Címke:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7563,8 +7590,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7643,7 +7670,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr "Végdátum"
@@ -7689,14 +7716,14 @@ msgstr ""
 msgid "Top-level"
 msgstr "Legfelső szint"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7718,7 +7745,7 @@ msgstr "Legfelső szint"
 msgid "Total"
 msgstr "Végösszeg"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr "Összesített écs."
 
@@ -7746,7 +7773,7 @@ msgstr "Tranzakció"
 msgid "Transaction Approval"
 msgstr "Tranzakció jóváhagyás"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7760,7 +7787,7 @@ msgstr "Tranzakció dátuma hiányzik!"
 msgid "Transaction Dates"
 msgstr "Tranzakció dátumok"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7869,9 +7896,9 @@ msgid "Two"
 msgstr "kettő"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7929,7 +7956,7 @@ msgstr "Egyedi szállító azonosító"
 msgid "Unique nonobsolete partnumbers"
 msgstr "Egyedi élő cikkszám"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7970,11 +7997,11 @@ msgstr "Ismeretlen adatbázist találtam."
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8103,7 +8130,7 @@ msgstr "Használja a túlfizetést/előutalást"
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Használt"
@@ -8117,7 +8144,7 @@ msgstr "Felhasználó"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr "A felhasználó már létezik. Beolvassa az adatait?"
 
@@ -8165,7 +8192,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Eltérés"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr "Eltérés"
@@ -8174,8 +8201,8 @@ msgstr "Eltérés"
 msgid "Variance:"
 msgstr "Eltérés:"
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8249,7 +8276,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "A szállító nincs az adatbázisban!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8263,7 +8290,7 @@ msgstr ""
 msgid "Void"
 msgstr "Érvénytelenít"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr "Utalványok"
 
@@ -8392,13 +8419,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8637,7 +8664,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/id.po
+++ b/locale/po/id.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Hutang Belum Lunas"
@@ -110,7 +110,7 @@ msgstr "Hutang Belum Lunas"
 msgid "AP Transaction"
 msgstr "Transkasi Hutang"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transkasi Hutang"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Piutang Belum Lunas"
@@ -156,7 +156,7 @@ msgstr "Piutang Belum Lunas"
 msgid "AR Transaction"
 msgstr "Transaksi Piutang"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transaksi Piutang"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaksi Piutang"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Akses ditolak"
 
@@ -191,11 +191,11 @@ msgstr "Akses ditolak"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Akun"
 msgid "Account Description"
 msgstr "Deskripsi Akun"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Label Akun"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nama Akun"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Jumlah"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Jumlah Terhutang"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr ""
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Aktiva"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr ""
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agustus"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1257,15 +1257,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr "Bisnis"
 msgid "Business Number"
 msgstr "Nomor Bisnis"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr "Tipe Bisnis"
@@ -1316,9 +1316,9 @@ msgstr ""
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1466,11 +1466,11 @@ msgstr "Ubah Password"
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Bagan Akun"
 
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1616,8 +1616,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1664,12 +1664,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1680,7 +1704,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Konfirmasi!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1708,7 +1732,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1765,7 +1789,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1853,7 +1877,7 @@ msgstr "Negara:"
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1893,7 +1917,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1904,7 +1928,7 @@ msgstr "Kredit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1931,22 +1955,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Mata Uang"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1965,7 +1989,7 @@ msgstr "Mata Uang"
 msgid "Currency"
 msgstr "Mata Uang"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1981,8 +2005,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2045,7 +2069,7 @@ msgstr "Pelanggan tidak ditemukan!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2122,17 +2146,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2162,8 +2186,8 @@ msgstr "Format Tanggal"
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2242,7 +2266,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2257,7 +2281,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2268,7 +2292,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Desember"
 
@@ -2353,11 +2377,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2370,7 +2394,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Hapus"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2383,7 +2407,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Hapus"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2406,21 +2430,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Pengiriman"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Tanggal Kirim"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2428,11 +2452,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2454,7 +2478,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2475,15 +2499,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2500,13 +2524,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2574,7 +2598,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2600,16 +2624,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2617,11 +2641,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2653,6 +2677,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2661,11 +2689,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2679,11 +2707,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2692,9 +2720,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2724,7 +2752,7 @@ msgstr ""
 msgid "E-mail address missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2885,7 +2913,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2942,14 +2970,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2993,7 +3021,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3002,7 +3030,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3011,7 +3039,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3036,7 +3064,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nama Negara"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3073,7 +3101,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3081,7 +3109,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3093,7 +3121,7 @@ msgstr ""
 msgid "Exch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3202,7 +3230,7 @@ msgstr ""
 msgid "Feb"
 msgstr ""
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Februari"
 
@@ -3218,7 +3246,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3362,7 +3390,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3385,11 +3413,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3420,7 +3448,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3428,7 +3456,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Laba/Rugi"
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3817,9 +3845,9 @@ msgstr "Inventory sudah disimpan!"
 msgid "Inventory transferred!"
 msgstr "Inventory sudah di-transfer"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3848,7 +3876,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3863,10 +3891,10 @@ msgstr "Tanggal Invoice harap diisi!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3959,7 +3987,7 @@ msgstr ""
 msgid "Jan"
 msgstr ""
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Januari"
 
@@ -3991,7 +4019,7 @@ msgstr ""
 msgid "Jul"
 msgstr ""
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juli"
 
@@ -3999,7 +4027,7 @@ msgstr "Juli"
 msgid "Jun"
 msgstr ""
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
@@ -4032,7 +4060,7 @@ msgstr "Tenaga Kerja/ Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4263,7 +4291,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4352,11 +4380,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Pengaturan Pengguna/User"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4377,7 +4405,7 @@ msgstr ""
 msgid "Mar"
 msgstr ""
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Maret"
 
@@ -4394,12 +4422,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4494,7 +4522,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4528,15 +4556,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nama"
@@ -4596,7 +4623,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4648,7 +4675,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr "Tidak Ada Perubahan"
 
@@ -4680,7 +4707,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4751,9 +4778,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4793,7 +4820,7 @@ msgstr "Tidak ada yang akan di-transfer!"
 msgid "Nov"
 msgstr ""
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4838,8 +4865,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Nomor"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4856,7 +4883,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Kadaluarsa"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4864,7 +4891,7 @@ msgstr ""
 msgid "Oct"
 msgstr ""
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktober"
 
@@ -4939,7 +4966,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "No. Pesanan"
@@ -4971,7 +4998,7 @@ msgstr "Tanggal Pesanan harap diisi!"
 msgid "Order Entry"
 msgstr "Pesanan"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5062,9 +5089,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5073,8 +5100,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5113,8 +5140,8 @@ msgstr "Nomor Packing List harap diisi!"
 msgid "Packing list"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5142,7 +5169,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5171,7 +5198,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5239,7 +5266,7 @@ msgstr "Hutang"
 msgid "Payment"
 msgstr "Pembayaran"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5301,11 +5328,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Post"
 msgstr "Posting"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5601,7 +5628,7 @@ msgstr ""
 msgid "Print"
 msgstr "Cetak"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5661,15 +5688,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5757,7 @@ msgstr "Tanggal Pembelian"
 msgid "Purchase Date:"
 msgstr "Tanggal Pembelian:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5756,7 +5783,7 @@ msgid "Purchase Orders"
 msgstr "Pesanan Pembelian (PO)"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5773,7 +5800,7 @@ msgstr "Pesanan Pembelian (PO)"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5986,13 +6013,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6062,12 +6089,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6079,7 +6106,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6147,7 +6174,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Tanggal Kirim"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6325,8 +6352,8 @@ msgstr "Nomor Sales Quotation"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6504,7 +6531,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Layar"
@@ -6688,7 +6715,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Jual"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6745,7 +6772,7 @@ msgstr ""
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr ""
 
@@ -6765,7 +6792,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "No. Seri"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6850,8 +6877,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6898,8 +6925,8 @@ msgstr "Tanggal Pengiriman harap diisi!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6970,8 +6997,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7017,14 +7044,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7048,7 +7075,7 @@ msgid "Startdate"
 msgstr "Tanggal Mulai"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7100,8 +7127,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7213,8 +7240,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7222,8 +7249,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7544,8 +7571,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7624,7 +7651,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7670,14 +7697,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7699,7 +7726,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7727,7 +7754,7 @@ msgstr "Transaksi"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7741,7 +7768,7 @@ msgstr "Tanggal Transaksi harap diisi"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7850,9 +7877,9 @@ msgid "Two"
 msgstr "Dua"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7910,7 +7937,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7951,11 +7978,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8084,7 +8111,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Digunakan"
@@ -8098,7 +8125,7 @@ msgstr "Pengguna"
 msgid "User Name"
 msgstr "Nama Pengguna"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8146,7 +8173,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Tersedia"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8155,8 +8182,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8230,7 +8257,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Data Supplier tidak ditemukan!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8244,7 +8271,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8372,13 +8399,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8617,7 +8644,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/is.po
+++ b/locale/po/is.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Icelandic (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Innkaupafærsla"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Innkaupafærslur"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Sölufærsla"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Sölufærslur"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Sölufærsla"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Reikningur"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Upphæð"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Eindagi"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "apríl"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Eignir"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "ágú"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "ágúst"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Afstemming"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1257,15 +1257,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Viðskiptanúmer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1316,9 +1316,9 @@ msgstr "Innkaup"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1466,11 +1466,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Listi yfir lykkla/reikninga"
 
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1616,8 +1616,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1664,12 +1664,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1680,7 +1704,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Staðfesta!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1708,7 +1732,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1765,7 +1789,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1853,7 +1877,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1893,7 +1917,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1904,7 +1928,7 @@ msgstr "Kredit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1931,22 +1955,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Gjaldm"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1965,7 +1989,7 @@ msgstr "Gjaldm"
 msgid "Currency"
 msgstr "Gjaldmiðill"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1981,8 +2005,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2045,7 +2069,7 @@ msgstr "Viðskiptavinur ekki á skrá!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2122,17 +2146,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2162,8 +2186,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2242,7 +2266,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2257,7 +2281,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2268,7 +2292,7 @@ msgstr ""
 msgid "Dec"
 msgstr "des"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "desember"
 
@@ -2353,11 +2377,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2370,7 +2394,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Eyða"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2383,7 +2407,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Eyða"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2406,21 +2430,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Afgreiðsludags."
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2428,11 +2452,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2454,7 +2478,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2475,15 +2499,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2500,13 +2524,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2574,7 +2598,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2600,16 +2624,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2617,11 +2641,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2653,6 +2677,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2661,11 +2689,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2679,11 +2707,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Dregið"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2692,9 +2720,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2724,7 +2752,7 @@ msgstr "R-póstur"
 msgid "E-mail address missing!"
 msgstr "R-póst vantar!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2885,7 +2913,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2941,14 +2969,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2992,7 +3020,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3001,7 +3029,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3010,7 +3038,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3034,7 +3062,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3071,7 +3099,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3079,7 +3107,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3091,7 +3119,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Vx"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3200,7 +3228,7 @@ msgstr ""
 msgid "Feb"
 msgstr "feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "febrúar"
 
@@ -3216,7 +3244,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3360,7 +3388,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3383,11 +3411,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3418,7 +3446,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3426,7 +3454,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3438,7 +3466,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3446,7 +3474,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3533,7 +3561,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3575,18 +3603,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3739,7 +3767,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3760,7 +3788,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3814,9 +3842,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3845,7 +3873,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3860,10 +3888,10 @@ msgstr "Sölureiknings dags. vantar!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3956,7 +3984,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "janúar"
 
@@ -3988,7 +4016,7 @@ msgstr ""
 msgid "Jul"
 msgstr "júl"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "júlí"
 
@@ -3996,7 +4024,7 @@ msgstr "júlí"
 msgid "Jun"
 msgstr "jún"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "júní"
@@ -4029,7 +4057,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4257,7 +4285,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4346,11 +4374,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4371,7 +4399,7 @@ msgstr ""
 msgid "Mar"
 msgstr "mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "mars"
 
@@ -4388,12 +4416,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "maí"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4488,7 +4516,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4522,15 +4550,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nafn"
@@ -4590,7 +4617,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4642,7 +4669,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4674,7 +4701,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4745,9 +4772,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4787,7 +4814,7 @@ msgstr ""
 msgid "Nov"
 msgstr "nóv"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "nóvember"
 
@@ -4832,8 +4859,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Númer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4850,7 +4877,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Úrelt"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4858,7 +4885,7 @@ msgstr ""
 msgid "Oct"
 msgstr "ókt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "óktóber"
 
@@ -4933,7 +4960,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Pöntun"
@@ -4965,7 +4992,7 @@ msgstr "Pöntunar dags. vantar"
 msgid "Order Entry"
 msgstr "Pöntunarblað"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5055,9 +5082,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5066,8 +5093,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5107,8 +5134,8 @@ msgstr "Númer fylgiseðils vantar!"
 msgid "Packing list"
 msgstr "Fylgiseðill"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5136,7 +5163,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5165,7 +5192,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5233,7 +5260,7 @@ msgstr "Útistandandi"
 msgid "Payment"
 msgstr "Greislur"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5295,11 +5322,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5465,7 +5492,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5473,7 +5500,7 @@ msgstr ""
 msgid "Post"
 msgstr "Bókfæra"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5595,7 +5622,7 @@ msgstr ""
 msgid "Print"
 msgstr "Prenta"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5655,15 +5682,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5723,7 +5750,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5749,7 +5776,7 @@ msgid "Purchase Orders"
 msgstr "Innkaupspantanir"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5766,7 +5793,7 @@ msgstr "Innkaupspöntun"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5981,13 +6008,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6057,12 +6084,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6074,7 +6101,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6141,7 +6168,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Pantað af"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6318,8 +6345,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6497,7 +6524,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skjá"
@@ -6681,7 +6708,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6738,7 +6765,7 @@ msgstr "sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "september"
 
@@ -6758,7 +6785,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6843,8 +6870,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6891,8 +6918,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6962,8 +6989,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7009,14 +7036,14 @@ msgstr "Standart"
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7040,7 +7067,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7092,8 +7119,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7204,8 +7231,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7213,8 +7240,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7535,8 +7562,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7615,7 +7642,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7661,14 +7688,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7690,7 +7717,7 @@ msgstr ""
 msgid "Total"
 msgstr "Samtals"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7718,7 +7745,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7732,7 +7759,7 @@ msgstr "Dags. vantar!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7841,9 +7868,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7901,7 +7928,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7942,11 +7969,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8075,7 +8102,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8089,7 +8116,7 @@ msgstr "Notandi"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8137,7 +8164,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Skatskildur"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8146,8 +8173,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8221,7 +8248,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Byrgir ekki til í gagnagrunni!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8235,7 +8262,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8363,13 +8390,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8608,7 +8635,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/it.po
+++ b/locale/po/it.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "fatture n."
 
@@ -102,7 +102,7 @@ msgstr "Fattura a debito"
 msgid "AP Invoices"
 msgstr "Fatture a debito"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -114,7 +114,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Transazione Fornitore"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transazioni Fornitori"
 
@@ -149,7 +149,7 @@ msgstr "Fattura a credito"
 msgid "AR Invoices"
 msgstr "Fatture a credito"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Transazione Cliente"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transazioni Clienti"
 
@@ -177,8 +177,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transazione Cliente"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Somma Crediti/Debiti/Libro giornale"
 
@@ -186,8 +186,8 @@ msgstr "Somma Crediti/Debiti/Libro giornale"
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Accesso negato"
 
@@ -195,11 +195,11 @@ msgstr "Accesso negato"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -224,22 +224,22 @@ msgstr "Conto"
 msgid "Account Description"
 msgstr "Descrizione conto"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Nome conto"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nome conto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -320,7 +320,7 @@ msgstr "Rateo"
 msgid "Accrual Basis:"
 msgstr "Rateo base:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -617,7 +617,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -691,11 +691,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -713,11 +713,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Importo"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Totale preventivato"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -729,13 +729,13 @@ msgstr "Importo Dovuto"
 msgid "Amount From"
 msgstr "Somma da"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr "Importo maggiore di"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr "Importo minore di"
 
@@ -799,9 +799,9 @@ msgid "Approval Status"
 msgstr "Stato approvazione"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Approva"
@@ -814,12 +814,12 @@ msgstr "Approva"
 msgid "Approved"
 msgstr "Approvato"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Approvato da"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Approvato il"
 
@@ -835,16 +835,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Aprile"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr "Valore acquisito"
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -884,7 +884,7 @@ msgstr "Attivit&agrave;"
 msgid "Asset Account"
 msgstr "Conto attività"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Classe attivo"
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr "Lista attività"
 
@@ -1014,7 +1014,7 @@ msgstr "Att.ne: [_1]"
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1084,13 +1084,13 @@ msgstr "Backup DB"
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1176,12 +1176,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1261,15 +1261,15 @@ msgstr ""
 msgid "Budget"
 msgstr "Preventivo"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Preventivo n."
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr "Preventivi trovati"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1285,7 +1285,7 @@ msgstr "Azienda"
 msgid "Business Number"
 msgstr "Partita IVA"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1320,9 +1320,9 @@ msgstr "Costo dei Beni Venduti"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1470,11 +1470,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Piano dei Conti"
 
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1621,8 +1621,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr "Confronta esercizi"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
@@ -1677,6 +1677,30 @@ msgstr ""
 #, fuzzy
 msgid "Compose e-mail"
 msgstr "Per email"
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:10
 msgid "Confirm Operation"
@@ -1686,7 +1710,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Conferma!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1714,7 +1738,7 @@ msgstr "Info contatto:"
 msgid "Contact Information"
 msgstr "Informazioni contatto"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr "Cerca contatto"
@@ -1771,7 +1795,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1859,7 +1883,7 @@ msgstr "Nazione"
 msgid "Create"
 msgstr "Crea"
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1871,7 +1895,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1899,7 +1923,7 @@ msgstr "Creato da"
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1910,7 +1934,7 @@ msgstr "Avere"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1937,22 +1961,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Nota di accredito"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1971,7 +1995,7 @@ msgstr "Valuta"
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1987,8 +2011,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2051,7 +2075,7 @@ msgstr "Cliente non sul file!"
 msgid "Customer/Vendor Accounts"
 msgstr "Conti fornitori"
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2128,17 +2152,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2168,8 +2192,8 @@ msgstr "Formato data"
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2248,7 +2272,7 @@ msgstr "Giorno(i)"
 msgid "Days"
 msgstr "Giorni"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2263,7 +2287,7 @@ msgstr "Fattura a debito"
 msgid "Debit Note"
 msgstr "Nota di addebito"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2274,7 +2298,7 @@ msgstr "Debiti"
 msgid "Dec"
 msgstr "Dic"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Dicembre"
 
@@ -2359,11 +2383,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2376,7 +2400,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Cancella"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2389,7 +2413,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Nuovo utente"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2412,21 +2436,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Consegna"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data di consegna"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2434,11 +2458,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2460,7 +2484,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2481,15 +2505,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2506,13 +2530,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2580,7 +2604,7 @@ msgstr "Dettagli"
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr "Sconto"
 
@@ -2606,16 +2630,16 @@ msgstr "Sconto (%)"
 msgid "Discount:"
 msgstr "Sconto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2623,11 +2647,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2659,6 +2683,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr "Duplicato numero fornitore"
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2667,11 +2695,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr "Prima nota scritta"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr "Cerca prima nota"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr "Tipo prima nota"
 
@@ -2685,11 +2713,11 @@ msgstr "Prima nota"
 msgid "Drawing"
 msgstr "Disegno"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2698,9 +2726,9 @@ msgstr ""
 msgid "Due"
 msgstr "Scadenza"
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2730,7 +2758,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Indirizzo e-mail mancante!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2891,7 +2919,7 @@ msgstr "undici"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2948,14 +2976,14 @@ msgstr "Senza codici cliente"
 msgid "Empty vendornumbers"
 msgstr "Fornitori senza codici"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2999,7 +3027,7 @@ msgstr "Inserisci utente"
 msgid "Enter employee numbers where they are missing"
 msgstr "Inserisci i numeri degli impiegati dove mancano"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr "Inserito da"
@@ -3008,7 +3036,7 @@ msgstr "Inserito da"
 msgid "Entered For"
 msgstr "Inserito per"
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr "Inserito il"
 
@@ -3017,7 +3045,7 @@ msgid "Entered at: [_1]"
 msgstr "Inserito il: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr "Entità"
 
@@ -3042,7 +3070,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Codice Entità"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3079,7 +3107,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3087,7 +3115,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr "Durata stimata"
 
@@ -3099,7 +3127,7 @@ msgstr "Tutti"
 msgid "Exch"
 msgstr "Cambio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3208,7 +3236,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Febbraio"
 
@@ -3224,7 +3252,7 @@ msgstr "cinquanta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3368,7 +3396,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3391,11 +3419,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3426,7 +3454,7 @@ msgstr "Riferimento libro giornale n."
 msgid "Gain"
 msgstr "Guadagno"
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr "Guadagno (Perdita)"
 
@@ -3434,7 +3462,7 @@ msgstr "Guadagno (Perdita)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Guadagno (Perdita)"
@@ -3447,7 +3475,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Libro giornale"
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr "Resoconto libro giornale"
 
@@ -3455,7 +3483,7 @@ msgstr "Resoconto libro giornale"
 msgid "General Ledger Reports"
 msgstr "Resoconti libro giornale"
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Genera"
@@ -3542,7 +3570,7 @@ msgstr ""
 msgid "HR"
 msgstr "Risorse umane"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3584,18 +3612,18 @@ msgid "Hundred"
 msgstr "cento"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3748,7 +3776,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3769,7 +3797,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr "Richiesta non valida di backup"
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr "Data/ora inserita non valida"
 
@@ -3825,9 +3853,9 @@ msgstr "Inventario registrato!"
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3856,7 +3884,7 @@ msgstr "Creata fattura"
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3871,10 +3899,10 @@ msgstr "Manca la data della Fattura!"
 msgid "Invoice No."
 msgstr "Numero Fattura"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3967,7 +3995,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Gen"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Gennaio"
 
@@ -3999,7 +4027,7 @@ msgstr "Righe giornale"
 msgid "Jul"
 msgstr "Lug"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Luglio"
 
@@ -4007,7 +4035,7 @@ msgstr "Luglio"
 msgid "Jun"
 msgstr "Giu"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Giugno"
@@ -4040,7 +4068,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4268,7 +4296,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4357,11 +4385,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Gestione utenti"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4382,7 +4410,7 @@ msgstr "Manuale"
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzo"
 
@@ -4399,12 +4427,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mag"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4499,7 +4527,7 @@ msgstr "Mese(i)"
 msgid "Months"
 msgstr "Mesi"
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4533,15 +4561,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nome"
@@ -4601,7 +4628,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4653,7 +4680,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr "Invariato"
 
@@ -4685,7 +4712,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4756,9 +4783,9 @@ msgstr "Classe di note"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4798,7 +4825,7 @@ msgstr "Nulla da trasferire!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembre"
 
@@ -4843,8 +4870,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Partita IVA"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4861,7 +4888,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4869,7 +4896,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Ott"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Ottobre"
 
@@ -4945,7 +4972,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Ordine"
@@ -4977,7 +5004,7 @@ msgstr "Manca la data dell'ordine"
 msgid "Order Entry"
 msgstr "Ordini"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5068,9 +5095,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5079,8 +5106,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "Ordine acquisto #"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5120,8 +5147,8 @@ msgstr "Manca il codice della Packing List!"
 msgid "Packing list"
 msgstr "Lista Etichette"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5149,7 +5176,7 @@ msgstr "Descrizione particolare"
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5180,7 +5207,7 @@ msgstr "Dettagli"
 msgid "Partial"
 msgstr "Parziale"
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5248,7 +5275,7 @@ msgstr "Debiti Fornitori"
 msgid "Payment"
 msgstr "Pagamento"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr "Somma pagata"
 
@@ -5310,11 +5337,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Percentuale"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5481,7 +5508,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5489,7 +5516,7 @@ msgstr ""
 msgid "Post"
 msgstr "Registra"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5611,7 +5638,7 @@ msgstr "Telefono principale"
 msgid "Print"
 msgstr "Stampa"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5671,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5740,7 +5767,7 @@ msgstr "Data d'acquisto"
 msgid "Purchase Date:"
 msgstr "Data acquisto:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr "Storico acquisti"
@@ -5766,7 +5793,7 @@ msgid "Purchase Orders"
 msgstr "Ordini di acquisto"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "Valore acquistato"
 
@@ -5783,7 +5810,7 @@ msgstr "Ordine di acquisto"
 msgid "Purchased"
 msgstr "Comprato"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5998,13 +6025,13 @@ msgstr "Transazione ricorrente per [_1]"
 msgid "Recurring Transactions"
 msgstr "Transazioni ricorrenti"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6074,12 +6101,12 @@ msgstr "Resoconto verificato"
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr "Nome resoconto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "Resoconto risultante"
 
@@ -6091,7 +6118,7 @@ msgstr "Resoconto inviato"
 msgid "Report Type"
 msgstr "Tipo resoconto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr "Resoconto [_1] in data [_2]"
 
@@ -6159,7 +6186,7 @@ msgstr "Data richiesta"
 msgid "Required by"
 msgstr "Necessario dal"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6337,8 +6364,8 @@ msgstr "titolo"
 msgid "Sales:"
 msgstr "Vendite"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6516,7 +6543,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Schermo"
@@ -6700,7 +6727,7 @@ msgstr "Scelto"
 msgid "Sell"
 msgstr "Vendere"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6757,7 +6784,7 @@ msgstr "Set"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Settembre"
 
@@ -6777,7 +6804,7 @@ msgstr "Serie #"
 msgid "Serial No."
 msgstr "Serie N."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6863,8 +6890,8 @@ msgstr "Spedire a"
 msgid "Ship To:"
 msgstr "Spedire a:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6911,8 +6938,8 @@ msgstr "Manca data spedizione"
 msgid "Shipping Label"
 msgstr "Etichetta di spedizione"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6984,8 +7011,8 @@ msgstr "Venduto"
 msgid "Some"
 msgstr "Alcuni"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7031,14 +7058,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Codifica industriale standard"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7062,7 +7089,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7114,8 +7141,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7227,8 +7254,8 @@ msgstr "TOTALE"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7236,8 +7263,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7558,8 +7585,8 @@ msgstr ""
 msgid "Thu"
 msgstr "gio"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7638,7 +7665,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7684,14 +7711,14 @@ msgstr "Seleziona tutti i controlli di rimozione"
 msgid "Top-level"
 msgstr "Cima livello"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7713,7 +7740,7 @@ msgstr "Cima livello"
 msgid "Total"
 msgstr "Totale"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7741,7 +7768,7 @@ msgstr "Scrittura"
 msgid "Transaction Approval"
 msgstr "Approvazione scritture"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7755,7 +7782,7 @@ msgstr "Manca la data della transazione!"
 msgid "Transaction Dates"
 msgstr "Date scrittura"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7864,9 +7891,9 @@ msgid "Two"
 msgstr "due"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7924,7 +7951,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7965,11 +7992,11 @@ msgstr "Trovato database sconosciuto."
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr "Sblocca"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8098,7 +8125,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Usato"
@@ -8112,7 +8139,7 @@ msgstr "Utente"
 msgid "User Name"
 msgstr "Nome utente"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8160,7 +8187,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Varianza"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr "Varianza"
@@ -8169,8 +8196,8 @@ msgstr "Varianza"
 msgid "Variance:"
 msgstr "Varianza:"
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8244,7 +8271,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fornitore non in archivio!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8258,7 +8285,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr "Lista Voucher"
 
@@ -8392,13 +8419,13 @@ msgstr "Desideri migrare il database?"
 msgid "Would you like to upgrade the database?"
 msgstr "Desideri aggiornare il database?"
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8637,7 +8664,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr "disposizione parziale"
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/lt.po
+++ b/locale/po/lt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -17,7 +17,7 @@ msgstr ""
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : "
 "n % 1 != 0 ? 2: 3);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -100,7 +100,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -112,7 +112,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Pirkimo Operaciją"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Pirkimo Operacijos"
 
@@ -147,7 +147,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Pardavimo Operaciją"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Pardavimo Operacijos"
 
@@ -175,8 +175,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Pardavimo Operaciją"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -184,8 +184,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -193,11 +193,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -222,22 +222,22 @@ msgstr "Sąskaita"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -689,11 +689,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -711,11 +711,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Suma"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -727,13 +727,13 @@ msgstr "Suma iki"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -797,9 +797,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -812,12 +812,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -833,16 +833,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Bal"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Balandis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgstr "Turtas"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Rug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Rugpjūtis"
 
@@ -1082,13 +1082,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balansas"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1174,12 +1174,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1259,15 +1259,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Įmonės kodas"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1318,9 +1318,9 @@ msgstr "PPS"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1468,11 +1468,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Sąskaitų planas"
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1618,8 +1618,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1666,12 +1666,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1682,7 +1706,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Patvirtinti!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1710,7 +1734,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1767,7 +1791,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1855,7 +1879,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1867,7 +1891,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1895,7 +1919,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1906,7 +1930,7 @@ msgstr "Kreditas"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1933,22 +1957,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Val."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1967,7 +1991,7 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valiūta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1983,8 +2007,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2047,7 +2071,7 @@ msgstr "Tokio kliento nėra!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2124,17 +2148,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2164,8 +2188,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2244,7 +2268,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2259,7 +2283,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2270,7 +2294,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Grd"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Gruodis"
 
@@ -2355,11 +2379,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2372,7 +2396,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Ištrinti"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2385,7 +2409,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Ištrinti"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2408,21 +2432,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Prystatimo Data"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2430,11 +2454,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2456,7 +2480,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2477,15 +2501,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2502,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2576,7 +2600,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2602,16 +2626,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2619,11 +2643,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2655,6 +2679,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2663,11 +2691,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2681,11 +2709,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Briežinys"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2694,9 +2722,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2726,7 +2754,7 @@ msgstr "E-paštas"
 msgid "E-mail address missing!"
 msgstr "E-pašto adreso nėra!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2887,7 +2915,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3036,7 +3064,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3073,7 +3101,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3081,7 +3109,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3093,7 +3121,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurs."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3202,7 +3230,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Vas"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Vasaris"
 
@@ -3218,7 +3246,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3362,7 +3390,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3385,11 +3413,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3420,7 +3448,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3428,7 +3456,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3440,7 +3468,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3448,7 +3476,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3535,7 +3563,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3577,18 +3605,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3741,7 +3769,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3762,7 +3790,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3816,9 +3844,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3847,7 +3875,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3862,10 +3890,10 @@ msgstr "Sąskaitos-faktūros datos nėra!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3958,7 +3986,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Sau"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Sausis"
 
@@ -3990,7 +4018,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Lie"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Liepa"
 
@@ -3998,7 +4026,7 @@ msgstr "Liepa"
 msgid "Jun"
 msgstr "Bir"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Birželis"
@@ -4031,7 +4059,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4259,7 +4287,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4348,11 +4376,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4373,7 +4401,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Kov"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Kovas"
 
@@ -4390,12 +4418,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Geg"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4490,7 +4518,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4524,15 +4552,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Vardas"
@@ -4592,7 +4619,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4644,7 +4671,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4676,7 +4703,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4747,9 +4774,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4789,7 +4816,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Lap"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Lapkritis"
 
@@ -4834,8 +4861,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numeris"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4852,7 +4879,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Pasenę"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4860,7 +4887,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Spa"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Spalis"
 
@@ -4935,7 +4962,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Užsakymas"
@@ -4967,7 +4994,7 @@ msgstr "Užsakymo datos nėra!"
 msgid "Order Entry"
 msgstr "Užsakymo įrašas"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5057,9 +5084,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5068,8 +5095,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5109,8 +5136,8 @@ msgstr "Įpakavimo sąrašo numerio nėra!"
 msgid "Packing list"
 msgstr "Įpakavimo sąrašas"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5138,7 +5165,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5167,7 +5194,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5235,7 +5262,7 @@ msgstr "Pirkimai"
 msgid "Payment"
 msgstr "Mokėjimas"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5297,11 +5324,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5467,7 +5494,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5475,7 +5502,7 @@ msgstr ""
 msgid "Post"
 msgstr "Patvirtinti"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5597,7 +5624,7 @@ msgstr ""
 msgid "Print"
 msgstr "Spausdinti"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5657,15 +5684,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5752,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5751,7 +5778,7 @@ msgid "Purchase Orders"
 msgstr "Pirkimo užsakymai"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5768,7 +5795,7 @@ msgstr "Pirkimo užsakymas"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5983,13 +6010,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6059,12 +6086,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6076,7 +6103,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6143,7 +6170,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Iki kada"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6320,8 +6347,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6499,7 +6526,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekranas"
@@ -6683,7 +6710,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6740,7 +6767,7 @@ msgstr "Rgs"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Rūgsėjis"
 
@@ -6760,7 +6787,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6845,8 +6872,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6893,8 +6920,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6964,8 +6991,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7011,14 +7038,14 @@ msgstr "Standartas"
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7042,7 +7069,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7094,8 +7121,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7206,8 +7233,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7215,8 +7242,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7537,8 +7564,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7617,7 +7644,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7663,14 +7690,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7692,7 +7719,7 @@ msgstr ""
 msgid "Total"
 msgstr "Iš viso"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7720,7 +7747,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7734,7 +7761,7 @@ msgstr "Operacijos datos nėra!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7843,9 +7870,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7903,7 +7930,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7944,11 +7971,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8077,7 +8104,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8091,7 +8118,7 @@ msgstr "Vartotojas"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8139,7 +8166,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Apmokestinama"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8148,8 +8175,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8223,7 +8250,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Tokio tiekėjo nėra!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8237,7 +8264,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8365,13 +8392,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8610,7 +8637,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/lv.po
+++ b/locale/po/lv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Latvian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "KP Neapmaksātie"
@@ -111,7 +111,7 @@ msgstr "KP Neapmaksātie"
 msgid "AP Transaction"
 msgstr "KP transakcija"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "KP transakcijas"
 
@@ -146,7 +146,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "DP Neapmaksātie"
@@ -157,7 +157,7 @@ msgstr "DP Neapmaksātie"
 msgid "AR Transaction"
 msgstr "DP transakcija"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "DP transakcijas"
 
@@ -174,8 +174,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "DP transakcija"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -183,8 +183,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -192,11 +192,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -221,22 +221,22 @@ msgstr "Konts"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -688,11 +688,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -710,11 +710,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Summa"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -726,13 +726,13 @@ msgstr "Nesamaksātā summa"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -796,9 +796,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -811,12 +811,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -832,16 +832,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Aprīlī"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr "Aktīvs"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Augustā"
 
@@ -1081,13 +1081,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Bilance"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1173,12 +1173,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1259,15 +1259,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1283,7 +1283,7 @@ msgstr "Komercdarbība"
 msgid "Business Number"
 msgstr "Reģistrācijas numurs"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1318,9 +1318,9 @@ msgstr "Pašizmaksa"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1468,11 +1468,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Kontu plāns"
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1618,8 +1618,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1666,12 +1666,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1682,7 +1706,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Apstiprināt!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1710,7 +1734,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1767,7 +1791,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1855,7 +1879,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1867,7 +1891,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1895,7 +1919,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1906,7 +1930,7 @@ msgstr "Kredīts"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1933,22 +1957,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Val."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1967,7 +1991,7 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valūta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1983,8 +2007,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2047,7 +2071,7 @@ msgstr "Nav tāda klienta!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2124,17 +2148,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2164,8 +2188,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2244,7 +2268,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2259,7 +2283,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2270,7 +2294,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Decembrī"
 
@@ -2355,11 +2379,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2372,7 +2396,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Dzēst"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2385,7 +2409,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Dzēst"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2408,21 +2432,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Piegādes datums"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2430,11 +2454,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2456,7 +2480,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2477,15 +2501,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2502,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2576,7 +2600,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2602,16 +2626,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2619,11 +2643,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2655,6 +2679,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2663,11 +2691,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2681,11 +2709,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Čeku izrakstīšana"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2694,9 +2722,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2726,7 +2754,7 @@ msgstr "E-pasts"
 msgid "E-mail address missing!"
 msgstr "Nepareiza E-pasta adrese!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2887,7 +2915,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2944,14 +2972,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2995,7 +3023,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3004,7 +3032,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3013,7 +3041,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3038,7 +3066,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Uzņēmuma nosaukums"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3075,7 +3103,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3083,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3095,7 +3123,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurss"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3204,7 +3232,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Februārī"
 
@@ -3220,7 +3248,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3364,7 +3392,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3387,11 +3415,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3422,7 +3450,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3430,7 +3458,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3442,7 +3470,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3450,7 +3478,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3537,7 +3565,7 @@ msgstr ""
 msgid "HR"
 msgstr "Personāldaļa"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3579,18 +3607,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3743,7 +3771,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3764,7 +3792,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3818,9 +3846,9 @@ msgstr "Krājums saglabāts"
 msgid "Inventory transferred!"
 msgstr "Krājums pārsūtīts"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3849,7 +3877,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3864,10 +3892,10 @@ msgstr "Nav norādīts rēķina datums!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3960,7 +3988,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Janvārī"
 
@@ -3992,7 +4020,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jūl"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Jūlijā"
 
@@ -4000,7 +4028,7 @@ msgstr "Jūlijā"
 msgid "Jun"
 msgstr "Jūn"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Jūnijā"
@@ -4033,7 +4061,7 @@ msgstr "Darbs/izmaksas"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4261,7 +4289,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4350,11 +4378,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4375,7 +4403,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Martā"
 
@@ -4392,12 +4420,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4492,7 +4520,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4526,15 +4554,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nosaukums"
@@ -4594,7 +4621,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4646,7 +4673,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4678,7 +4705,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4749,9 +4776,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4791,7 +4818,7 @@ msgstr "Nav nekā pārsūtīšanai"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembrī"
 
@@ -4836,8 +4863,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numurs"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4854,7 +4881,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Novecojis"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4862,7 +4889,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktobrī"
 
@@ -4937,7 +4964,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Orderis"
@@ -4969,7 +4996,7 @@ msgstr "Nav norādīts ordera datums!"
 msgid "Order Entry"
 msgstr "Ordera ieraksts"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5060,9 +5087,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5071,8 +5098,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5112,8 +5139,8 @@ msgstr "Nav norādīts iesaiņojumu numurs!"
 msgid "Packing list"
 msgstr "Iesaiņojumu saraksts"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5141,7 +5168,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5170,7 +5197,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5238,7 +5265,7 @@ msgstr "Kreditoru parādi"
 msgid "Payment"
 msgstr "Maksājums"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5300,11 +5327,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5471,7 +5498,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5479,7 +5506,7 @@ msgstr ""
 msgid "Post"
 msgstr "Iegrāmatot"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5601,7 +5628,7 @@ msgstr ""
 msgid "Print"
 msgstr "Drukāt"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5661,15 +5688,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5729,7 +5756,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5755,7 +5782,7 @@ msgid "Purchase Orders"
 msgstr "Pirkšanas orderi"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5772,7 +5799,7 @@ msgstr "Pirkšanas orderis"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5987,13 +6014,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6063,12 +6090,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6080,7 +6107,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,7 +6175,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Pieprasīja"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6326,8 +6353,8 @@ msgstr "Tāmi nevar izdzēst!"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6505,7 +6532,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekrāns"
@@ -6689,7 +6716,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6746,7 +6773,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Septembrī"
 
@@ -6766,7 +6793,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Seriālais Nr."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6851,8 +6878,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6899,8 +6926,8 @@ msgstr "Nav norādīts nosūtīšanas datums"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6971,8 +6998,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7018,14 +7045,14 @@ msgstr "Standarts"
 msgid "Standard Industrial Codes"
 msgstr "Standarta industrijas kodi"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7049,7 +7076,7 @@ msgid "Startdate"
 msgstr "Sākuma datums"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7101,8 +7128,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7213,8 +7240,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7222,8 +7249,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7544,8 +7571,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7624,7 +7651,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7670,14 +7697,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7699,7 +7726,7 @@ msgstr ""
 msgid "Total"
 msgstr "Pavisam Kopā"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7727,7 +7754,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7741,7 +7768,7 @@ msgstr "Nav norādīts transakcijas datums!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7850,9 +7877,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7910,7 +7937,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7951,11 +7978,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8084,7 +8111,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8098,7 +8125,7 @@ msgstr "Lietotājs"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8146,7 +8173,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Apliekams ar nodokli"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8155,8 +8182,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8230,7 +8257,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Nav tāda pārdevēja!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8244,7 +8271,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8373,13 +8400,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8618,7 +8645,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/ms_MY.po
+++ b/locale/po/ms_MY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Malay (Malaysia) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "Invois"
 
@@ -98,7 +98,7 @@ msgstr "Invois AP"
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "AP Memberangsangkan"
@@ -110,7 +110,7 @@ msgstr "AP Memberangsangkan"
 msgid "AP Transaction"
 msgstr "Transakai AP"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transaksi Ap"
 
@@ -145,7 +145,7 @@ msgstr "Invois AR"
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "AR Memberangsangkan"
@@ -156,7 +156,7 @@ msgstr "AR Memberangsangkan"
 msgid "AR Transaction"
 msgstr "Transaksi AR"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transaksi AR"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transaksi AR"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Amaun AR/AP/GL"
 
@@ -182,8 +182,8 @@ msgstr "Amaun AR/AP/GL"
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Akses Dinafikan"
 
@@ -191,11 +191,11 @@ msgstr "Akses Dinafikan"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Akaun"
 msgid "Account Description"
 msgstr "Deskripsi Akaun"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Label Akaun"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nama Akaun"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr "Basis Yang Diubah"
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Laporan Berumur"
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Jumlah"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Jumlah yang Dibajetkan"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Jumlah terhutang"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr "Jumlah Melebihi"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr "Jumlah Kurang Daripada"
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Diluluskan"
@@ -810,12 +810,12 @@ msgstr "Diluluskan"
 msgid "Approved"
 msgstr "Diluluskan"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Diluluskan Oleh"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Disahkan Di"
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr "Nilai Diperlukan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr "Dapatan Nilai Yang Tinggal"
 
@@ -880,7 +880,7 @@ msgstr "Aset"
 msgid "Asset Account"
 msgstr "Akaun Aset"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Kelas Aset"
@@ -905,7 +905,7 @@ msgstr "Laporan Aset Susut Nilai"
 msgid "Asset Disposal Report"
 msgstr "Laporan Aset Pembuangan"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ogos"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Ogos"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Baki"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr "Asas"
 msgid "Batch"
 msgstr "Kumpulan"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr "Kelas Kumpulan"
 
@@ -1160,7 +1160,7 @@ msgstr "Tarikh Kumpulan"
 msgid "Batch Description"
 msgstr "Deskripsi Kumpulan"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr "ID Kumpulan"
 
@@ -1172,12 +1172,12 @@ msgstr "Kumpulan ID hilang"
 msgid "Batch Name"
 msgstr "Nama Batch"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Nombor Kumpulan"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr "Carian Kumpulan"
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Nombor Bajet"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr "Keputusan Carian Bajet"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr "Laporan Bajet Varian"
 
@@ -1282,7 +1282,7 @@ msgstr "Perniagaan"
 msgid "Business Number"
 msgstr "Nombor Bisnes"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr "Jenis Perniagaan"
@@ -1317,9 +1317,9 @@ msgstr "COGS"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Tidak boleh membatalkan invois yang telah dibatalkan"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1469,11 +1469,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr "Carta ID"
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Carta Akaun"
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1620,8 +1620,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1668,12 +1668,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1684,7 +1708,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Sah!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1712,7 +1736,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr "Carian Hubungan"
@@ -1769,7 +1793,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1857,7 +1881,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1869,7 +1893,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr "Bina pankalan data?"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1897,7 +1921,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1908,7 +1932,7 @@ msgstr "Kredit"
 msgid "Credit Account"
 msgstr "Akaun Kredit"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "No Akaun Kredit"
 
@@ -1935,22 +1959,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr "Nota kredit"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr "Kredit"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1969,7 +1993,7 @@ msgstr ""
 msgid "Currency"
 msgstr "Mata Wang"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1985,8 +2009,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2049,7 +2073,7 @@ msgstr "Pelangan tiada dalam fail!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2126,17 +2150,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2166,8 +2190,8 @@ msgstr ""
 msgid "Date From"
 msgstr "Dari Tarikh"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2246,7 +2270,7 @@ msgstr "Hari"
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2261,7 +2285,7 @@ msgstr "Invois debit"
 msgid "Debit Note"
 msgstr "Nota debit"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2272,7 +2296,7 @@ msgstr "Debit"
 msgid "Dec"
 msgstr "Dis"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Disember"
 
@@ -2357,11 +2381,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2374,7 +2398,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Padam"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr "Padam Kumpulan"
 
@@ -2387,7 +2411,7 @@ msgstr "Padam Jadual"
 msgid "Delete User"
 msgstr "Padam"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr "Padam Baucer"
 
@@ -2410,21 +2434,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Tarikh Penghantaran"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2432,11 +2456,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2458,7 +2482,7 @@ msgstr "Penyusutan"
 msgid "Depreciate Through"
 msgstr "Melalui Penyusutan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Susut Nilai"
@@ -2479,15 +2503,15 @@ msgstr "Kaedah Susut Nilai"
 msgid "Depreciation Starts"
 msgstr "Permulaan Susut Nilai"
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2504,13 +2528,13 @@ msgstr "Permulaan Susut Nilai"
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2578,7 +2602,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr "Disk"
 
@@ -2604,16 +2628,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Pembuangan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr "Tarikh Pembuangan"
 
@@ -2621,11 +2645,11 @@ msgstr "Tarikh Pembuangan"
 msgid "Disposal Method"
 msgstr "Cara Pembuangan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr "Kesalahan bahagian 0"
 
@@ -2657,6 +2681,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr "Dr."
@@ -2665,11 +2693,11 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Draf yang tercatat"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr "Carian Draf"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr "Jenis Draf"
 
@@ -2683,11 +2711,11 @@ msgstr "Draf"
 msgid "Drawing"
 msgstr "Lukisan"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr "Gugurkan"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2696,9 +2724,9 @@ msgstr "Gugurkan"
 msgid "Due"
 msgstr "Tarikh Akhir"
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2728,7 +2756,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "alamat emel hilang"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2889,7 +2917,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2946,14 +2974,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2997,7 +3025,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr "Dimasukkan Oleh"
@@ -3006,7 +3034,7 @@ msgstr "Dimasukkan Oleh"
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr "Di Masukkan Di"
 
@@ -3015,7 +3043,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr "Entiti"
 
@@ -3040,7 +3068,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Kod Entiti"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr "Masukkan ID"
 
@@ -3077,7 +3105,7 @@ msgstr "Kesalahan membina backup data"
 msgid "Error creating batch.  Please try again."
 msgstr "Kesalahan mencipta kumpulan. sila cuba lagi. "
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr "Kesalahan daripada fungsi"
 
@@ -3085,7 +3113,7 @@ msgstr "Kesalahan daripada fungsi"
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Ralat: Tidak boleh termasuk ringkasan akaun selain menu dropdown"
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3097,7 +3125,7 @@ msgstr "Setiap"
 msgid "Exch"
 msgstr "Tukar"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3206,7 +3234,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Februari"
 
@@ -3222,7 +3250,7 @@ msgstr ""
 msgid "File"
 msgstr "Fail"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr "Fail Masukkan"
 
@@ -3366,7 +3394,7 @@ msgstr "Daripada Jumlah"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr "Tarikh Mula"
@@ -3389,11 +3417,11 @@ msgstr "Dari tarikh"
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Permintaan penuh"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3424,7 +3452,7 @@ msgstr "Nombor rujukan GL"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr "Dapat (Kerugian)"
 
@@ -3432,7 +3460,7 @@ msgstr "Dapat (Kerugian)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Dapat (Kerugian)"
@@ -3445,7 +3473,7 @@ msgstr ""
 msgid "General Journal"
 msgstr "Jurnal umum"
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr "Laporan Lajuran Umum"
 
@@ -3453,7 +3481,7 @@ msgstr "Laporan Lajuran Umum"
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Hasilkan"
@@ -3540,7 +3568,7 @@ msgstr ""
 msgid "HR"
 msgstr "HR"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3582,18 +3610,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3746,7 +3774,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr "Kesalahan Dalaman Pangkalan Data"
 
@@ -3767,7 +3795,7 @@ msgstr "Laporan Asas Tidak Sah"
 msgid "Invalid backup request"
 msgstr "Permintaan backup tidak sah"
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr "Tarikh/Masa tidak sah dimasukkan"
 
@@ -3821,9 +3849,9 @@ msgstr "Inventori disimpan"
 msgid "Inventory transferred!"
 msgstr "Inventori di hantar"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3852,7 +3880,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3867,10 +3895,10 @@ msgstr "Tarikh Invois hilang!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3963,7 +3991,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Januari"
 
@@ -3995,7 +4023,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julai"
 
@@ -4003,7 +4031,7 @@ msgstr "Julai"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Jun"
@@ -4036,7 +4064,7 @@ msgstr "Tenaga Kerja/Overhead"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4264,7 +4292,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4353,11 +4381,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Pengguna diurus"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4378,7 +4406,7 @@ msgstr "Manual"
 msgid "Mar"
 msgstr "Mac"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Mac"
 
@@ -4395,12 +4423,12 @@ msgstr "Max Invois Setiap Cek Resit "
 msgid "Max per dropdown"
 msgstr "Maksima setiap penurunan"
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mei"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4495,7 +4523,7 @@ msgstr "Bulan"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4529,15 +4557,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nama"
@@ -4597,7 +4624,7 @@ msgid "Next Number"
 msgstr "Nombor Seterusnya"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr "Seterusnya Dalam Urutan"
 
@@ -4649,7 +4676,7 @@ msgstr "Tiada Nombor Pekerja"
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4683,7 +4710,7 @@ msgstr ""
 msgid "No report specified"
 msgstr "Tiada laporan dinyatakan"
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4754,9 +4781,9 @@ msgstr "Kelas Nota"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4796,7 +4823,7 @@ msgstr "TIada apa-apa untuk dihantar"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4841,8 +4868,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Nombor"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4859,7 +4886,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Lama"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr "Dilupuskan Oleh"
 
@@ -4867,7 +4894,7 @@ msgstr "Dilupuskan Oleh"
 msgid "Oct"
 msgstr "Okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktober"
 
@@ -4943,7 +4970,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Pesanan"
@@ -4975,7 +5002,7 @@ msgstr "Tarikh Pesanan Hilang!"
 msgid "Order Entry"
 msgstr "Entri pesanan"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5066,9 +5093,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5077,8 +5104,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5118,8 +5145,8 @@ msgstr ""
 msgid "Packing list"
 msgstr "Senarai Bungkusan"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5147,7 +5174,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5176,7 +5203,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5271,7 @@ msgstr ""
 msgid "Payment"
 msgstr "Pembayaran"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr "Jumlah Pembayaran"
 
@@ -5307,11 +5334,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Peratus"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr "Peratusan Pembuangan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr "Peratusan Yang Tinggal"
 
@@ -5478,7 +5505,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5486,7 +5513,7 @@ msgstr ""
 msgid "Post"
 msgstr "Simpan"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr "Simpan Kumpulan"
 
@@ -5608,7 +5635,7 @@ msgstr ""
 msgid "Print"
 msgstr "Cetak"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5668,15 +5695,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr "Teruskan"
 
@@ -5737,7 +5764,7 @@ msgstr "Tarikh Pembelian"
 msgid "Purchase Date:"
 msgstr "Tarikh Pembelian"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr "Rekod Pembelian"
@@ -5763,7 +5790,7 @@ msgid "Purchase Orders"
 msgstr "Beli Pesanan"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "Nilai Pembtanelian"
 
@@ -5780,7 +5807,7 @@ msgstr "Beli Pesanan"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5995,13 +6022,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Perulangan Input Transaksi"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6071,12 +6098,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "Hasil Laporan"
 
@@ -6088,7 +6115,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6156,7 +6183,7 @@ msgstr "Tarikh yang Diperlukan"
 msgid "Required by"
 msgstr "Diperlukan oleh"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6334,8 +6361,8 @@ msgstr "Nombor Sebut Harga Jualan"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6513,7 +6540,7 @@ msgstr "Jadual"
 msgid "Scheduled"
 msgstr "Sudah Dijadualkan"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skrin"
@@ -6697,7 +6724,7 @@ msgstr "Terpilih"
 msgid "Sell"
 msgstr "Jual"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6754,7 +6781,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr "Tugas Berasingan"
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "September"
 
@@ -6774,7 +6801,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "No. Siri"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6860,8 +6887,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6908,8 +6935,8 @@ msgstr "Tarikh penghantaran hilang!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6980,8 +7007,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7027,14 +7054,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr "Standart kod industri"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7058,7 +7085,7 @@ msgid "Startdate"
 msgstr "Tarikh mula"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr "Baki Permulaan"
 
@@ -7110,8 +7137,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7223,8 +7250,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr "Tanda"
 
@@ -7232,8 +7259,8 @@ msgstr "Tanda"
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7554,8 +7581,8 @@ msgstr ""
 msgid "Thu"
 msgstr "Khamis"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7634,7 +7661,7 @@ msgstr "Kepada Jumlah"
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr "Kepada tarikh"
@@ -7680,14 +7707,14 @@ msgstr ""
 msgid "Top-level"
 msgstr "Tahap Tertinggi"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7709,7 +7736,7 @@ msgstr "Tahap Tertinggi"
 msgid "Total"
 msgstr "Jumlah"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7737,7 +7764,7 @@ msgstr "Transaksi"
 msgid "Transaction Approval"
 msgstr "Transaksi Diterima"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7751,7 +7778,7 @@ msgstr "Tarikh Transaksi Hilang!"
 msgid "Transaction Dates"
 msgstr "Tarikh Penterjemahan"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7860,9 +7887,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7920,7 +7947,7 @@ msgstr "Nombor Unik Pembekal"
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7961,11 +7988,11 @@ msgstr "Pangkalan data tidak dikenali dijumpai"
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8094,7 +8121,7 @@ msgstr "Guna lebihan pembayaran/prabayaran"
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Digunakan"
@@ -8108,7 +8135,7 @@ msgstr "Pengguna"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr "Pengguna telah wujud. impot?"
 
@@ -8156,7 +8183,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Varian"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr "Varian"
@@ -8165,8 +8192,8 @@ msgstr "Varian"
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8240,7 +8267,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Pembekal tiada dalam fail!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8254,7 +8281,7 @@ msgstr ""
 msgid "Void"
 msgstr "Batal"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr "Senarai Baucer"
 
@@ -8383,13 +8410,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8628,7 +8655,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/nb.po
+++ b/locale/po/nb.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "# Fakturaer"
 
@@ -106,7 +106,7 @@ msgstr "Inngående faktura"
 msgid "AP Invoices"
 msgstr "Inngående fakturaer"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Ubetalte Inngående fakturaer"
@@ -118,7 +118,7 @@ msgstr "Ubetalte Inngående fakturaer"
 msgid "AP Transaction"
 msgstr "Leverandør Postering"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Leverandør Posteringer"
 
@@ -153,7 +153,7 @@ msgstr "Utgående Faktura"
 msgid "AR Invoices"
 msgstr "Utgående Fakturaer"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Utestående fordringer Kunder"
@@ -164,7 +164,7 @@ msgstr "Utestående fordringer Kunder"
 msgid "AR Transaction"
 msgstr "Kunde Postering"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Kunde Postering"
 
@@ -181,8 +181,8 @@ msgstr "Kunde konto tilgjengelig når kundene er registret."
 msgid "AR transaction"
 msgstr "Kunde Postering"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Kunde/Leverandør/Hovedbok Beløp"
 
@@ -190,8 +190,8 @@ msgstr "Kunde/Leverandør/Hovedbok Beløp"
 msgid "Abandonment"
 msgstr "Skrinlagt"
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Nektet Adgang"
 
@@ -199,11 +199,11 @@ msgstr "Nektet Adgang"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -228,22 +228,22 @@ msgstr "Konto"
 msgid "Account Description"
 msgstr "Kontobeskrivelse"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Kontobetegnelse"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Kontonavn"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -324,7 +324,7 @@ msgstr "Kostnad"
 msgid "Accrual Basis:"
 msgstr "Kostnadsbase"
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr "Akkumulert Nedskrivning"
 
@@ -621,7 +621,7 @@ msgstr "Just"
 msgid "Adjusted"
 msgstr "justert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr "Juster grunnlag"
 
@@ -641,7 +641,7 @@ msgstr "Justeringsdetaljer"
 msgid "Aged"
 msgstr "Gamle"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Gammel Rapport"
 
@@ -695,11 +695,11 @@ msgstr "Opptatt"
 msgid "Allow Input"
 msgstr "Tillat Innlegg"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -717,11 +717,11 @@ msgstr "Tillat Innlegg"
 msgid "Amount"
 msgstr "Beløp"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Beløp Budsjettert"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -733,13 +733,13 @@ msgstr "Forfalt beløp"
 msgid "Amount From"
 msgstr "Beløp skjema"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr "Beløp større enn"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr "Beløp mindre enn"
 
@@ -809,9 +809,9 @@ msgid "Approval Status"
 msgstr "Godkjennings  status"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Godkjenne"
@@ -824,12 +824,12 @@ msgstr "Godkjenne"
 msgid "Approved"
 msgstr "Godkjent"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Godkjent av"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Godkjent ved"
 
@@ -845,16 +845,16 @@ msgstr ""
 msgid "Apr"
 msgstr "apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "april"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr "Ervervet verdi"
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr "Ervervet verdi gjennstår"
 
@@ -894,7 +894,7 @@ msgstr "Eiendeler"
 msgid "Asset Account"
 msgstr "Eiendel kontoer"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Eiendel klasser"
@@ -919,7 +919,7 @@ msgstr "Eiendel nedskrivnings Rapport"
 msgid "Asset Disposal Report"
 msgstr "Eiendel disposisjons Rapport"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr "Eiendel oversikt"
 
@@ -1024,7 +1024,7 @@ msgstr "Attn: [_1]"
 msgid "Aug"
 msgstr "aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "august"
 
@@ -1094,13 +1094,13 @@ msgstr "Sikkerhetskopi DB"
 msgid "Backup Roles"
 msgstr "Sikkerhetskopi roller"
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balanse"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1158,7 +1158,7 @@ msgstr "Basis"
 msgid "Batch"
 msgstr "Gruppe"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr "Gruppe Klasse"
 
@@ -1174,7 +1174,7 @@ msgstr "Batch dato"
 msgid "Batch Description"
 msgstr "Gruppe beskrivelse"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr "Gruppe ID"
 
@@ -1186,12 +1186,12 @@ msgstr "Gruppe ID mangler"
 msgid "Batch Name"
 msgstr "Gruppe navn"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Batch nummer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr "Gruppe Søk"
 
@@ -1272,15 +1272,15 @@ msgstr "Bokføring er lukket fram til"
 msgid "Budget"
 msgstr "Beudsjett"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Budsjettnummer"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr "Budsjett søke resultat"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr "Budsjett Avviksrapport"
 
@@ -1296,7 +1296,7 @@ msgstr "Firma"
 msgid "Business Number"
 msgstr "Firmanummer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr "Firma type"
@@ -1331,9 +1331,9 @@ msgstr "Varekostnad"
 msgid "COGS Lots Report"
 msgstr "Varekostnad Rapport"
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1349,7 +1349,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Kan ikke annullere en annullert Faktura"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1481,11 +1481,11 @@ msgstr "Skift passord"
 msgid "Chargeable"
 msgstr "Kan forandres"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr "Chart ID"
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Kontoplan"
 
@@ -1545,7 +1545,7 @@ msgstr "Oppgjørs datoen er [*,_1,dag] inn i fremtiden etter postering."
 msgid "Clear date over [*,_1,day]"
 msgstr "Oppgjørs dato over  [*,_1,day]"
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1632,8 +1632,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1680,7 +1680,7 @@ msgstr "Sammenlign datoer"
 msgid "Comparison Periods"
 msgstr "Sammenlign perioder"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
@@ -1688,6 +1688,30 @@ msgstr ""
 #, fuzzy
 msgid "Compose e-mail"
 msgstr "Til E-mail"
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:10
 msgid "Confirm Operation"
@@ -1697,7 +1721,7 @@ msgstr "Bekreft handling"
 msgid "Confirm!"
 msgstr "Bekreft!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Konflikt med eksisterende data, kanskje ar det lagt inn før?"
 
@@ -1725,7 +1749,7 @@ msgstr "Kontakt Info:"
 msgid "Contact Information"
 msgstr "Kontakt Informasjon"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr "Kontakt søk"
@@ -1785,7 +1809,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1873,7 +1897,7 @@ msgstr "Land"
 msgid "Create"
 msgstr "Opprett"
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1885,7 +1909,7 @@ msgstr "Opprett Gruppe"
 msgid "Create Database?"
 msgstr "Opprett Database"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1913,7 +1937,7 @@ msgstr "Laget av"
 msgid "Created On"
 msgstr "Laget på"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1924,7 +1948,7 @@ msgstr "Kredit"
 msgid "Credit Account"
 msgstr "Kredittkonto"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Kredittkontonummer"
 
@@ -1951,22 +1975,22 @@ msgstr "Kredittgrense:"
 msgid "Credit Note"
 msgstr "Kreditnota"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr "Kreditt"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Val"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1985,7 +2009,7 @@ msgstr "Val"
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -2001,8 +2025,8 @@ msgstr "Nåværende fortjeneste"
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2065,7 +2089,7 @@ msgstr "Kunde mangler i databasen!"
 msgid "Customer/Vendor Accounts"
 msgstr "Kunde/Leverandør Kontoer"
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr "D M"
 
@@ -2142,17 +2166,17 @@ msgstr "Databasen eksisterer."
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2182,8 +2206,8 @@ msgstr "Datoformat"
 msgid "Date From"
 msgstr "Datoskjema"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2262,7 +2286,7 @@ msgstr "Dag(er)"
 msgid "Days"
 msgstr "Dager"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2277,7 +2301,7 @@ msgstr "Faktura"
 msgid "Debit Note"
 msgstr "Regning"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2288,7 +2312,7 @@ msgstr "Tilgodehavende"
 msgid "Dec"
 msgstr "des"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "desember"
 
@@ -2373,11 +2397,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2390,7 +2414,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Slett"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr "Slett Gruppe"
 
@@ -2403,7 +2427,7 @@ msgstr "Slette Fordelinger"
 msgid "Delete User"
 msgstr "Opprett bruker"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr "Slette Kuponger"
 
@@ -2426,21 +2450,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Levering"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leveringsdato"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr "Avdeling Basis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr "Avdeling Metode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr "Avdeling Start"
 
@@ -2448,11 +2472,11 @@ msgstr "Avdeling Start"
 msgid "Dep. Through"
 msgstr "Nedskrevet gjennom"
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr "Avdeling YTD"
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr "Avdeling denne kjøring"
 
@@ -2474,7 +2498,7 @@ msgstr "Avskrive"
 msgid "Depreciate Through"
 msgstr "Avskrive igjennom"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Avskrivning"
@@ -2495,15 +2519,15 @@ msgstr "Avskrivnings Metode"
 msgid "Depreciation Starts"
 msgstr "Avskrivnings Start"
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2520,13 +2544,13 @@ msgstr "Avskrivnings Start"
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2594,7 +2618,7 @@ msgstr "Detaljer"
 msgid "Disable Back Button"
 msgstr "Deaktiver Tilbake Knapp"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr "Rab"
 
@@ -2620,16 +2644,16 @@ msgstr "Rabatt (%)"
 msgid "Discount:"
 msgstr "Rabatt:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr "Vis Aktivert Verdi"
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Deponert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr "Deponert Dato"
 
@@ -2637,11 +2661,11 @@ msgstr "Deponert Dato"
 msgid "Disposal Method"
 msgstr "Deponert Metode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Deponert Rapport [_1] på dato [_2]"
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr "Feil, dividert på 0"
 
@@ -2673,6 +2697,10 @@ msgstr "Doble kundenummer"
 msgid "Double vendornumbers"
 msgstr "Doble leverandørnummer"
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr "Dr."
@@ -2681,11 +2709,11 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Kladd Sendt"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr "Søk kladd"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr "Kladd type"
 
@@ -2699,11 +2727,11 @@ msgstr "Kladd"
 msgid "Drawing"
 msgstr "Tegning"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr "Dropdowns"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2712,9 +2740,9 @@ msgstr "Dropdowns"
 msgid "Due"
 msgstr "Forfall"
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2744,7 +2772,7 @@ msgstr "Epost"
 msgid "E-mail address missing!"
 msgstr "Epost-adresse mangler!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2905,7 +2933,7 @@ msgstr "Eleve"
 msgid "Eleven-o"
 msgstr "Eleve-o"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr "E-mail"
 
@@ -2964,14 +2992,14 @@ msgstr "Tomme kundenummer"
 msgid "Empty vendornumbers"
 msgstr "Tomme leverandørnummer"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3015,7 +3043,7 @@ msgstr "Legg inn Bruker"
 msgid "Enter employee numbers where they are missing"
 msgstr "Legg inn ansattnummer hvor de mangler"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr "Lagt inn av"
@@ -3024,7 +3052,7 @@ msgstr "Lagt inn av"
 msgid "Entered For"
 msgstr "Lagt inn For"
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr "Lagt inn ved"
 
@@ -3033,7 +3061,7 @@ msgid "Entered at: [_1]"
 msgstr "Lagt inn ved: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr "Eksisterende"
 
@@ -3058,7 +3086,7 @@ msgstr "Eksisterende Kredittkonto"
 msgid "Entity Name"
 msgstr "Eksisterende Kode"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr "Eksisterende ID"
 
@@ -3095,7 +3123,7 @@ msgstr "Feil ved kreering av backup fil"
 msgid "Error creating batch.  Please try again."
 msgstr "Feil ved kreering av Gruppe fil. Prøv igjen."
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr "Feil fra Funksjon "
 
@@ -3103,7 +3131,7 @@ msgstr "Feil fra Funksjon "
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Feil: Kan ikke inkludere sumkonto i andre nedtrekksmenyer"
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr "Est. Levetid"
 
@@ -3115,7 +3143,7 @@ msgstr "Hver"
 msgid "Exch"
 msgstr "Vxl"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3224,7 +3252,7 @@ msgstr "Faks: [_1]"
 msgid "Feb"
 msgstr "feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "februar"
 
@@ -3240,7 +3268,7 @@ msgstr "Femti"
 msgid "File"
 msgstr "Fil"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr "Importert Fil"
 
@@ -3384,7 +3412,7 @@ msgstr "Fra Beløp"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr "Fra Dato"
@@ -3407,11 +3435,11 @@ msgstr "Fra Dato"
 msgid "Full"
 msgstr "Full"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Fulle Rettigheter"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3442,7 +3470,7 @@ msgstr "GL Referansenummer"
 msgid "Gain"
 msgstr "Overskudd"
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr "Overskudd (Tap)"
 
@@ -3450,7 +3478,7 @@ msgstr "Overskudd (Tap)"
 msgid "Gain Account"
 msgstr "Oversuddskonto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Overskudd (Tap)"
@@ -3463,7 +3491,7 @@ msgstr "Kunder uten opphold"
 msgid "General Journal"
 msgstr "Hovedbok "
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr "Hovedboks Rapport"
 
@@ -3471,7 +3499,7 @@ msgstr "Hovedboks Rapport"
 msgid "General Ledger Reports"
 msgstr "Hovedboks Rapporter"
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Generer"
@@ -3558,7 +3586,7 @@ msgstr "G-talk"
 msgid "HR"
 msgstr "Personal"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3600,18 +3628,18 @@ msgid "Hundred"
 msgstr "Hundre"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3765,7 +3793,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr "Intern Database Error"
 
@@ -3786,7 +3814,7 @@ msgstr "Invalid Rapport Grunnlag"
 msgid "Invalid backup request"
 msgstr "Invalid backup forespørsel"
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr "Invalid Dato/Tid lagt inn"
 
@@ -3844,9 +3872,9 @@ msgstr "Varebeholdning lagret"
 msgid "Inventory transferred!"
 msgstr "Varebeholdning overført"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3875,7 +3903,7 @@ msgstr "Faktura Opprettet"
 msgid "Invoice Created Date missing!"
 msgstr "Faktura Opprettet Dato mangler!"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3890,10 +3918,10 @@ msgstr "Fakturadato mangler!"
 msgid "Invoice No."
 msgstr "Fakturanummer."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3989,7 +4017,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "januar"
 
@@ -4021,7 +4049,7 @@ msgstr "Protokoll Linjer"
 msgid "Jul"
 msgstr "jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "juli"
 
@@ -4029,7 +4057,7 @@ msgstr "juli"
 msgid "Jun"
 msgstr "jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "juni"
@@ -4062,7 +4090,7 @@ msgstr "Arbeid/kostnader"
 msgid "Labor/Service Code"
 msgstr "Arbeide/Tjenester"
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4297,7 +4325,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4388,11 +4416,11 @@ msgstr ""
 "Forsikre deg om at alle navn kun består av alfanumeriske tegn (og "
 "understreker) og er minst ett tegn langt"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Behandle Brukere"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4413,7 +4441,7 @@ msgstr "Bruksanvisning"
 msgid "Mar"
 msgstr "mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "mars"
 
@@ -4430,12 +4458,12 @@ msgstr "Maks antall Fakturaer pr. Sjekktalong"
 msgid "Max per dropdown"
 msgstr "Maks pr. nedtrekk"
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4531,7 +4559,7 @@ msgstr "Måned(er)"
 msgid "Months"
 msgstr "Måneder"
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr "Mere informasjon finnes i error loggene"
 
@@ -4566,15 +4594,14 @@ msgstr "Må ha kontantkonto i parti"
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Navn"
@@ -4634,7 +4661,7 @@ msgid "Next Number"
 msgstr "Neste nr"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr "Neste i kø"
 
@@ -4686,7 +4713,7 @@ msgstr "Ingen NULL Annsattnummer"
 msgid "No Old Password"
 msgstr "Ikke noe gammelt passord"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr "Ingen forandringer"
 
@@ -4718,7 +4745,7 @@ msgstr "Ingen referanse nøkkel satt og ingen overskrivning gitt"
 msgid "No report specified"
 msgstr "Ingen Rapport Spesifisert"
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr "Ingen MVA fra valgte"
 
@@ -4791,9 +4818,9 @@ msgstr ""
 "Legg merke til at prosessen som startes ved å trykke på knappen nedenfor, kan "
 "være"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4833,7 +4860,7 @@ msgstr "Ingenting å overføre!"
 msgid "Nov"
 msgstr "nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "november"
 
@@ -4878,8 +4905,8 @@ msgstr "Nummer mangler i rad [_1]"
 msgid "Number:"
 msgstr "Nummer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr "ODS"
 
@@ -4896,7 +4923,7 @@ msgstr "OVERBETALT / FORHÅNDSBETALT / BETALT"
 msgid "Obsolete"
 msgstr "Foreldet"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr "Foreldet ved"
 
@@ -4904,7 +4931,7 @@ msgstr "Foreldet ved"
 msgid "Oct"
 msgstr "okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "oktober"
 
@@ -4980,7 +5007,7 @@ msgid "Or Add To Batch"
 msgstr "Eller legg til parti"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Ordre"
@@ -5012,7 +5039,7 @@ msgstr "Ordredato mangler!"
 msgid "Order Entry"
 msgstr "Ordrer"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5103,9 +5130,9 @@ msgstr "Overbetalingkonto"
 msgid "Overpayments"
 msgstr "Overbetaling"
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5114,8 +5141,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "PO #"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5155,8 +5182,8 @@ msgstr "Nummer for følgeseddel mangler!"
 msgid "Packing list"
 msgstr "Følgeseddel"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5184,7 +5211,7 @@ msgstr "Varebeskrivelse"
 msgid "Part Group"
 msgstr "Varegruppe"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5215,7 +5242,7 @@ msgstr "Detaljer"
 msgid "Partial"
 msgstr "Begrensett"
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Begrenset Salgs Rapport [_1] på dato [_2]"
 
@@ -5283,7 +5310,7 @@ msgstr "Utbetalinger"
 msgid "Payment"
 msgstr "Betaling"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr "Betalings Beløp"
 
@@ -5345,11 +5372,11 @@ msgstr "Betalinger koblet ti annullerte fakturaer trenge å bli reversert. "
 msgid "Percent"
 msgstr "Prosent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr "Prosent Fordelt"
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr "Prosent gjenværende"
 
@@ -5527,7 +5554,7 @@ msgstr "Bruk v. 1.2 UI for å legge til SRU kontoer."
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr "Bruk v. 1.2 UI for å legge til SRU kontoer."
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5535,7 +5562,7 @@ msgstr "Bruk v. 1.2 UI for å legge til SRU kontoer."
 msgid "Post"
 msgstr "Bokfør"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr "Bokfør Batch"
 
@@ -5661,7 +5688,7 @@ msgstr "Sentralbord tlf"
 msgid "Print"
 msgstr "Skriv ut"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr "Skriv Batch"
 
@@ -5721,15 +5748,15 @@ msgstr "Skriver Postering [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Skrive Arbeidsordre [_1]"
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr "Prioritert Dep."
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr "Prioritert gjennom"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr "Fortsettelser"
 
@@ -5790,7 +5817,7 @@ msgstr "Innkjøpsdato"
 msgid "Purchase Date:"
 msgstr "Innkjøpsdato:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr "Innkjøpshistorikk"
@@ -5816,7 +5843,7 @@ msgid "Purchase Orders"
 msgstr "Innkjøpsordrer"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "Innkjøpsverdi"
 
@@ -5833,7 +5860,7 @@ msgstr "Innkjøpsordre"
 msgid "Purchased"
 msgstr "Kjøpt"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -6048,13 +6075,13 @@ msgstr "Gjentagende Posteringer for [_1]"
 msgid "Recurring Transactions"
 msgstr "Gjentagende Posteringer"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6124,12 +6151,12 @@ msgstr "Rapport Godkjent"
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr "Rapportnavn"
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "Rapportresultat"
 
@@ -6141,7 +6168,7 @@ msgstr "Innsendt Rapport"
 msgid "Report Type"
 msgstr "Rapport Type"
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr "Rapport [_1] på dato [_2]"
 
@@ -6209,7 +6236,7 @@ msgstr "Nødvendig Dato"
 msgid "Required by"
 msgstr "Leveringsdato"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr "Obligatorisk inntasting ikke utført"
 
@@ -6387,8 +6414,8 @@ msgstr "Hilsen"
 msgid "Sales:"
 msgstr "Salg:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6566,7 +6593,7 @@ msgstr "Planlagt"
 msgid "Scheduled"
 msgstr "Planlagt"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skjerm"
@@ -6750,7 +6777,7 @@ msgstr "Valgt"
 msgid "Sell"
 msgstr "Selg"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6807,7 +6834,7 @@ msgstr "sep"
 msgid "Separate Duties"
 msgstr "Saperate Plikter"
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "september"
 
@@ -6827,7 +6854,7 @@ msgstr "Serie #"
 msgid "Serial No."
 msgstr "Serienummer"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6913,8 +6940,8 @@ msgstr "Send til"
 msgid "Ship To:"
 msgstr "Send til:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6961,8 +6988,8 @@ msgstr "Mangler leveringsdato"
 msgid "Shipping Label"
 msgstr "Sendings Etikett"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -7034,8 +7061,8 @@ msgstr "Solgt"
 msgid "Some"
 msgstr "Noen"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7081,14 +7108,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Standard industrikoder (SIC)"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7113,7 +7140,7 @@ msgid "Startdate"
 msgstr "Startdato"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr "Start Balanse"
 
@@ -7165,8 +7192,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7278,8 +7305,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr "Merkelappapp"
 
@@ -7287,8 +7314,8 @@ msgstr "Merkelappapp"
 msgid "Tag:"
 msgstr "Merkelappapp"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7621,8 +7648,8 @@ msgstr "Gjennom Dato"
 msgid "Thu"
 msgstr "Tors"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7701,7 +7728,7 @@ msgstr "Til Beløp"
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr "Til Dato"
@@ -7747,14 +7774,14 @@ msgstr "Veksle alle fjernings avmerkingsboksene"
 msgid "Top-level"
 msgstr "Topplan"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7776,7 +7803,7 @@ msgstr "Topplan"
 msgid "Total"
 msgstr "I alt"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr "Total akkumulert  inskudd"
 
@@ -7804,7 +7831,7 @@ msgstr "Postering"
 msgid "Transaction Approval"
 msgstr "Godkjenne Postering"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7818,7 +7845,7 @@ msgstr "Posterings dato mangler!"
 msgid "Transaction Dates"
 msgstr "Posterings datoer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7927,9 +7954,9 @@ msgid "Two"
 msgstr "To"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7990,7 +8017,7 @@ msgstr "Unike Leverandørnummer"
 msgid "Unique nonobsolete partnumbers"
 msgstr "Unike ikke foreldete varenummer"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -8033,11 +8060,11 @@ msgstr "Ukjent database funnet"
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr "Låsopp"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr "Lås opp gruppe"
 
@@ -8166,7 +8193,7 @@ msgstr "Bruk overbetaling/forhånsbetaling"
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "Brukt"
@@ -8180,7 +8207,7 @@ msgstr "Bruker"
 msgid "User Name"
 msgstr "Bruker Navn"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr "Bruker eksisterer allerede. Importer?"
 
@@ -8228,7 +8255,7 @@ msgstr "verdivurdering"
 msgid "Variable"
 msgstr "Forandring"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr "Forandring"
@@ -8237,8 +8264,8 @@ msgstr "Forandring"
 msgid "Variance:"
 msgstr "Forandring:"
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8312,7 +8339,7 @@ msgstr "Leverandør mangler i en bedrift!"
 msgid "Vendor not on file!"
 msgstr "Leverandør mangler i database!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8326,7 +8353,7 @@ msgstr "Bekrefte"
 msgid "Void"
 msgstr "Annullert"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr "Kupong Liste"
 
@@ -8460,13 +8487,13 @@ msgstr "Vil du migrere databasen"
 msgid "Would you like to upgrade the database?"
 msgstr "Vil du oppgradere databasen?"
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr "XLS"
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr "XLSX"
 
@@ -8707,7 +8734,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr "delvis til rådighet"
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr "permalink"
 

--- a/locale/po/nl.po
+++ b/locale/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "# Facturen"
 
@@ -105,7 +105,7 @@ msgstr "Inkoopfactuur"
 msgid "AP Invoices"
 msgstr "Inkoopfacturen"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Openstaande Crediteuren"
@@ -117,7 +117,7 @@ msgstr "Openstaande Crediteuren"
 msgid "AP Transaction"
 msgstr "Crediteurenboeking"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Crediteurenboekingen"
 
@@ -152,7 +152,7 @@ msgstr "Verkoopfactuur"
 msgid "AR Invoices"
 msgstr "Verkoopfacturen"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Openstaande Debiteuren"
@@ -163,7 +163,7 @@ msgstr "Openstaande Debiteuren"
 msgid "AR Transaction"
 msgstr "Debiteurenboeking"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Debiteurenboekingen"
 
@@ -180,8 +180,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Debiteurenboeking"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Debiteuren/Crediteuren/Grootboek Bedrag"
 
@@ -189,8 +189,8 @@ msgstr "Debiteuren/Crediteuren/Grootboek Bedrag"
 msgid "Abandonment"
 msgstr "Afschrijving"
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Toegang geweigerd"
 
@@ -198,11 +198,11 @@ msgstr "Toegang geweigerd"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -227,22 +227,22 @@ msgstr "Rekening"
 msgid "Account Description"
 msgstr "Omschrijving grootboekrekening"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Rekeninglabel"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Rekeninghouder"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -323,7 +323,7 @@ msgstr "Aangegroeid"
 msgid "Accrual Basis:"
 msgstr "Aangroeibasis:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr "Cum. Afschrijving"
 
@@ -620,7 +620,7 @@ msgstr "Aanp."
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr "Aangepaste basis"
 
@@ -640,7 +640,7 @@ msgstr "Details van aanpassing"
 msgid "Aged"
 msgstr "Verlopen"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Verouderingsrapportage"
 
@@ -694,11 +694,11 @@ msgstr "Toegewezen"
 msgid "Allow Input"
 msgstr "Invoer toestaan"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -716,11 +716,11 @@ msgstr "Invoer toestaan"
 msgid "Amount"
 msgstr "Bedrag"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Gebudgetteerd Bedrag"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -732,13 +732,13 @@ msgstr "Verschuldigd Bedrag"
 msgid "Amount From"
 msgstr "Bedrag vanaf"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr "Bedrag groter dan"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr "Bedrag kleiner dan"
 
@@ -802,9 +802,9 @@ msgid "Approval Status"
 msgstr "Goedkeuringsstatus"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Goedkeuren"
@@ -817,12 +817,12 @@ msgstr "Goedkeuren"
 msgid "Approved"
 msgstr "Goedgekeurd"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Goedgekeurd door"
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Goedgekeurd op"
 
@@ -838,16 +838,16 @@ msgstr ""
 msgid "Apr"
 msgstr "apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "april"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr "Verkregen prijs bij verkoop"
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr "Verkregen restwaarde"
 
@@ -887,7 +887,7 @@ msgstr "Activa"
 msgid "Asset Account"
 msgstr "Activa rekening"
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr "Activa soort"
@@ -912,7 +912,7 @@ msgstr "Activa afschrijvingsrapport"
 msgid "Asset Disposal Report"
 msgstr "Activa verwijderingsrapport"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr "Activalijst"
 
@@ -1017,7 +1017,7 @@ msgstr "Aan: [_1]"
 msgid "Aug"
 msgstr "aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "augustus"
 
@@ -1087,13 +1087,13 @@ msgstr "Backup DB"
 msgid "Backup Roles"
 msgstr "Backup rollen"
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1151,7 +1151,7 @@ msgstr "Basis"
 msgid "Batch"
 msgstr "Groep"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr "Groep soort"
 
@@ -1167,7 +1167,7 @@ msgstr "Batch Datum"
 msgid "Batch Description"
 msgstr "Groep omschrijving"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr "Groep ID"
 
@@ -1179,12 +1179,12 @@ msgstr "Groep ID ontbreekt"
 msgid "Batch Name"
 msgstr "Groep naam"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr "Batch Nummer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr "Groep zoeken"
 
@@ -1265,15 +1265,15 @@ msgstr "Boeken afgesloten tot"
 msgid "Budget"
 msgstr "Begroting"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr "Begrotingnummer"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr "Begroting Zoek Resultaten"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr "Begroting verschil rapport"
 
@@ -1289,7 +1289,7 @@ msgstr "Bedrijf"
 msgid "Business Number"
 msgstr "KvK-nummer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr "Bedrijfstype"
@@ -1324,9 +1324,9 @@ msgstr "Kostprijs omzet"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr "CSV"
 
@@ -1342,7 +1342,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr "Teruggedraaide factuur niet terugdraaibaar!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1476,11 +1476,11 @@ msgstr "Wachtwoord aanpassen"
 msgid "Chargeable"
 msgstr "Belastbaar"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr "Chart ID"
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Rekeningstelsel"
 
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1627,8 +1627,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr "Vergelijking periode"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
@@ -1683,6 +1683,30 @@ msgstr ""
 #, fuzzy
 msgid "Compose e-mail"
 msgstr "Naar e-mail adres"
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:10
 msgid "Confirm Operation"
@@ -1692,7 +1716,7 @@ msgstr "Bevestig bewerking"
 msgid "Confirm!"
 msgstr "Bevestig!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Conflicteert met bestaande gegevens. Misschien heeft u het al ingevoerd"
 
@@ -1720,7 +1744,7 @@ msgstr "Contact informatie:"
 msgid "Contact Information"
 msgstr "Contact informatie"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr "Zoek Contact"
@@ -1777,7 +1801,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1865,7 +1889,7 @@ msgstr "Land:"
 msgid "Create"
 msgstr "Aanmaken"
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1877,7 +1901,7 @@ msgstr "Groep maken"
 msgid "Create Database?"
 msgstr "Database maken?"
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1905,7 +1929,7 @@ msgstr "Gemaakt door"
 msgid "Created On"
 msgstr "Gemaakt op"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1916,7 +1940,7 @@ msgstr "Credit"
 msgid "Credit Account"
 msgstr "Crediteurenrekening"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Nummer crediteurenrekening"
 
@@ -1943,22 +1967,22 @@ msgstr "Kredietlimiet:"
 msgid "Credit Note"
 msgstr "Creditmemo"
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr "Credit"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Val."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1977,7 +2001,7 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1993,8 +2017,8 @@ msgstr "Resultaat"
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2057,7 +2081,7 @@ msgstr "Klant bestaat niet!"
 msgid "Customer/Vendor Accounts"
 msgstr "Klanten-/leveranciersrekeningen"
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr "Dag Maand"
 
@@ -2134,17 +2158,17 @@ msgstr "Database bestaat al."
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2174,8 +2198,8 @@ msgstr "Datum formaat"
 msgid "Date From"
 msgstr "Datum vanaf"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2254,7 +2278,7 @@ msgstr "Dag(en)"
 msgid "Days"
 msgstr "Dagen"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2269,7 +2293,7 @@ msgstr "Debitfactuur"
 msgid "Debit Note"
 msgstr "Debetmemo"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2280,7 +2304,7 @@ msgstr "Debet"
 msgid "Dec"
 msgstr "dec"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "december"
 
@@ -2365,11 +2389,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2382,7 +2406,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Verwijder"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr "Groep verwijderen"
 
@@ -2395,7 +2419,7 @@ msgstr "Inplanning Verwijderen"
 msgid "Delete User"
 msgstr "Gebruiker maken"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr "Vouchers Verwijderen"
 
@@ -2418,21 +2442,21 @@ msgstr ""
 msgid "Delivery"
 msgstr "Bezorging"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leverdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr "Afschr. Basis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr "Afschr. methode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr "Afschr. begint"
 
@@ -2440,11 +2464,11 @@ msgstr "Afschr. begint"
 msgid "Dep. Through"
 msgstr "Afschr. tot"
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr "Afschr. dit jr"
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr "Afschr. dit rapport"
 
@@ -2466,7 +2490,7 @@ msgstr "Afschrijven"
 msgid "Depreciate Through"
 msgstr "Afschrijvingen door"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Afschrijving"
@@ -2487,15 +2511,15 @@ msgstr "Afschrijvingsmethode"
 msgid "Depreciation Starts"
 msgstr "Afschrijving begint"
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2512,13 +2536,13 @@ msgstr "Afschrijving begint"
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2586,7 +2610,7 @@ msgstr "Details"
 msgid "Disable Back Button"
 msgstr "Uitzetten \"Back\" knop"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr "Korting"
 
@@ -2612,16 +2636,16 @@ msgstr "Korting (%)"
 msgid "Discount:"
 msgstr "Korting:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr "Verkregen restwaarde afschrijving"
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Verwijdering"
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr "Verwijderingsdatum"
 
@@ -2629,11 +2653,11 @@ msgstr "Verwijderingsdatum"
 msgid "Disposal Method"
 msgstr "Verwijderingsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Verwijderingsrapport [_1] op datum [_2]"
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr "Delen door 0 kan niet! Onmodelijk!"
 
@@ -2665,6 +2689,10 @@ msgstr "Dubbele klantnummers"
 msgid "Double vendornumbers"
 msgstr "Dubbele leveranciersnummers"
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr "Dr."
@@ -2673,11 +2701,11 @@ msgstr "Dr."
 msgid "Draft Posted"
 msgstr "Concept geboekt"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr "Concept zoeken"
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr "Concept type"
 
@@ -2691,11 +2719,11 @@ msgstr "Concepten"
 msgid "Drawing"
 msgstr "Tekening"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr "Selectielijsten"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2704,9 +2732,9 @@ msgstr "Selectielijsten"
 msgid "Due"
 msgstr "Verschuldigd op"
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2736,7 +2764,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "E-mailadres ontbreekt!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2897,7 +2925,7 @@ msgstr "Elf"
 msgid "Eleven-o"
 msgstr "Elf"
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr "E-mail"
 
@@ -2956,14 +2984,14 @@ msgstr "Niet-gevulde klantnummers"
 msgid "Empty vendornumbers"
 msgstr "Niet-gevulde leveranciersnummers"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3007,7 +3035,7 @@ msgstr "Voer gebruiker in"
 msgid "Enter employee numbers where they are missing"
 msgstr "Voer personeelsnummers in waar deze missen"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr "Registratie door"
@@ -3016,7 +3044,7 @@ msgstr "Registratie door"
 msgid "Entered For"
 msgstr "Ingevoerd voor"
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr "Ingeboekt op"
 
@@ -3025,7 +3053,7 @@ msgid "Entered at: [_1]"
 msgstr "Ingevoerd op: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr "Bedrijfseenheid"
 
@@ -3050,7 +3078,7 @@ msgstr "Entiteit crediteurenrekening"
 msgid "Entity Name"
 msgstr "Bedrijfseenheid code"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr "Invoer ID"
 
@@ -3087,7 +3115,7 @@ msgstr "Fout in aanmaken backup bestand"
 msgid "Error creating batch.  Please try again."
 msgstr "Fout in aanmaken groep. Probeer opniew."
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr "Functionele fout"
 
@@ -3095,7 +3123,7 @@ msgstr "Functionele fout"
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Fout: Samenvattingsrekening niet combineerbaar met selectielijsten"
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr "Verw. Levensduur"
 
@@ -3107,7 +3135,7 @@ msgstr "Elke"
 msgid "Exch"
 msgstr "Wissel"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3216,7 +3244,7 @@ msgstr "Fax: [_1]"
 msgid "Feb"
 msgstr "feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "februari"
 
@@ -3232,7 +3260,7 @@ msgstr "Vijftig"
 msgid "File"
 msgstr "Bestand"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr "Bestand geimporteerd"
 
@@ -3376,7 +3404,7 @@ msgstr "Vanaf bedrag"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr "Vanaf datum"
@@ -3399,11 +3427,11 @@ msgstr "Vanaf datum"
 msgid "Full"
 msgstr "Volledig"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr "Systeem administrateur"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3434,7 +3462,7 @@ msgstr "Memoriaal Referentiecode"
 msgid "Gain"
 msgstr "Winst"
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr "Winst  (Verlies)"
 
@@ -3442,7 +3470,7 @@ msgstr "Winst  (Verlies)"
 msgid "Gain Account"
 msgstr "Winstrekening"
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 #, fuzzy
 msgid "Gain/Loss"
 msgstr "Winst  (Verlies)"
@@ -3455,7 +3483,7 @@ msgstr "Opvolgende verkoopfactuurnummers"
 msgid "General Journal"
 msgstr "Grootboek journaal"
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr "Grootboekrapport"
 
@@ -3463,7 +3491,7 @@ msgstr "Grootboekrapport"
 msgid "General Ledger Reports"
 msgstr "Grootboekrapportages"
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Genereer"
@@ -3550,7 +3578,7 @@ msgstr "Gtalk"
 msgid "HR"
 msgstr "Personeelszaken"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3592,18 +3620,18 @@ msgid "Hundred"
 msgstr "honderd"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3756,7 +3784,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr "Interne database fout"
 
@@ -3777,7 +3805,7 @@ msgstr "Geen geldige rapportage basis"
 msgid "Invalid backup request"
 msgstr "Ongeldige backup verzoek"
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr "Ongeldige datum/tijd ingevoerd"
 
@@ -3835,9 +3863,9 @@ msgstr "Voorraad opgeslagen!"
 msgid "Inventory transferred!"
 msgstr "Voorraad overgeheveld!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3866,7 +3894,7 @@ msgstr "Factuur aangemaakt"
 msgid "Invoice Created Date missing!"
 msgstr "Factuur aanmaakdatum mist!"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3881,10 +3909,10 @@ msgstr "Factuurdatum ontbreekt!"
 msgid "Invoice No."
 msgstr "Factuurnr"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3982,7 +4010,7 @@ msgstr ""
 msgid "Jan"
 msgstr "jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "januari"
 
@@ -4014,7 +4042,7 @@ msgstr "Journaalregels"
 msgid "Jul"
 msgstr "jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "juli"
 
@@ -4022,7 +4050,7 @@ msgstr "juli"
 msgid "Jun"
 msgstr "jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "juni"
@@ -4055,7 +4083,7 @@ msgstr "Arbeids-/Overheadkosten"
 msgid "Labor/Service Code"
 msgstr "Arbeid-/dienstcode"
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4286,7 +4314,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4377,11 +4405,11 @@ msgstr ""
 "Controleer dat iedere naam alleen bestaat uit alfanumerieke karakters (en "
 "lage streep) en minimaal een karakter lang is"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr "Toekennen bevoegdheden aan gebruikers"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4402,7 +4430,7 @@ msgstr "Handmatig"
 msgid "Mar"
 msgstr "mrt"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "maart"
 
@@ -4419,12 +4447,12 @@ msgstr "Max. facturen per cheque"
 msgid "Max per dropdown"
 msgstr "Max per dropdown"
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "mei"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4520,7 +4548,7 @@ msgstr "Maand(en)"
 msgid "Months"
 msgstr "Maanden"
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr "Meer informatie is te zien in de \"error logs\""
 
@@ -4557,15 +4585,14 @@ msgstr "Kasrekening noodzakelijk in transactiegroep"
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Naam"
@@ -4625,7 +4652,7 @@ msgid "Next Number"
 msgstr "Volgende Nummer"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr "Eerstvolgende in aangegeven volgorder"
 
@@ -4677,7 +4704,7 @@ msgstr "Werknemer NUMMER (moet ingevuld worden!)"
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr "Geen veranderingen"
 
@@ -4711,7 +4738,7 @@ msgstr "Geen referentiesleutel en geen vervanging beschikbaar "
 msgid "No report specified"
 msgstr "Geen specificatie rapport aangegeven"
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr "Geen belastingformulier geselecteerd"
 
@@ -4784,9 +4811,9 @@ msgstr "Notitie soort"
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4826,7 +4853,7 @@ msgstr "Niets over te boeken!"
 msgid "Nov"
 msgstr "nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "november"
 
@@ -4871,8 +4898,8 @@ msgstr "Getal mist in regel [_1]"
 msgid "Number:"
 msgstr "Nummer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr "ODS"
 
@@ -4889,7 +4916,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Niet actief"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr "Incourant door"
 
@@ -4897,7 +4924,7 @@ msgstr "Incourant door"
 msgid "Oct"
 msgstr "okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "oktober"
 
@@ -4973,7 +5000,7 @@ msgid "Or Add To Batch"
 msgstr "Of Voeg toe aan Groep"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Bestelling"
@@ -5005,7 +5032,7 @@ msgstr "Orderdatum ontbreekt!"
 msgid "Order Entry"
 msgstr "Orderinvoer"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5096,9 +5123,9 @@ msgstr "Rekening overschot bedragen"
 msgid "Overpayments"
 msgstr "Overschot bedragen"
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5107,8 +5134,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr "PO #"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5148,8 +5175,8 @@ msgstr "Nummer ontbreekt op de pakbon!"
 msgid "Packing list"
 msgstr "Pakbon"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5177,7 +5204,7 @@ msgstr "Artikelomschrijving"
 msgid "Part Group"
 msgstr "Artikelgroep"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5208,7 +5235,7 @@ msgstr "Details"
 msgid "Partial"
 msgstr "Gedeeltelijk"
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Gedeeltelijk afschrijvingsrapportage [_1] op datum [_2]"
 
@@ -5276,7 +5303,7 @@ msgstr "Betalingen"
 msgid "Payment"
 msgstr "Betaling"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr "Betalingsbedrag"
 
@@ -5338,11 +5365,11 @@ msgstr "Betalingen m.b.t. niet geldige facturen moeten worden teruggeboekt"
 msgid "Percent"
 msgstr "procent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr "Percentage verwijderd"
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr "Resterend Percentage"
 
@@ -5521,7 +5548,7 @@ msgstr ""
 "Maakt u gebruik van het 1.2 gebruikersinterface om de volgende GIFI accounts "
 "toe te voegen"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5529,7 +5556,7 @@ msgstr ""
 msgid "Post"
 msgstr "Inboeken"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr "Boek transactiegroep"
 
@@ -5651,7 +5678,7 @@ msgstr "Eerste telefoonnummer"
 msgid "Print"
 msgstr "Afdrukken"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr "Print groep"
 
@@ -5711,15 +5738,15 @@ msgstr "Afdrukken transactie [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Afdrukken werkbon [_1]"
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr "Eerdere Afschr."
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr "Voorafgaand aan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr "vervolgt"
 
@@ -5780,7 +5807,7 @@ msgstr "Inkoop datum"
 msgid "Purchase Date:"
 msgstr "Datum Inkoop"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr "Inkoophistorie"
@@ -5806,7 +5833,7 @@ msgid "Purchase Orders"
 msgstr "Inkooporders"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr "Inkoopprijs"
 
@@ -5823,7 +5850,7 @@ msgstr "Inkooporder"
 msgid "Purchased"
 msgstr "Gekocht"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -6038,13 +6065,13 @@ msgstr "Herhalende Transactie voor [_1]"
 msgid "Recurring Transactions"
 msgstr "Geplande Transacties"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6114,12 +6141,12 @@ msgstr "Rapport goedgekeurd"
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr "Rapportnaam"
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr "Rapportresultaat"
 
@@ -6131,7 +6158,7 @@ msgstr "Rapport ingediend"
 msgid "Report Type"
 msgstr "Rapportsoort"
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr "Rapport [_1] op datum [_2]"
 
@@ -6199,7 +6226,7 @@ msgstr "Uiterlijke leverdatum"
 msgid "Required by"
 msgstr "Nodig voor"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr "Niet voorzien van de benodigde input"
 
@@ -6377,8 +6404,8 @@ msgstr "Titulatuur"
 msgid "Sales:"
 msgstr "Verkoop:"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6556,7 +6583,7 @@ msgstr "Inplannen"
 msgid "Scheduled"
 msgstr "Ingepland"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Scherm"
@@ -6740,7 +6767,7 @@ msgstr "Gekozen"
 msgid "Sell"
 msgstr "Verkopen"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6797,7 +6824,7 @@ msgstr "sep"
 msgid "Separate Duties"
 msgstr "Afzonderlijke Taken"
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "september"
 
@@ -6817,7 +6844,7 @@ msgstr "Serie#"
 msgid "Serial No."
 msgstr "Serienr"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6903,8 +6930,8 @@ msgstr "Verzenden aan:"
 msgid "Ship To:"
 msgstr "Verzenden aan:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6951,8 +6978,8 @@ msgstr "Verzenddatum ontbreekt!"
 msgid "Shipping Label"
 msgstr "Verzendlabel"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -7024,8 +7051,8 @@ msgstr "Verkocht"
 msgid "Some"
 msgstr "Sommige"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7072,14 +7099,14 @@ msgstr "Standaard"
 msgid "Standard Industrial Codes"
 msgstr "Standaard Industiële Codes"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7104,7 +7131,7 @@ msgid "Startdate"
 msgstr "Begindatum"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr "Beginsaldo"
 
@@ -7156,8 +7183,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7269,8 +7296,8 @@ msgstr "TOTAAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr "Label"
 
@@ -7278,8 +7305,8 @@ msgstr "Label"
 msgid "Tag:"
 msgstr "Label:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7602,8 +7629,8 @@ msgstr "Per datum"
 msgid "Thu"
 msgstr "Donder"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7682,7 +7709,7 @@ msgstr "Tot bedrag"
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr "tot Datum"
@@ -7728,14 +7755,14 @@ msgstr "Vink alle verwijder-aankruisvakjes aan"
 msgid "Top-level"
 msgstr "Hoogste Niveau"
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7757,7 +7784,7 @@ msgstr "Hoogste Niveau"
 msgid "Total"
 msgstr "Totaal"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr "Totaal afschrijvingen"
 
@@ -7785,7 +7812,7 @@ msgstr "Boeking"
 msgid "Transaction Approval"
 msgstr "Transactiegoedkeuring"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7799,7 +7826,7 @@ msgstr "Boekingsdatum ontbreekt!"
 msgid "Transaction Dates"
 msgstr "Transactiedatums"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7908,9 +7935,9 @@ msgid "Two"
 msgstr "Twee"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7968,7 +7995,7 @@ msgstr "Leverancier Nummer"
 msgid "Unique nonobsolete partnumbers"
 msgstr "Unieke geldige artikelnummers"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -8011,11 +8038,11 @@ msgstr "Onbekende database aangetroffen"
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr "Ontgrendel"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr "Batch ontgrendelen"
 
@@ -8144,7 +8171,7 @@ msgstr "Gebruik meerbetaling/vooruitbetaling"
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr "al in gebruik"
@@ -8158,7 +8185,7 @@ msgstr "Gebruiker"
 msgid "User Name"
 msgstr "Gebruikersnaam"
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr "Gebruiker bestaat al    Importeer?"
 
@@ -8206,7 +8233,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Verschil"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr "Verschil"
@@ -8215,8 +8242,8 @@ msgstr "Verschil"
 msgid "Variance:"
 msgstr "Afwijking:"
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8290,7 +8317,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverancier bestaat niet!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8304,7 +8331,7 @@ msgstr ""
 msgid "Void"
 msgstr "Maak ongeldig"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr "Tegoedbonnenlijst"
 
@@ -8438,13 +8465,13 @@ msgstr "Wilt u de database migreren?"
 msgid "Would you like to upgrade the database?"
 msgstr "Wilt u de database upgraden?"
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr "XLS"
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8685,7 +8712,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr "gedeeltelijk verwijderd"
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr "permanente URL"
 

--- a/locale/po/nl_BE.po
+++ b/locale/po/nl_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Dutch (Belgium) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Openstaande Crediteuren"
@@ -110,7 +110,7 @@ msgstr "Openstaande Crediteuren"
 msgid "AP Transaction"
 msgstr "Crediteurenboeking"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Crediteurenboekingen"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Openstaande Debiteuren"
@@ -156,7 +156,7 @@ msgstr "Openstaande Debiteuren"
 msgid "AR Transaction"
 msgstr "Debiteurenboeking"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Debiteurenboekingen"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Debiteurenboeking"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Rekening"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Bedrag"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Verschuldigd bedrag"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activa (bezittingen)"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Augustus"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Zaaktype"
 msgid "Business Number"
 msgstr "Kamer van Koophandel nummer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Kostprijs Verkopen"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Rekeningstelsel"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bevestig!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "Credit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Val."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "Val."
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "Klant bestaat niet!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "December"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Verwijder"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Verwijder"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leverdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Tekening"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "E-mailadres ontbreekt!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr "elf"
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Bedrijfsnaam"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Wisselkoers"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Februari"
 
@@ -3219,7 +3247,7 @@ msgstr "vijftig"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "Personeel"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr "honderd"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3819,9 +3847,9 @@ msgstr "Voorraad opgeslagen"
 msgid "Inventory transferred!"
 msgstr "Voorraad overgeheveld"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3850,7 +3878,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3865,10 +3893,10 @@ msgstr "Factuurdatum ontbreekt!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3961,7 +3989,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Januari"
 
@@ -3993,7 +4021,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juli"
 
@@ -4001,7 +4029,7 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
@@ -4034,7 +4062,7 @@ msgstr "Arbeid/Overheadskosten"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4262,7 +4290,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4351,11 +4379,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4376,7 +4404,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mrt"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Maart"
 
@@ -4393,12 +4421,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mei"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4493,7 +4521,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4527,15 +4555,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Naam"
@@ -4595,7 +4622,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4647,7 +4674,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4679,7 +4706,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4750,9 +4777,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4792,7 +4819,7 @@ msgstr "Niets over te boeken!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4837,8 +4864,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Nummer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4855,7 +4882,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Niet actief"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4863,7 +4890,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktober"
 
@@ -4938,7 +4965,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Bestelling"
@@ -4970,7 +4997,7 @@ msgstr "Geen order datum aanwezig"
 msgid "Order Entry"
 msgstr "Order invoer"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5061,9 +5088,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5072,8 +5099,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5113,8 +5140,8 @@ msgstr "Pakbon nummer ontbreekt!"
 msgid "Packing list"
 msgstr "Pakbon"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5142,7 +5169,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5171,7 +5198,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5239,7 +5266,7 @@ msgstr "Betalingen"
 msgid "Payment"
 msgstr "Betaling"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5301,11 +5328,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5480,7 +5507,7 @@ msgstr ""
 msgid "Post"
 msgstr "Boek"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5602,7 +5629,7 @@ msgstr ""
 msgid "Print"
 msgstr "Afdrukken"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5662,15 +5689,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5757,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5756,7 +5783,7 @@ msgid "Purchase Orders"
 msgstr "Inkooporders"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5773,7 +5800,7 @@ msgstr "Inkooporder"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5988,13 +6015,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6064,12 +6091,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6081,7 +6108,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,7 +6176,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Nodig voor"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6327,8 +6354,8 @@ msgstr "Kan offerte niet verwijderen!"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6506,7 +6533,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Scherm"
@@ -6690,7 +6717,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6747,7 +6774,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "September"
 
@@ -6767,7 +6794,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serienr"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6852,8 +6879,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6900,8 +6927,8 @@ msgstr "Verzenddatum ontbreekt!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6972,8 +6999,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7019,14 +7046,14 @@ msgstr "Standaard"
 msgid "Standard Industrial Codes"
 msgstr "Standaard Industiële Codes"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7050,7 +7077,7 @@ msgid "Startdate"
 msgstr "Begindatum"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7102,8 +7129,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7214,8 +7241,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7223,8 +7250,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7545,8 +7572,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7625,7 +7652,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7671,14 +7698,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7700,7 +7727,7 @@ msgstr ""
 msgid "Total"
 msgstr "Totaal"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,7 +7755,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7742,7 +7769,7 @@ msgstr "Boekingsdatum ontbreekt!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7851,9 +7878,9 @@ msgid "Two"
 msgstr "twee"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7911,7 +7938,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7952,11 +7979,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8085,7 +8112,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8099,7 +8126,7 @@ msgstr "Gebruiker"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8147,7 +8174,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Belastbaar percentage"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8156,8 +8183,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8231,7 +8258,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverancier bestaat niet!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8245,7 +8272,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8374,13 +8401,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8619,7 +8646,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/pl.po
+++ b/locale/po/pl.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -17,7 +17,7 @@ msgstr ""
 "%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
 "%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -100,7 +100,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Zobowiązania Nieuregulowane"
@@ -112,7 +112,7 @@ msgstr "Zobowiązania Nieuregulowane"
 msgid "AP Transaction"
 msgstr "Transakcja Zobowiązań"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transakcje Zobowiązań"
 
@@ -147,7 +147,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Należności Nieuregulowane"
@@ -158,7 +158,7 @@ msgstr "Należności Nieuregulowane"
 msgid "AR Transaction"
 msgstr "Transakcja Należności"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transakcje Należności"
 
@@ -175,8 +175,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transakcja Należności"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -184,8 +184,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -193,11 +193,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -222,22 +222,22 @@ msgstr "Konto"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -689,11 +689,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -711,11 +711,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Kwota"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -727,13 +727,13 @@ msgstr "Kwota Należna"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -797,9 +797,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -812,12 +812,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -833,16 +833,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Kwiecień"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Kwiecień"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgstr "Aktywy"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Sierpień"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Sierpień"
 
@@ -1082,13 +1082,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1174,12 +1174,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1260,15 +1260,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1284,7 +1284,7 @@ msgstr "Działalność"
 msgid "Business Number"
 msgstr "NIP"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1319,9 +1319,9 @@ msgstr "Koszta Sprzedaży"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1469,11 +1469,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plan Kont"
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1619,8 +1619,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1667,12 +1667,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1683,7 +1707,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Potwierdż!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1711,7 +1735,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Kredyt"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1934,22 +1958,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Waluta"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Waluta"
 msgid "Currency"
 msgstr "Waluta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "Brak Odbiorcy w bazie danych"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2125,17 +2149,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Grudzień"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Grudzień"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Usuń"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2386,7 +2410,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Usuń"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data Dostawy"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2431,11 +2455,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2478,15 +2502,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2603,16 +2627,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2620,11 +2644,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2664,11 +2692,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2682,11 +2710,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Rysunek"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Brak adresu E-mail!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3005,7 +3033,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nazwa Firmy"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3076,7 +3104,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3096,7 +3124,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Kurs Walut"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Luty"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Luty"
 
@@ -3221,7 +3249,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3388,11 +3416,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3431,7 +3459,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3443,7 +3471,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3451,7 +3479,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3538,7 +3566,7 @@ msgstr ""
 msgid "HR"
 msgstr "Kadry"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3580,18 +3608,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3744,7 +3772,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3765,7 +3793,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3821,9 +3849,9 @@ msgstr "Inwentarz zapisany!"
 msgid "Inventory transferred!"
 msgstr "Inwentarz przeniesiony!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3852,7 +3880,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3867,10 +3895,10 @@ msgstr "Brak Daty Wystawienia"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3963,7 +3991,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Styczeń"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Styczeń"
 
@@ -3995,7 +4023,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Lipiec"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Lipiec"
 
@@ -4003,7 +4031,7 @@ msgstr "Lipiec"
 msgid "Jun"
 msgstr "Czerwiec"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Czerwiec"
@@ -4036,7 +4064,7 @@ msgstr "Koszty Pracownicze/Administracyjne"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4264,7 +4292,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4353,11 +4381,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4378,7 +4406,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Marzec"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Marzec"
 
@@ -4395,12 +4423,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Maj"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4495,7 +4523,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4529,15 +4557,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nazwa"
@@ -4597,7 +4624,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4649,7 +4676,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4681,7 +4708,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4752,9 +4779,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4794,7 +4821,7 @@ msgstr "Nie ma nic do przeniesienia!"
 msgid "Nov"
 msgstr "Listopad"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Listopad"
 
@@ -4839,8 +4866,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numer Katalogu"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4857,7 +4884,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Przestarzałe"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4865,7 +4892,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Pażdziernik"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Pażdziernik"
 
@@ -4940,7 +4967,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Zlecenie"
@@ -4972,7 +4999,7 @@ msgstr "Brak Daty Zlecenia"
 msgid "Order Entry"
 msgstr "Wystawianie Zleceń"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5063,9 +5090,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5074,8 +5101,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5115,8 +5142,8 @@ msgstr "Brak Numeru Listy Pakunkowej"
 msgid "Packing list"
 msgstr "Lista Pakunkowa"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5144,7 +5171,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5173,7 +5200,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5241,7 +5268,7 @@ msgstr "Zobowiązania"
 msgid "Payment"
 msgstr "Kasa Wypłaci"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5303,11 +5330,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5474,7 +5501,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5482,7 +5509,7 @@ msgstr ""
 msgid "Post"
 msgstr "Zatwierdż"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5604,7 +5631,7 @@ msgstr ""
 msgid "Print"
 msgstr "Wydrukuj"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5664,15 +5691,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5732,7 +5759,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5758,7 +5785,7 @@ msgid "Purchase Orders"
 msgstr "Zlecenia Zakupu"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5775,7 +5802,7 @@ msgstr "Zlecenie Zakupu"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5990,13 +6017,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6066,12 +6093,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6083,7 +6110,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6151,7 +6178,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Termin Dostawy"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6329,8 +6356,8 @@ msgstr "Numer Oferty Sprzedaży"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6508,7 +6535,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ekran"
@@ -6692,7 +6719,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Sprzedaż"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6749,7 +6776,7 @@ msgstr "Wrzesień"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Wrzesień"
 
@@ -6769,7 +6796,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Nr. Sr."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6854,8 +6881,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6902,8 +6929,8 @@ msgstr "Brak Dnia Dostawy!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6974,8 +7001,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7021,14 +7048,14 @@ msgstr "Standartowe"
 msgid "Standard Industrial Codes"
 msgstr "Europejska Klasyfikacja Działalności"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7052,7 +7079,7 @@ msgid "Startdate"
 msgstr "Dzień Zatrudnienia"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7104,8 +7131,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7217,8 +7244,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7226,8 +7253,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7548,8 +7575,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7628,7 +7655,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7674,14 +7701,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7703,7 +7730,7 @@ msgstr ""
 msgid "Total"
 msgstr "Wartość Brutto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,7 +7758,7 @@ msgstr "Transakcja"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7745,7 +7772,7 @@ msgstr "Brak Daty Transakcji!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7854,9 +7881,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7914,7 +7941,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7955,11 +7982,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8088,7 +8115,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8102,7 +8129,7 @@ msgstr "Użytkownik"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8150,7 +8177,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Opodatkowane"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8159,8 +8186,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8234,7 +8261,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Brak Dostawcy w bazie danych"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8248,7 +8275,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8377,13 +8404,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8622,7 +8649,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/pt.po
+++ b/locale/po/pt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr "Transacção Fornecedores"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transacções Fornecedores"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr "Transacção Clientes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transacções Clientes"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transacção Clientes"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Conta"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Total em dívida"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Activo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Saldo"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1257,15 +1257,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Número de negócio"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1316,9 +1316,9 @@ msgstr "Custo de Vendas"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1466,11 +1466,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plano de Contas"
 
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1616,8 +1616,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1664,12 +1664,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1680,7 +1704,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1708,7 +1732,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1765,7 +1789,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1853,7 +1877,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1865,7 +1889,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1893,7 +1917,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1904,7 +1928,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1931,22 +1955,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Moeda"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1965,7 +1989,7 @@ msgstr "Moeda"
 msgid "Currency"
 msgstr "Moeda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1981,8 +2005,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2045,7 +2069,7 @@ msgstr "Cliente inexistente!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2122,17 +2146,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2162,8 +2186,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2242,7 +2266,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2257,7 +2281,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2268,7 +2292,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dez"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Dezembro"
 
@@ -2353,11 +2377,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2370,7 +2394,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Remover"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2383,7 +2407,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Remover"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2406,21 +2430,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2428,11 +2452,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2454,7 +2478,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2475,15 +2499,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2500,13 +2524,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2574,7 +2598,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2600,16 +2624,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2617,11 +2641,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2653,6 +2677,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2661,11 +2689,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2679,11 +2707,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2692,9 +2720,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2724,7 +2752,7 @@ msgstr "E-Mail"
 msgid "E-mail address missing!"
 msgstr "Falta Endereço de E-mail!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2885,7 +2913,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2941,14 +2969,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2992,7 +3020,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3001,7 +3029,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3010,7 +3038,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3034,7 +3062,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3071,7 +3099,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3079,7 +3107,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3091,7 +3119,7 @@ msgstr ""
 msgid "Exch"
 msgstr "Câmbio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3200,7 +3228,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fev"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Fevereiro"
 
@@ -3216,7 +3244,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3360,7 +3388,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3383,11 +3411,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3418,7 +3446,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3426,7 +3454,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3438,7 +3466,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3446,7 +3474,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3533,7 +3561,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3575,18 +3603,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3739,7 +3767,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3760,7 +3788,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3816,9 +3844,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3847,7 +3875,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3862,10 +3890,10 @@ msgstr "Data de Factura não encontrada!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3958,7 +3986,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Janeiro"
 
@@ -3990,7 +4018,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julho"
 
@@ -3998,7 +4026,7 @@ msgstr "Julho"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junho"
@@ -4031,7 +4059,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4259,7 +4287,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4348,11 +4376,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4373,7 +4401,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Março"
 
@@ -4390,12 +4418,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4490,7 +4518,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4524,15 +4552,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nome"
@@ -4592,7 +4619,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4644,7 +4671,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4676,7 +4703,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4747,9 +4774,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4789,7 +4816,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembro"
 
@@ -4834,8 +4861,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4852,7 +4879,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4860,7 +4887,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Out"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Outubro"
 
@@ -4935,7 +4962,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Encomenda"
@@ -4967,7 +4994,7 @@ msgstr "Falta data da Encomenda"
 msgid "Order Entry"
 msgstr "Encomendas de Clientes"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5057,9 +5084,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5068,8 +5095,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5109,8 +5136,8 @@ msgstr "Falta Numero de Lista de Expedição"
 msgid "Packing list"
 msgstr "Lista de Expedição"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5138,7 +5165,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5167,7 +5194,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5235,7 +5262,7 @@ msgstr "Fornecedores"
 msgid "Payment"
 msgstr "Pagamento"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5297,11 +5324,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5467,7 +5494,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5475,7 +5502,7 @@ msgstr ""
 msgid "Post"
 msgstr "Processar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5597,7 +5624,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5657,15 +5684,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5752,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5751,7 +5778,7 @@ msgid "Purchase Orders"
 msgstr "Ordens de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5768,7 +5795,7 @@ msgstr "Ordem de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5983,13 +6010,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6059,12 +6086,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6076,7 +6103,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6143,7 +6170,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6320,8 +6347,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6499,7 +6526,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Ecran"
@@ -6683,7 +6710,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6740,7 +6767,7 @@ msgstr "Set"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Setembro"
 
@@ -6760,7 +6787,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6845,8 +6872,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6893,8 +6920,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6964,8 +6991,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7011,14 +7038,14 @@ msgstr "Padrão"
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7042,7 +7069,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7094,8 +7121,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7206,8 +7233,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7215,8 +7242,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7537,8 +7564,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7617,7 +7644,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7663,14 +7690,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7692,7 +7719,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7720,7 +7747,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7734,7 +7761,7 @@ msgstr "Falta Data de transacção!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7843,9 +7870,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7903,7 +7930,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7944,11 +7971,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8077,7 +8104,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8091,7 +8118,7 @@ msgstr "Utilizador"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8139,7 +8166,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Sujeito a impostos"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8148,8 +8175,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8223,7 +8250,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fornecedor não existe"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8237,7 +8264,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8365,13 +8392,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8610,7 +8637,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/pt_BR.po
+++ b/locale/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/ledgersmb/"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "# Faturas"
 
@@ -102,7 +102,7 @@ msgstr "Fatura a pagar"
 msgid "AP Invoices"
 msgstr "Faturas a pagar"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Contas a Pagar Pendentes"
@@ -114,7 +114,7 @@ msgstr "Contas a Pagar Pendentes"
 msgid "AP Transaction"
 msgstr "Transação - Contas a Pagar"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Transações - Contas a Pagar"
 
@@ -149,7 +149,7 @@ msgstr "Fatura a receber"
 msgid "AR Invoices"
 msgstr "Faturas a receber"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Contas a Receber Pendentes"
@@ -160,7 +160,7 @@ msgstr "Contas a Receber Pendentes"
 msgid "AR Transaction"
 msgstr "Transação - Contas a Receber"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Transações - Contas a Receber"
 
@@ -177,8 +177,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Transação - Contas a Receber"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "Montante APagar/AReceber/Razão"
 
@@ -186,8 +186,8 @@ msgstr "Montante APagar/AReceber/Razão"
 msgid "Abandonment"
 msgstr "Abandono"
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Acesso não-permitido"
 
@@ -195,11 +195,11 @@ msgstr "Acesso não-permitido"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -224,22 +224,22 @@ msgstr "Conta"
 msgid "Account Description"
 msgstr "Descrição da conta"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Etiqueta de Conta"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Nome da Conta"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -320,7 +320,7 @@ msgstr "Resultado final"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -617,7 +617,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Velho"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -691,11 +691,11 @@ msgstr "Alocado"
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -713,11 +713,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Total"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -729,13 +729,13 @@ msgstr "Total Devido"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -799,9 +799,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -814,12 +814,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -835,16 +835,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Abr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -884,7 +884,7 @@ msgstr "Ativo"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1014,7 +1014,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ago"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Agosto"
 
@@ -1084,13 +1084,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balanço"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1176,12 +1176,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1262,15 +1262,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr "Negócio"
 msgid "Business Number"
 msgstr "Número de negócio"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1321,9 +1321,9 @@ msgstr "CMV"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1473,11 +1473,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Faturáveis"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Plano de Contas"
 
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1623,8 +1623,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1671,12 +1671,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1687,7 +1711,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Confirmar!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1715,7 +1739,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1772,7 +1796,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1860,7 +1884,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1872,7 +1896,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1900,7 +1924,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1911,7 +1935,7 @@ msgstr "Crédito"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1938,22 +1962,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Moeda"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1972,7 +1996,7 @@ msgstr "Moeda"
 msgid "Currency"
 msgstr "Moeda"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1988,8 +2012,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2052,7 +2076,7 @@ msgstr "Cliente não está no arquivo!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2129,17 +2153,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2169,8 +2193,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2249,7 +2273,7 @@ msgstr "Dia(s)"
 msgid "Days"
 msgstr "Dias"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2264,7 +2288,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2275,7 +2299,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dez"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Dezembro"
 
@@ -2360,11 +2384,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2377,7 +2401,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Apagar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2390,7 +2414,7 @@ msgstr "Apagar a Programação"
 msgid "Delete User"
 msgstr "Apagar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2413,21 +2437,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Data de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2435,11 +2459,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2461,7 +2485,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2482,15 +2506,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2507,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2581,7 +2605,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2607,16 +2631,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2624,11 +2648,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2660,6 +2684,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2668,11 +2696,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2686,11 +2714,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Desenho"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2699,9 +2727,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2731,7 +2759,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Endereço de e-mail faltando!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2892,7 +2920,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2949,14 +2977,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3000,7 +3028,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3009,7 +3037,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3018,7 +3046,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3043,7 +3071,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Nome da Empresa"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3080,7 +3108,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3088,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3100,7 +3128,7 @@ msgstr "Cada"
 msgid "Exch"
 msgstr "Câmbio"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3209,7 +3237,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Fev"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Fevereiro"
 
@@ -3225,7 +3253,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3369,7 +3397,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3392,11 +3420,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3427,7 +3455,7 @@ msgstr "Número de Referência da Conta"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3435,7 +3463,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3447,7 +3475,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3455,7 +3483,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Gerar"
@@ -3542,7 +3570,7 @@ msgstr ""
 msgid "HR"
 msgstr "Recursos Humanos"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3584,18 +3612,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3748,7 +3776,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3769,7 +3797,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3825,9 +3853,9 @@ msgstr "Inventário salvo!"
 msgid "Inventory transferred!"
 msgstr "Inventário transferido!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3856,7 +3884,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3871,10 +3899,10 @@ msgstr "Data da Fatura não encontrada!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3967,7 +3995,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Janeiro"
 
@@ -3999,7 +4027,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Julho"
 
@@ -4007,7 +4035,7 @@ msgstr "Julho"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Junho"
@@ -4040,7 +4068,7 @@ msgstr "Mão-de-Obra/Sobretaxa"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4268,7 +4296,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4357,11 +4385,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4382,7 +4410,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Março"
 
@@ -4399,12 +4427,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Mai"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4499,7 +4527,7 @@ msgstr "Mês(es)"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4533,15 +4561,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Nome"
@@ -4601,7 +4628,7 @@ msgid "Next Number"
 msgstr "Próximo Número"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4653,7 +4680,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4685,7 +4712,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4756,9 +4783,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4798,7 +4825,7 @@ msgstr "Nada a transferir!"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Novembro"
 
@@ -4843,8 +4870,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Número"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4861,7 +4888,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Obsoleto"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4869,7 +4896,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Out"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Outubro"
 
@@ -4944,7 +4971,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Pedido"
@@ -4976,7 +5003,7 @@ msgstr "Data do Pedido Faltando"
 msgid "Order Entry"
 msgstr "Entrada de Pedido"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5067,9 +5094,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5078,8 +5105,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5119,8 +5146,8 @@ msgstr "Número da lista de conteúdo faltando!"
 msgid "Packing list"
 msgstr "Lista de Conteúdo"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5148,7 +5175,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5177,7 +5204,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5245,7 +5272,7 @@ msgstr "A Pagar"
 msgid "Payment"
 msgstr "Pagamento"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5307,11 +5334,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5478,7 +5505,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5486,7 +5513,7 @@ msgstr ""
 msgid "Post"
 msgstr "Lançar"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5608,7 +5635,7 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimir"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5668,15 +5695,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5736,7 +5763,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5762,7 +5789,7 @@ msgid "Purchase Orders"
 msgstr "Ordens de Compra"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5779,7 +5806,7 @@ msgstr "Ordem de Compra"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5994,13 +6021,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Transações Recorrentes"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6070,12 +6097,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6087,7 +6114,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,7 +6182,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Requerido por"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6333,8 +6360,8 @@ msgstr "Númenro da Cotação de Vendas"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6512,7 +6539,7 @@ msgstr "Programação"
 msgid "Scheduled"
 msgstr "Programado"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Tela"
@@ -6696,7 +6723,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Vender"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6753,7 +6780,7 @@ msgstr "Set"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Setembro"
 
@@ -6773,7 +6800,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Nº Série"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6859,8 +6886,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6907,8 +6934,8 @@ msgstr "Data do Despacho faltando!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6979,8 +7006,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7026,14 +7053,14 @@ msgstr "Padrão"
 msgid "Standard Industrial Codes"
 msgstr "Códigos Industriais Padrão"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7057,7 +7084,7 @@ msgid "Startdate"
 msgstr "Data Inicial"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7109,8 +7136,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7222,8 +7249,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7231,8 +7258,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7553,8 +7580,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7633,7 +7660,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7679,14 +7706,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7708,7 +7735,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7736,7 +7763,7 @@ msgstr "Transação"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7750,7 +7777,7 @@ msgstr "Data de transação faltando!"
 msgid "Transaction Dates"
 msgstr "Datas das Transações"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7859,9 +7886,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7919,7 +7946,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7960,11 +7987,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8093,7 +8120,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8107,7 +8134,7 @@ msgstr "Usuário"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8155,7 +8182,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Faturáveis"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8164,8 +8191,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8239,7 +8266,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Fornecedor não está no arquivo!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8253,7 +8280,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8382,13 +8409,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8627,7 +8654,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/ru.po
+++ b/locale/po/ru.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Russian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -19,7 +19,7 @@ msgstr ""
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
 "%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr "# Счета на оплату"
 
@@ -106,7 +106,7 @@ msgstr "Счет-фактура КЗ"
 msgid "AP Invoices"
 msgstr "Счета-фактуры КЗ"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Задолженость поставщиков"
@@ -118,7 +118,7 @@ msgstr "Задолженость поставщиков"
 msgid "AP Transaction"
 msgstr "Проводка закупки"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Проводки закупки"
 
@@ -153,7 +153,7 @@ msgstr "Счет-фактура ДЗ"
 msgid "AR Invoices"
 msgstr "Счета-фактуры ДЗ"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Задолженость клиентов"
@@ -164,7 +164,7 @@ msgstr "Задолженость клиентов"
 msgid "AR Transaction"
 msgstr "Проводка продаж"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Проводки продаж"
 
@@ -181,8 +181,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Проводка продаж"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr "ДЗ/КЗ/ГК Amount"
 
@@ -190,8 +190,8 @@ msgstr "ДЗ/КЗ/ГК Amount"
 msgid "Abandonment"
 msgstr "Отказ"
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr "Доступ невозможен"
 
@@ -199,11 +199,11 @@ msgstr "Доступ невозможен"
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -228,22 +228,22 @@ msgstr "Счет"
 msgid "Account Description"
 msgstr "Описание счета"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr "Маркировка счета"
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr "Название счета"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -324,7 +324,7 @@ msgstr "Начисление"
 msgid "Accrual Basis:"
 msgstr "База начисления"
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr "Накопленный износ"
 
@@ -621,7 +621,7 @@ msgstr "Корректировка"
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr "Детали корректировки"
 msgid "Aged"
 msgstr "Возраст определен"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr "Период определения возраста"
 
@@ -695,11 +695,11 @@ msgstr "Размещено"
 msgid "Allow Input"
 msgstr "Разрешить ввод"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -717,11 +717,11 @@ msgstr "Разрешить ввод"
 msgid "Amount"
 msgstr "Сумма"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr "Сумма в бюджете"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -733,13 +733,13 @@ msgstr "Сумма к получению"
 msgid "Amount From"
 msgstr "Сумма из"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr "Сумма больше чем"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr "Сумма меньше чем"
 
@@ -803,9 +803,9 @@ msgid "Approval Status"
 msgstr "Статус для подтверждения"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr "Подтвердить"
@@ -818,12 +818,12 @@ msgstr "Подтвердить"
 msgid "Approved"
 msgstr "Подтверждено"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr "Подтверждено "
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr "Подтверждено в"
 
@@ -839,16 +839,16 @@ msgstr ""
 msgid "Apr"
 msgstr "апр"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "апрель"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -888,7 +888,7 @@ msgstr "Актив"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -913,7 +913,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "Aug"
 msgstr "авг"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "август"
 
@@ -1088,13 +1088,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Баланс"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1180,12 +1180,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1266,15 +1266,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1290,7 +1290,7 @@ msgstr "Бизнес"
 msgid "Business Number"
 msgstr "Бизнес-код"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1325,9 +1325,9 @@ msgstr "COGS"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1343,7 +1343,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1476,11 +1476,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr "Возмещаемый"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "План счетов"
 
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1626,8 +1626,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1674,12 +1674,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1690,7 +1714,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Подтвердить!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1718,7 +1742,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1775,7 +1799,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1863,7 +1887,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1875,7 +1899,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1903,7 +1927,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1914,7 +1938,7 @@ msgstr "Кредит"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1941,22 +1965,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Валюта"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1975,7 +1999,7 @@ msgstr "Валюта"
 msgid "Currency"
 msgstr "Валюта"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1991,8 +2015,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2055,7 +2079,7 @@ msgstr "Клиент отсутствует в справочнике!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2132,17 +2156,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2172,8 +2196,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2252,7 +2276,7 @@ msgstr "День"
 msgid "Days"
 msgstr "Дней"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2267,7 +2291,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2278,7 +2302,7 @@ msgstr ""
 msgid "Dec"
 msgstr "дек"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "декабрь"
 
@@ -2363,11 +2387,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2380,7 +2404,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Удалить"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2393,7 +2417,7 @@ msgstr "Удалить расписание"
 msgid "Delete User"
 msgstr "Удалить"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2416,21 +2440,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Дата получения"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2438,11 +2462,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2464,7 +2488,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2485,15 +2509,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2510,13 +2534,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2584,7 +2608,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2610,16 +2634,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2627,11 +2651,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2663,6 +2687,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2671,11 +2699,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2689,11 +2717,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Изображение"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2702,9 +2730,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2734,7 +2762,7 @@ msgstr "E-mail"
 msgid "E-mail address missing!"
 msgstr "Не указан адрес E-mail!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2895,7 +2923,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2952,14 +2980,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3012,7 +3040,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3021,7 +3049,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3046,7 +3074,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Наименование организации"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3083,7 +3111,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3091,7 +3119,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3103,7 +3131,7 @@ msgstr "каждый"
 msgid "Exch"
 msgstr "Курс"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3212,7 +3240,7 @@ msgstr ""
 msgid "Feb"
 msgstr "фев"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "февраль"
 
@@ -3228,7 +3256,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3372,7 +3400,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3395,11 +3423,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3430,7 +3458,7 @@ msgstr "Номер справочника Главной книги"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3438,7 +3466,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3450,7 +3478,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3458,7 +3486,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Создать"
@@ -3545,7 +3573,7 @@ msgstr ""
 msgid "HR"
 msgstr "Сотрудники"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3587,18 +3615,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3751,7 +3779,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3772,7 +3800,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3828,9 +3856,9 @@ msgstr "Инвентарь сохранен!"
 msgid "Inventory transferred!"
 msgstr "Инвентарь перемещен!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3859,7 +3887,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3874,10 +3902,10 @@ msgstr "Не указана дата выставления счета-факт�
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3970,7 +3998,7 @@ msgstr ""
 msgid "Jan"
 msgstr "янв"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "январь"
 
@@ -4002,7 +4030,7 @@ msgstr ""
 msgid "Jul"
 msgstr "июл"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "июль"
 
@@ -4010,7 +4038,7 @@ msgstr "июль"
 msgid "Jun"
 msgstr "июн"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "июнь"
@@ -4043,7 +4071,7 @@ msgstr "Работа/накладные расходы"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4271,7 +4299,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4360,11 +4388,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4385,7 +4413,7 @@ msgstr ""
 msgid "Mar"
 msgstr "март"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "март"
 
@@ -4402,12 +4430,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "май"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4502,7 +4530,7 @@ msgstr "месяц"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4536,15 +4564,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Наименование"
@@ -4604,7 +4631,7 @@ msgid "Next Number"
 msgstr "Следующий номер"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4656,7 +4683,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4688,7 +4715,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4759,9 +4786,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4801,7 +4828,7 @@ msgstr "Ничего не перемещено!"
 msgid "Nov"
 msgstr "ноя"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "ноябрь"
 
@@ -4846,8 +4873,8 @@ msgstr ""
 msgid "Number:"
 msgstr "код"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4864,7 +4891,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Устаревший"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4872,7 +4899,7 @@ msgstr ""
 msgid "Oct"
 msgstr "окт"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "октябрь"
 
@@ -4947,7 +4974,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Заказ клиента"
@@ -4979,7 +5006,7 @@ msgstr "Пропущена дата заказа"
 msgid "Order Entry"
 msgstr "Заказы"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5070,9 +5097,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5081,8 +5108,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5122,8 +5149,8 @@ msgstr "Пропущен номер упаковочного списока!"
 msgid "Packing list"
 msgstr "Упаковочный список"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5151,7 +5178,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5180,7 +5207,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5248,7 +5275,7 @@ msgstr "Подлежащий оплате"
 msgid "Payment"
 msgstr "Оплата"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5310,11 +5337,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5481,7 +5508,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5489,7 +5516,7 @@ msgstr ""
 msgid "Post"
 msgstr "Сохранить"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5611,7 +5638,7 @@ msgstr ""
 msgid "Print"
 msgstr "Печать"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5671,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5739,7 +5766,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5765,7 +5792,7 @@ msgid "Purchase Orders"
 msgstr "Заказы поставщику"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5782,7 +5809,7 @@ msgstr "Заказ поставщику"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5997,13 +6024,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Повторяющиеся проводки"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6073,12 +6100,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6090,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6158,7 +6185,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Запрошен"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6336,8 +6363,8 @@ msgstr "Номер продажи резерва"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6515,7 +6542,7 @@ msgstr "Расписание"
 msgid "Scheduled"
 msgstr "Назначено расписание"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Экран"
@@ -6699,7 +6726,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Продажа"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6756,7 +6783,7 @@ msgstr "сен"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "сентябрь"
 
@@ -6776,7 +6803,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Серийный ном."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6862,8 +6889,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6910,8 +6937,8 @@ msgstr "Пропущена дата доставки"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6982,8 +7009,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7029,14 +7056,14 @@ msgstr "Стандартные"
 msgid "Standard Industrial Codes"
 msgstr "Стандартный промышленный код"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7060,7 +7087,7 @@ msgid "Startdate"
 msgstr "Начальная дата"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7112,8 +7139,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7225,8 +7252,8 @@ msgstr "ИТОГО"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr "Тег"
 
@@ -7234,8 +7261,8 @@ msgstr "Тег"
 msgid "Tag:"
 msgstr "Тег:"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7556,8 +7583,8 @@ msgstr ""
 msgid "Thu"
 msgstr "Чтв"
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7636,7 +7663,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7682,14 +7709,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7711,7 +7738,7 @@ msgstr ""
 msgid "Total"
 msgstr "Итого"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7739,7 +7766,7 @@ msgstr "Проводка"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7753,7 +7780,7 @@ msgstr "Пропущена Дата проводки!"
 msgid "Transaction Dates"
 msgstr "Дата проводки"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7862,9 +7889,9 @@ msgid "Two"
 msgstr "Два"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7922,7 +7949,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7963,11 +7990,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8096,7 +8123,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8110,7 +8137,7 @@ msgstr "Сотрудник"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8158,7 +8185,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Возмещаемый"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8167,8 +8194,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8242,7 +8269,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Поставщика нет в справочнике!"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8256,7 +8283,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8385,13 +8412,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8630,7 +8657,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/sv.po
+++ b/locale/po/sv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Leverantörsskulder"
@@ -110,7 +110,7 @@ msgstr "Leverantörsskulder"
 msgid "AP Transaction"
 msgstr "Betald kostnad"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Leverantörsfakturor"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Kundfordringar"
@@ -156,7 +156,7 @@ msgstr "Kundfordringar"
 msgid "AR Transaction"
 msgstr "Betald fodran"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Kundfakturor"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Betald fodran"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Konto"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr "Utgången"
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr "Kopplad"
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Belopp"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "Förfallet belopp"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Apr"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "Tillgång"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Aug"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Augusti"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Balans"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "Verksamhet"
 msgid "Business Number"
 msgstr "Organisationsnummer"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "Inköpskostnader"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1469,11 +1469,11 @@ msgstr "Ändra lösenord"
 msgid "Chargeable"
 msgstr "Debiterbar"
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Kontoplan"
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1619,8 +1619,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1667,12 +1667,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1683,7 +1707,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Bekräfta!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1711,7 +1735,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1768,7 +1792,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1856,7 +1880,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1868,7 +1892,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1896,7 +1920,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1907,7 +1931,7 @@ msgstr "Kredit"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1934,22 +1958,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1968,7 +1992,7 @@ msgstr "Valuta"
 msgid "Currency"
 msgstr "Valuta"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1984,8 +2008,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2048,7 +2072,7 @@ msgstr "Kund finns ej"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2125,17 +2149,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2165,8 +2189,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2245,7 +2269,7 @@ msgstr "Dag(ar"
 msgid "Days"
 msgstr "Dagar"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2260,7 +2284,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2271,7 +2295,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "December"
 
@@ -2356,11 +2380,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2373,7 +2397,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Radera"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2386,7 +2410,7 @@ msgstr "Ta bort schemaläggning"
 msgid "Delete User"
 msgstr "Radera"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2409,21 +2433,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Leveransdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2431,11 +2455,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2457,7 +2481,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2478,15 +2502,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2503,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2577,7 +2601,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2603,16 +2627,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2620,11 +2644,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2656,6 +2680,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2664,11 +2692,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2682,11 +2710,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Ritning"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2695,9 +2723,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2727,7 +2755,7 @@ msgstr "E-Post"
 msgid "E-mail address missing!"
 msgstr "E-Postadress saknas"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2888,7 +2916,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2945,14 +2973,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2996,7 +3024,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3005,7 +3033,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3014,7 +3042,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3039,7 +3067,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Företags namn"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3076,7 +3104,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3084,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3096,7 +3124,7 @@ msgstr "Varje"
 msgid "Exch"
 msgstr "Vxl"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3205,7 +3233,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Feb"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Februari"
 
@@ -3221,7 +3249,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3365,7 +3393,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3388,11 +3416,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3423,7 +3451,7 @@ msgstr "Huvudboks verifikat nr"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3431,7 +3459,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3443,7 +3471,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3451,7 +3479,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Skapa"
@@ -3538,7 +3566,7 @@ msgstr ""
 msgid "HR"
 msgstr "Mänskligt kapital"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3580,18 +3608,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3744,7 +3772,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3765,7 +3793,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3820,9 +3848,9 @@ msgstr "Lager sparat"
 msgid "Inventory transferred!"
 msgstr "Lager överfört"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3851,7 +3879,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3866,10 +3894,10 @@ msgstr "Fakturadatum saknas"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3962,7 +3990,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Jan"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Januari"
 
@@ -3994,7 +4022,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Jul"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Juli"
 
@@ -4002,7 +4030,7 @@ msgstr "Juli"
 msgid "Jun"
 msgstr "Jun"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Juni"
@@ -4035,7 +4063,7 @@ msgstr "Arbetskostnader"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4263,7 +4291,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4352,11 +4380,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4377,7 +4405,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Mars"
 
@@ -4394,12 +4422,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "Maj"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4494,7 +4522,7 @@ msgstr "Månad(er)"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4528,15 +4556,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Namn"
@@ -4596,7 +4623,7 @@ msgid "Next Number"
 msgstr "Nästa nummer"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4648,7 +4675,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4680,7 +4707,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4751,9 +4778,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4793,7 +4820,7 @@ msgstr "Inget att överföra"
 msgid "Nov"
 msgstr "Nov"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "November"
 
@@ -4838,8 +4865,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Nummer"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4856,7 +4883,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Utgången"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4864,7 +4891,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Okt"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Oktober"
 
@@ -4939,7 +4966,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Order"
@@ -4971,7 +4998,7 @@ msgstr "Orderdatum saknas"
 msgid "Order Entry"
 msgstr "Beställningar"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5062,9 +5089,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "Förtryckt blankett"
 
@@ -5073,8 +5100,8 @@ msgstr "Förtryckt blankett"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5114,8 +5141,8 @@ msgstr "Packsedelsnummer saknas"
 msgid "Packing list"
 msgstr "Packsedel"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5143,7 +5170,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5172,7 +5199,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5240,7 +5267,7 @@ msgstr "Utbetalningar"
 msgid "Payment"
 msgstr "Bocka av utförd betalning"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5302,11 +5329,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5473,7 +5500,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5481,7 +5508,7 @@ msgstr ""
 msgid "Post"
 msgstr "Bokför"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5603,7 +5630,7 @@ msgstr ""
 msgid "Print"
 msgstr "Skriv ut"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5663,15 +5690,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5731,7 +5758,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5757,7 +5784,7 @@ msgid "Purchase Orders"
 msgstr "Inköpsordrar"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5774,7 +5801,7 @@ msgstr "Inköpsorder"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5989,13 +6016,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Återkommande transaktion"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6065,12 +6092,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6082,7 +6109,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6150,7 +6177,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Beställt den"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6328,8 +6355,8 @@ msgstr "Säljoffert nr"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6507,7 +6534,7 @@ msgstr "Schemalägg"
 msgid "Scheduled"
 msgstr "Schemalagd"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Skärm"
@@ -6691,7 +6718,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Sälj"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6748,7 +6775,7 @@ msgstr "Sep"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "September"
 
@@ -6768,7 +6795,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Serie nr."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6854,8 +6881,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6902,8 +6929,8 @@ msgstr "Leveransdatum saknas"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6974,8 +7001,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7021,14 +7048,14 @@ msgstr "Standard"
 msgid "Standard Industrial Codes"
 msgstr "Standard industrikoder"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7052,7 +7079,7 @@ msgid "Startdate"
 msgstr "Startdatum"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7104,8 +7131,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7217,8 +7244,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7226,8 +7253,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7548,8 +7575,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7628,7 +7655,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7674,14 +7701,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7703,7 +7730,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,7 +7758,7 @@ msgstr "Transaktion"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7745,7 +7772,7 @@ msgstr "Transaktionsdatum saknas"
 msgid "Transaction Dates"
 msgstr "Överföringsdatum"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7854,9 +7881,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7914,7 +7941,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7955,11 +7982,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8088,7 +8115,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8102,7 +8129,7 @@ msgstr "Användare"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8150,7 +8177,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Debiterbar"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8159,8 +8186,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8234,7 +8261,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Leverantör finns ej"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8248,7 +8275,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8377,13 +8404,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8622,7 +8649,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/tr.po
+++ b/locale/po/tr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr ""
@@ -110,7 +110,7 @@ msgstr ""
 msgid "AP Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Borç İşlemleri"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "AR Transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Alacak İşlemleri"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Alacak İşlemleri"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "Hesap"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -686,11 +686,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -708,11 +708,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Miktar"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -724,13 +724,13 @@ msgstr ""
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -794,9 +794,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -809,12 +809,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -830,16 +830,16 @@ msgstr ""
 msgid "Apr"
 msgstr "Nis"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Nisan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr "Aktif"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Aug"
 msgstr "Ağu"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Ağustos"
 
@@ -1079,13 +1079,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr ""
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1171,12 +1171,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1256,15 +1256,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1280,7 +1280,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "ŞirketNo"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1315,9 +1315,9 @@ msgstr "SMM"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1333,7 +1333,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1465,11 +1465,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "Hesap Planı"
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1615,8 +1615,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1663,12 +1663,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1679,7 +1703,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Onayla!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1707,7 +1731,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1764,7 +1788,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1852,7 +1876,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1864,7 +1888,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1892,7 +1916,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1903,7 +1927,7 @@ msgstr "Alacak"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1930,22 +1954,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1964,7 +1988,7 @@ msgstr ""
 msgid "Currency"
 msgstr "Para Birimi"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1980,8 +2004,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2044,7 +2068,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2121,17 +2145,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2161,8 +2185,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2241,7 +2265,7 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2256,7 +2280,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2267,7 +2291,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Ara"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Aralık"
 
@@ -2352,11 +2376,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2369,7 +2393,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Sil"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2382,7 +2406,7 @@ msgstr ""
 msgid "Delete User"
 msgstr "Sil"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2405,21 +2429,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2427,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2453,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2474,15 +2498,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2499,13 +2523,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2573,7 +2597,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2599,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2616,11 +2640,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2652,6 +2676,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2660,11 +2688,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2678,11 +2706,11 @@ msgstr ""
 msgid "Drawing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2691,9 +2719,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2723,7 +2751,7 @@ msgstr "Posta"
 msgid "E-mail address missing!"
 msgstr "Posta adresi yok!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2884,7 +2912,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2940,14 +2968,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2991,7 +3019,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3000,7 +3028,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3009,7 +3037,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3033,7 +3061,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3070,7 +3098,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3078,7 +3106,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "Exch"
 msgstr "D.Kuru"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3199,7 +3227,7 @@ msgstr ""
 msgid "Feb"
 msgstr "Şub"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Şubat"
 
@@ -3215,7 +3243,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3359,7 +3387,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3382,11 +3410,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3417,7 +3445,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3425,7 +3453,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3445,7 +3473,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr ""
@@ -3532,7 +3560,7 @@ msgstr ""
 msgid "HR"
 msgstr ""
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3574,18 +3602,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3738,7 +3766,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3759,7 +3787,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3813,9 +3841,9 @@ msgstr ""
 msgid "Inventory transferred!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3844,7 +3872,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3859,10 +3887,10 @@ msgstr "Fatura Tarihi yok!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3955,7 +3983,7 @@ msgstr ""
 msgid "Jan"
 msgstr "Oca"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "Ocak"
 
@@ -3987,7 +4015,7 @@ msgstr ""
 msgid "Jul"
 msgstr "Tem"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Temmuz"
 
@@ -3995,7 +4023,7 @@ msgstr "Temmuz"
 msgid "Jun"
 msgstr "Haz"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Haziran"
@@ -4028,7 +4056,7 @@ msgstr ""
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4256,7 +4284,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4345,11 +4373,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4370,7 +4398,7 @@ msgstr ""
 msgid "Mar"
 msgstr "Mar"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Mart"
 
@@ -4387,12 +4415,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "May"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4487,7 +4515,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4521,15 +4549,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "İsim"
@@ -4589,7 +4616,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4641,7 +4668,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4673,7 +4700,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4744,9 +4771,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4786,7 +4813,7 @@ msgstr ""
 msgid "Nov"
 msgstr "Kas"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Kasım"
 
@@ -4831,8 +4858,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Numara"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4849,7 +4876,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Eski"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4857,7 +4884,7 @@ msgstr ""
 msgid "Oct"
 msgstr "Eki"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Ekim"
 
@@ -4932,7 +4959,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "Sipariş"
@@ -4964,7 +4991,7 @@ msgstr "Sipariş Tarihi yok!"
 msgid "Order Entry"
 msgstr "Sipariş Girişi"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5054,9 +5081,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr ""
 
@@ -5065,8 +5092,8 @@ msgstr ""
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5106,8 +5133,8 @@ msgstr ""
 msgid "Packing list"
 msgstr "Paketleme Listesi"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5135,7 +5162,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5164,7 +5191,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5232,7 +5259,7 @@ msgstr "Borçlar"
 msgid "Payment"
 msgstr "Ödeme"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5294,11 +5321,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5464,7 +5491,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5472,7 +5499,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5594,7 +5621,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5654,15 +5681,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5749,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5748,7 +5775,7 @@ msgid "Purchase Orders"
 msgstr "Satınalma Siparişleri"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5765,7 +5792,7 @@ msgstr "Satınalma Siparişi"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5979,13 +6006,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6055,12 +6082,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6072,7 +6099,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6139,7 +6166,7 @@ msgstr ""
 msgid "Required by"
 msgstr "Talep tarihi:"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6316,8 +6343,8 @@ msgstr ""
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6495,7 +6522,7 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr ""
@@ -6679,7 +6706,7 @@ msgstr ""
 msgid "Sell"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6736,7 +6763,7 @@ msgstr "Eyl"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Eylül"
 
@@ -6756,7 +6783,7 @@ msgstr ""
 msgid "Serial No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6841,8 +6868,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6889,8 +6916,8 @@ msgstr ""
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6960,8 +6987,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7007,14 +7034,14 @@ msgstr ""
 msgid "Standard Industrial Codes"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7038,7 +7065,7 @@ msgid "Startdate"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7090,8 +7117,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7202,8 +7229,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7211,8 +7238,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7532,8 +7559,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7612,7 +7639,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7658,14 +7685,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7687,7 +7714,7 @@ msgstr ""
 msgid "Total"
 msgstr "Toplam"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7715,7 +7742,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7729,7 +7756,7 @@ msgstr "İşlem Tarihi yok!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7838,9 +7865,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7898,7 +7925,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7939,11 +7966,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8072,7 +8099,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8086,7 +8113,7 @@ msgstr "Kullanıcı"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8134,7 +8161,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Vergiye tabi"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8143,8 +8170,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8218,7 +8245,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8232,7 +8259,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8360,13 +8387,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8605,7 +8632,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/uk.po
+++ b/locale/po/uk.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -18,7 +18,7 @@ msgstr ""
 "> 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % "
 "100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -101,7 +101,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "Несплачені рахунки витрат"
@@ -113,7 +113,7 @@ msgstr "Несплачені рахунки витрат"
 msgid "AP Transaction"
 msgstr "Проводка витрат"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "Проводки витрат"
 
@@ -148,7 +148,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "Несплачені рахунки доходів"
@@ -159,7 +159,7 @@ msgstr "Несплачені рахунки доходів"
 msgid "AR Transaction"
 msgstr "Проводка доходів"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "Проводки доходів"
 
@@ -176,8 +176,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "Проводка доходів"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -185,8 +185,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -194,11 +194,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -223,22 +223,22 @@ msgstr "Рахунок"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -616,7 +616,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -690,11 +690,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -712,11 +712,11 @@ msgstr ""
 msgid "Amount"
 msgstr "Сума"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -728,13 +728,13 @@ msgstr "Заплатити суму"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -798,9 +798,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -813,12 +813,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -834,16 +834,16 @@ msgstr ""
 msgid "Apr"
 msgstr "квітня"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "Квітень"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -883,7 +883,7 @@ msgstr "Актив"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -908,7 +908,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Aug"
 msgstr "серпня"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "Серпень"
 
@@ -1083,13 +1083,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "Баланс"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1175,12 +1175,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1261,15 +1261,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1285,7 +1285,7 @@ msgstr ""
 msgid "Business Number"
 msgstr "Бізнес-номер"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1320,9 +1320,9 @@ msgstr "COGS"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1470,11 +1470,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "План Рахунків"
 
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1620,8 +1620,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1668,12 +1668,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1684,7 +1708,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "Підтвердіть!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1712,7 +1736,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1769,7 +1793,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1857,7 +1881,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1869,7 +1893,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1897,7 +1921,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1908,7 +1932,7 @@ msgstr "Кредит"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1935,22 +1959,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "Валюта"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1969,7 +1993,7 @@ msgstr "Валюта"
 msgid "Currency"
 msgstr "Валюта"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1985,8 +2009,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2049,7 +2073,7 @@ msgstr "Клієнта нема в списку!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2126,17 +2150,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2166,8 +2190,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2246,7 +2270,7 @@ msgstr ""
 msgid "Days"
 msgstr "Дні(в)"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2261,7 +2285,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2272,7 +2296,7 @@ msgstr ""
 msgid "Dec"
 msgstr "грудня"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "Грудень"
 
@@ -2357,11 +2381,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2374,7 +2398,7 @@ msgstr ""
 msgid "Delete"
 msgstr "Видалити"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2387,7 +2411,7 @@ msgstr "Видалити розклад"
 msgid "Delete User"
 msgstr "Видалити"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2410,21 +2434,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "Дата доставки"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2432,11 +2456,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2458,7 +2482,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2479,15 +2503,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2504,13 +2528,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2578,7 +2602,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2604,16 +2628,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2621,11 +2645,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2657,6 +2681,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2665,11 +2693,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2683,11 +2711,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "Малюнок"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2696,9 +2724,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2728,7 +2756,7 @@ msgstr "Ел. пошта"
 msgid "E-mail address missing!"
 msgstr "Не вказана адреса ел. пошти!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2889,7 +2917,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2946,14 +2974,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2997,7 +3025,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3006,7 +3034,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3015,7 +3043,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3040,7 +3068,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "Назва підприємства"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3077,7 +3105,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3085,7 +3113,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3097,7 +3125,7 @@ msgstr "Кожні"
 msgid "Exch"
 msgstr "Курс"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3206,7 +3234,7 @@ msgstr ""
 msgid "Feb"
 msgstr "лютого"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "Лютий"
 
@@ -3222,7 +3250,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3366,7 +3394,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3389,11 +3417,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3424,7 +3452,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3432,7 +3460,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3444,7 +3472,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3452,7 +3480,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "Створити"
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "HR"
 msgstr "HR"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3581,18 +3609,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3745,7 +3773,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3766,7 +3794,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3822,9 +3850,9 @@ msgstr "Інвентар збережено!"
 msgid "Inventory transferred!"
 msgstr "Інвентар перенесено!"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3853,7 +3881,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3868,10 +3896,10 @@ msgstr "Не вказана дата виставлення рахунка-фа�
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3964,7 +3992,7 @@ msgstr ""
 msgid "Jan"
 msgstr "січня"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "січень"
 
@@ -3996,7 +4024,7 @@ msgstr ""
 msgid "Jul"
 msgstr "липня"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "Липень"
 
@@ -4004,7 +4032,7 @@ msgstr "Липень"
 msgid "Jun"
 msgstr "червня"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "Червень"
@@ -4037,7 +4065,7 @@ msgstr "Робота/додаткові витрати"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4265,7 +4293,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4354,11 +4382,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4379,7 +4407,7 @@ msgstr ""
 msgid "Mar"
 msgstr "березня"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "Березень"
 
@@ -4396,12 +4424,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "травня"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4496,7 +4524,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4530,15 +4558,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "Назва"
@@ -4598,7 +4625,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4650,7 +4677,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4682,7 +4709,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4753,9 +4780,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4795,7 +4822,7 @@ msgstr "Нема що перенести"
 msgid "Nov"
 msgstr "листопада"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "Листопад"
 
@@ -4840,8 +4867,8 @@ msgstr ""
 msgid "Number:"
 msgstr "Номер"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4858,7 +4885,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "Застаріле"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4866,7 +4893,7 @@ msgstr ""
 msgid "Oct"
 msgstr "жовтня"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "Жовтень"
 
@@ -4941,7 +4968,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr ""
@@ -4973,7 +5000,7 @@ msgstr "Не вказано дату замовлення!"
 msgid "Order Entry"
 msgstr "Виставлення замовлення"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5064,9 +5091,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5075,8 +5102,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5116,8 +5143,8 @@ msgstr "Не вказано номер пакувального списку"
 msgid "Packing list"
 msgstr "Пакувальний список"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5145,7 +5172,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5174,7 +5201,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5242,7 +5269,7 @@ msgstr "Зобовязання (платіжні)"
 msgid "Payment"
 msgstr "Платіж"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5304,11 +5331,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5475,7 +5502,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5483,7 +5510,7 @@ msgstr ""
 msgid "Post"
 msgstr "Виставити"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5605,7 +5632,7 @@ msgstr ""
 msgid "Print"
 msgstr "Надрукувати"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5665,15 +5692,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5733,7 +5760,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5759,7 +5786,7 @@ msgid "Purchase Orders"
 msgstr "Купівельні замовлення"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5776,7 +5803,7 @@ msgstr "Купівельне замовлення"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5989,13 +6016,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "Періодичні проводки"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6065,12 +6092,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6082,7 +6109,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6150,7 +6177,7 @@ msgstr ""
 msgid "Required by"
 msgstr ""
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6328,8 +6355,8 @@ msgstr "Не вдається видалити котирування!"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6507,7 +6534,7 @@ msgstr "Розклад"
 msgid "Scheduled"
 msgstr "В розкладі"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "Екран"
@@ -6691,7 +6718,7 @@ msgstr ""
 msgid "Sell"
 msgstr "Продати"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6748,7 +6775,7 @@ msgstr "вересня"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "Вересень"
 
@@ -6768,7 +6795,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "Серійний No."
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6854,8 +6881,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6902,8 +6929,8 @@ msgstr "Відсутня дата відсилання!"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6974,8 +7001,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7021,14 +7048,14 @@ msgstr "Стандартні"
 msgid "Standard Industrial Codes"
 msgstr "Стандартні індустріальні коди"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7052,7 +7079,7 @@ msgid "Startdate"
 msgstr "Дата початку"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7104,8 +7131,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7217,8 +7244,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7226,8 +7253,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7548,8 +7575,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7628,7 +7655,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7674,14 +7701,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7703,7 +7730,7 @@ msgstr ""
 msgid "Total"
 msgstr "Загальна Сума"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,7 +7758,7 @@ msgstr ""
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7745,7 +7772,7 @@ msgstr "Не вказана дата проводки"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7854,9 +7881,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7914,7 +7941,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7955,11 +7982,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8088,7 +8115,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8102,7 +8129,7 @@ msgstr "Користувач"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8150,7 +8177,7 @@ msgstr ""
 msgid "Variable"
 msgstr "Оподатковується"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8159,8 +8186,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8234,7 +8261,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "Потачальника нема у списку "
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8248,7 +8275,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8377,13 +8404,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8622,7 +8649,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/zh_CN.po
+++ b/locale/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "应付未付"
@@ -110,7 +110,7 @@ msgstr "应付未付"
 msgid "AP Transaction"
 msgstr "应付交易"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "应付交易"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "应收未收"
@@ -156,7 +156,7 @@ msgstr "应收未收"
 msgid "AR Transaction"
 msgstr "应收交易"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "应收交易"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "应收交易"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "帐户"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "总计"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "应得的总计"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "四月"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "四月"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "资产"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "八月"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "八月"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "余额"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "业务"
 msgid "Business Number"
 msgstr "业务编号"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "货销成本"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "会计科目表"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "入帐成功!"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "贷方"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "目前"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "目前"
 msgid "Currency"
 msgstr "币别"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "客户未存档"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr "日"
 msgid "Days"
 msgstr "日"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "十二月"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "十二月"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "删除"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr "删除预定"
 msgid "Delete User"
 msgstr "删除"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "图画"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "电子邮件"
 msgid "E-mail address missing!"
 msgstr "未指明电子邮件位址!"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "公司名称"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr ""
 msgid "Exch"
 msgstr "汇率"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "二月"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "二月"
 
@@ -3219,7 +3247,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "产生"
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "人事管理"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3817,9 +3845,9 @@ msgstr "巳储存存货"
 msgid "Inventory transferred!"
 msgstr "转移的存货"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3848,7 +3876,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3863,10 +3891,10 @@ msgstr "未指明发票日期!"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3959,7 +3987,7 @@ msgstr ""
 msgid "Jan"
 msgstr "一月"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "一月"
 
@@ -3991,7 +4019,7 @@ msgstr ""
 msgid "Jul"
 msgstr "七月"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "七月"
 
@@ -3999,7 +4027,7 @@ msgstr "七月"
 msgid "Jun"
 msgstr "六月"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "六月"
@@ -4032,7 +4060,7 @@ msgstr "劳工/经常费用"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4260,7 +4288,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4349,11 +4377,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4374,7 +4402,7 @@ msgstr ""
 msgid "Mar"
 msgstr "三月"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "三月"
 
@@ -4391,12 +4419,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "五月"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4491,7 +4519,7 @@ msgstr "月"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4525,15 +4553,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "名称"
@@ -4593,7 +4620,7 @@ msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4645,7 +4672,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4677,7 +4704,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4748,9 +4775,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4790,7 +4817,7 @@ msgstr "没有可转移的项目"
 msgid "Nov"
 msgstr "十一月"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "十一月"
 
@@ -4835,8 +4862,8 @@ msgstr ""
 msgid "Number:"
 msgstr "编号"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4853,7 +4880,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "停用"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4861,7 +4888,7 @@ msgstr ""
 msgid "Oct"
 msgstr "十月"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "十月"
 
@@ -4936,7 +4963,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "订单"
@@ -4968,7 +4995,7 @@ msgstr "未指明下单日期!"
 msgid "Order Entry"
 msgstr "下单项目"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5059,9 +5086,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5070,8 +5097,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5111,8 +5138,8 @@ msgstr "未指明包装清单编号!"
 msgid "Packing list"
 msgstr "出货单"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5140,7 +5167,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5169,7 +5196,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5237,7 +5264,7 @@ msgstr "应付科目"
 msgid "Payment"
 msgstr "付款"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5299,11 +5326,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5470,7 +5497,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5478,7 +5505,7 @@ msgstr ""
 msgid "Post"
 msgstr "加入"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5600,7 +5627,7 @@ msgstr ""
 msgid "Print"
 msgstr "列印"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5660,15 +5687,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5728,7 +5755,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5754,7 +5781,7 @@ msgid "Purchase Orders"
 msgstr "采购单"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5771,7 +5798,7 @@ msgstr "采购单"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5986,13 +6013,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "多次记录"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6062,12 +6089,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6079,7 +6106,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6147,7 +6174,7 @@ msgstr ""
 msgid "Required by"
 msgstr "需要者"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6325,8 +6352,8 @@ msgstr "报价单编号"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6504,7 +6531,7 @@ msgstr "预定"
 msgid "Scheduled"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "萤幕"
@@ -6688,7 +6715,7 @@ msgstr ""
 msgid "Sell"
 msgstr "卖价"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6745,7 +6772,7 @@ msgstr "九月"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "九月"
 
@@ -6765,7 +6792,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "序号"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6851,8 +6878,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6899,8 +6926,8 @@ msgstr "未指明海运日期"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6971,8 +6998,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7018,14 +7045,14 @@ msgstr "标准"
 msgid "Standard Industrial Codes"
 msgstr "标准工业编码"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7049,7 +7076,7 @@ msgid "Startdate"
 msgstr "开始日期"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7101,8 +7128,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 msgid "Status"
 msgstr ""
@@ -7213,8 +7240,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7222,8 +7249,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7544,8 +7571,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7624,7 +7651,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7670,14 +7697,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7699,7 +7726,7 @@ msgstr ""
 msgid "Total"
 msgstr "总计"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7727,7 +7754,7 @@ msgstr "记录"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7741,7 +7768,7 @@ msgstr "未指明交易日期!"
 msgid "Transaction Dates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7850,9 +7877,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7910,7 +7937,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7951,11 +7978,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8084,7 +8111,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8098,7 +8125,7 @@ msgstr "使用者"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8146,7 +8173,7 @@ msgstr ""
 msgid "Variable"
 msgstr "应税"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8155,8 +8182,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8230,7 +8257,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "档案没有此供应商"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8244,7 +8271,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8373,13 +8400,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8618,7 +8645,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/locale/po/zh_TW.po
+++ b/locale/po/zh_TW.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2022-07-24 17:53+0000\n"
+"POT-Creation-Date: 2022-07-28 08:16+0000\n"
 "PO-Revision-Date: 2019-01-21 05:20+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:174
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:182
 msgid "# Invoices"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "AP Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:309
 #: UI/Reports/filters/invoice_outstanding.html:4
 msgid "AP Outstanding"
 msgstr "應付未付"
@@ -110,7 +110,7 @@ msgstr "應付未付"
 msgid "AP Transaction"
 msgstr "應付交易"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:131
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:130
 msgid "AP Transactions"
 msgstr "應付交易"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "AR Invoices"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:311
 #: UI/Reports/filters/invoice_outstanding.html:8
 msgid "AR Outstanding"
 msgstr "應收未收"
@@ -156,7 +156,7 @@ msgstr "應收未收"
 msgid "AR Transaction"
 msgstr "應收交易"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:133
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:132
 msgid "AR Transactions"
 msgstr "應收交易"
 
@@ -173,8 +173,8 @@ msgstr ""
 msgid "AR transaction"
 msgstr "應收交易"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:115
 msgid "AR/AP/GL Amount"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB.pm:455 lib/LedgerSMB.pm:456
-#: lib/LedgerSMB/Scripts/configuration.pm:368
+#: lib/LedgerSMB.pm:491 lib/LedgerSMB.pm:492
+#: lib/LedgerSMB/Scripts/configuration.pm:366
 msgid "Access Denied"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Access denied: Bad username or password"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:69
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:138 old/bin/aa.pl:603 old/bin/aa.pl:674
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:603 old/bin/aa.pl:674
 #: old/bin/aa.pl:842 old/bin/ic.pl:1109 old/bin/ir.pl:439 old/bin/ir.pl:912
 #: old/bin/is.pl:1012 old/bin/is.pl:472 old/bin/oe.pl:446
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
@@ -220,22 +220,22 @@ msgstr "帳戶"
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:80
+#: lib/LedgerSMB/Report/Budget/Variance.pm:79
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:160 UI/Reports/co/filter_bm.html:84
+#: lib/LedgerSMB/Report/GL.pm:159 UI/Reports/co/filter_bm.html:84
 #: UI/Reports/co/filter_cd.html:68 UI/Reports/filters/gl.html:286
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:129
-#: lib/LedgerSMB/Report/Budget/Variance.pm:76 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:151
-#: lib/LedgerSMB/Report/Contact/History.pm:62
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:147
-#: lib/LedgerSMB/Report/Contact/Search.pm:107 lib/LedgerSMB/Report/GL.pm:155
-#: lib/LedgerSMB/Report/GL.pm:219 lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Report/Budget/Search.pm:128
+#: lib/LedgerSMB/Report/Budget/Variance.pm:75 lib/LedgerSMB/Report/COA.pm:87
+#: lib/LedgerSMB/Report/Contact/History.pm:150
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:146
+#: lib/LedgerSMB/Report/Contact/Search.pm:106 lib/LedgerSMB/Report/GL.pm:154
+#: lib/LedgerSMB/Report/GL.pm:218 lib/LedgerSMB/Report/Invoices/Payments.pm:186
 #: lib/LedgerSMB/Report/PNL/ECA.pm:88
 #: lib/LedgerSMB/Report/Taxform/Details.pm:119
 #: lib/LedgerSMB/Report/Taxform/Details.pm:89
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:816
+#: lib/LedgerSMB/Scripts/asset.pm:819
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:822
+#: lib/LedgerSMB/Scripts/asset.pm:825
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Aged"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:191 UI/Reports/filters/aging.html:6
+#: lib/LedgerSMB/Report/Aging.pm:188 UI/Reports/filters/aging.html:6
 msgid "Aging Report"
 msgstr ""
 
@@ -687,11 +687,11 @@ msgstr ""
 msgid "Allow Input"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:85
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:128 old/bin/aa.pl:672
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:672
 #: old/bin/aa.pl:839 old/bin/am.pl:311 old/bin/ir.pl:690 old/bin/ir.pl:909
 #: old/bin/is.pl:1009 old/bin/is.pl:788 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
@@ -709,11 +709,11 @@ msgstr ""
 msgid "Amount"
 msgstr "金額"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:85
+#: lib/LedgerSMB/Report/Budget/Variance.pm:84
 msgid "Amount Budgetted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:249
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:257
 #: lib/LedgerSMB/Scripts/payment.pm:936 lib/LedgerSMB/Scripts/payment.pm:941
 #: UI/Reports/filters/invoice_outstanding.html:240
 #: UI/Reports/filters/invoice_search.html:363 templates/demo/check_base.tex:67
@@ -725,13 +725,13 @@ msgstr "到期金額"
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:194
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:153
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:152
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:196
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:195
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:154
 msgid "Amount Less Than"
 msgstr ""
 
@@ -795,9 +795,9 @@ msgid "Approval Status"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:229
-#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:643
-#: lib/LedgerSMB/Scripts/asset.pm:744 lib/LedgerSMB/Scripts/asset.pm:849
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
+#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
+#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:426
 msgid "Approve"
 msgstr ""
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:96
+#: lib/LedgerSMB/Report/Budget/Search.pm:95
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:160
 msgid "Approved By"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:487
+#: lib/LedgerSMB/Scripts/asset.pm:486
 msgid "Approved at"
 msgstr ""
 
@@ -831,16 +831,16 @@ msgstr ""
 msgid "Apr"
 msgstr "四月"
 
-#: lib/LedgerSMB.pm:537 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
+#: lib/LedgerSMB.pm:573 old/bin/aa.pl:70 old/bin/gl.pl:65 old/bin/io.pl:67
 msgid "April"
 msgstr "四月"
 
-#: lib/LedgerSMB/Scripts/asset.pm:578 lib/LedgerSMB/Scripts/asset.pm:687
-#: lib/LedgerSMB/Scripts/asset.pm:810
+#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:813
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:716
+#: lib/LedgerSMB/Scripts/asset.pm:718
 msgid "Aquired Value Remaining"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr "資產"
 msgid "Asset Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:476 UI/asset/begin_approval.html:14
+#: lib/LedgerSMB/Scripts/asset.pm:475 UI/asset/begin_approval.html:14
 #: UI/asset/begin_report.html:13
 msgid "Asset Class"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:144
+#: lib/LedgerSMB/Report/Listings/Asset.pm:143
 msgid "Asset Listing"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Aug"
 msgstr "八月"
 
-#: lib/LedgerSMB.pm:541 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
+#: lib/LedgerSMB.pm:577 old/bin/aa.pl:74 old/bin/gl.pl:69 old/bin/io.pl:71
 msgid "August"
 msgstr "八月"
 
@@ -1080,13 +1080,13 @@ msgstr ""
 msgid "Backup Roles"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:170 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:97
+#: lib/LedgerSMB/Report/GL.pm:169 lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:96
 #: UI/Reports/filters/gl.html:292 templates/demo/invoice.html:154
 #: templates/demo/invoice.tex:200
 msgid "Balance"
 msgstr "餘額"
 
-#: UI/Reports/balance_sheet.html:25 UI/Reports/filters/balance_sheet.html:7
+#: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
 #: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:107
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:110
 msgid "Batch Class"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:160
 msgid "Batch ID"
 msgstr ""
 
@@ -1172,12 +1172,12 @@ msgstr ""
 msgid "Batch Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:143 UI/create_batch.html:10
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:142 UI/create_batch.html:10
 #: UI/create_batch.html:70
 msgid "Batch Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:177
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:176
 msgid "Batch Search"
 msgstr ""
 
@@ -1258,15 +1258,15 @@ msgstr ""
 msgid "Budget"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/Budget/Variance.pm:118
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:113
+#: lib/LedgerSMB/Report/Budget/Search.pm:112
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:107
+#: lib/LedgerSMB/Report/Budget/Variance.pm:106
 msgid "Budget Variance Report"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "業務"
 msgid "Business Number"
 msgstr "業務編號"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:80 UI/Contact/divs/credit.html:234
+#: lib/LedgerSMB/Report/Contact/Search.pm:79 UI/Contact/divs/credit.html:234
 #: UI/Contact/divs/credit.html:235
 msgid "Business Type"
 msgstr ""
@@ -1317,9 +1317,9 @@ msgstr "貨銷成本"
 msgid "COGS Lots Report"
 msgstr ""
 
-#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:119
-#: UI/Reports/aging_report.html:102 UI/Reports/balance_sheet.html:118
-#: UI/Reports/display_report.html:86
+#: UI/Contact/pricelist.html:127 UI/Reports/PNL.html:117
+#: UI/Reports/aging_report.html:101 UI/Reports/balance_sheet.html:116
+#: UI/Reports/display_report.html:59
 msgid "CSV"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:154 lib/LedgerSMB/Scripts/setup.pm:185
+#: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:185
 #: lib/LedgerSMB/Scripts/setup.pm:236 old/bin/io.pl:1824
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
@@ -1467,11 +1467,11 @@ msgstr ""
 msgid "Chargeable"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:150
+#: lib/LedgerSMB/Report/GL.pm:149
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:139 sql/Pg-database.sql:2552
+#: lib/LedgerSMB/Report/COA.pm:138 sql/Pg-database.sql:2552
 msgid "Chart of Accounts"
 msgstr "會計科目表"
 
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Clear date over [*,_1,day]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:140 UI/Reports/filters/gl.html:259
+#: lib/LedgerSMB/Report/GL.pm:139 UI/Reports/filters/gl.html:259
 #: UI/reconciliation/report.html:118 UI/reconciliation/report.html:250
 #: UI/reconciliation/report.html:323
 msgid "Cleared"
@@ -1617,8 +1617,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:81
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:74
 #: lib/LedgerSMB/Scripts/contact.pm:186 UI/Contact/contact.html:12
-#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:14
-#: UI/Reports/display_report.html:28 UI/main.html:32
+#: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
+#: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:33 templates/demo/display_report.tex:36
 #: UI/src/components/LoginPage.vue:36
 msgid "Company"
@@ -1665,12 +1665,36 @@ msgstr ""
 msgid "Comparison Periods"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:163
+#: lib/LedgerSMB/Scripts/report_aging.pm:166
 msgid "Complete"
 msgstr ""
 
 #: UI/email.html:7
 msgid "Compose e-mail"
+msgstr ""
+
+#: UI/src/components/GIFI.vue:18
+msgid "Configure GIFI codes"
+msgstr ""
+
+#: UI/src/components/SIC.vue:18
+msgid "Configure Standard Industry Codes (SIC)"
+msgstr ""
+
+#: UI/src/components/BusinessTypes.vue:18
+msgid "Configure Type of Businesses"
+msgstr ""
+
+#: UI/src/components/Languages.vue:18
+msgid "Configure languages"
+msgstr ""
+
+#: UI/src/components/Pricegroups.vue:17
+msgid "Configure pricegroups"
+msgstr ""
+
+#: UI/src/components/Warehouses.vue:17
+msgid "Configure warehouses"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:10
@@ -1681,7 +1705,7 @@ msgstr ""
 msgid "Confirm!"
 msgstr "入帳成功！"
 
-#: lib/LedgerSMB.pm:461
+#: lib/LedgerSMB.pm:497
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
@@ -1709,7 +1733,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:94
+#: lib/LedgerSMB/Report/Contact/Search.pm:93
 #: UI/Reports/filters/contact_search.html:7
 msgid "Contact Search"
 msgstr ""
@@ -1766,7 +1790,7 @@ msgstr ""
 msgid "Contributing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:67
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:59
 #: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/Taxform/Summary.pm:86
 #: old/bin/arap.pl:165 UI/Contact/divs/company.html:51
@@ -1854,7 +1878,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:196
+#: lib/LedgerSMB/Report/COA.pm:195
 msgid "Create Account"
 msgstr ""
 
@@ -1866,7 +1890,7 @@ msgstr ""
 msgid "Create Database?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:203
+#: lib/LedgerSMB/Report/COA.pm:202
 msgid "Create Heading"
 msgstr ""
 
@@ -1894,7 +1918,7 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:92
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
 #: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:144
@@ -1905,7 +1929,7 @@ msgstr "貸方"
 msgid "Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:72
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr ""
 
@@ -1932,22 +1956,22 @@ msgstr ""
 msgid "Credit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:112 lib/LedgerSMB/Report/GL.pm:124
+#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:123
 #: lib/LedgerSMB/Report/Trial_Balance.pm:176
 #: lib/LedgerSMB/Scripts/payment.pm:209 UI/Reports/co/filter_cd.html:90
 #: UI/reconciliation/report.html:159 UI/reconciliation/report.html:161
 msgid "Credits"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:254
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
 #: old/bin/ic.pl:1100 old/bin/oe.pl:2519
 msgid "Curr"
 msgstr "目前"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:74
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:80
-#: lib/LedgerSMB/Report/Contact/Search.pm:84
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:79
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
 #: old/bin/aa.pl:424 old/bin/ir.pl:325 old/bin/is.pl:323 old/bin/oe.pl:1629
@@ -1966,7 +1990,7 @@ msgstr "目前"
 msgid "Currency"
 msgstr "幣別"
 
-#: lib/LedgerSMB/Report/Aging.pm:140 old/bin/pe.pl:729
+#: lib/LedgerSMB/Report/Aging.pm:137 old/bin/pe.pl:729
 #: UI/Reports/co/filter_bm.html:52 UI/Reports/filters/aging.html:98
 #: UI/lib/report_base.html:159 UI/lib/report_base.html:252
 #: templates/demo/statement.html:62 templates/demo/statement.tex:54
@@ -1982,8 +2006,8 @@ msgstr ""
 msgid "Custom Flags"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:86
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
+#: lib/LedgerSMB/Report/Aging.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
 #: old/bin/aa.pl:516 old/bin/ic.pl:1108 old/bin/is.pl:439 old/bin/pe.pl:1074
@@ -2046,7 +2070,7 @@ msgstr "沒有此客戶的記錄！"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:805
+#: lib/LedgerSMB/Scripts/asset.pm:808
 msgid "D M"
 msgstr ""
 
@@ -2123,17 +2147,17 @@ msgstr ""
 msgid "Database version mismatch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:128 lib/LedgerSMB/Report/GL.pm:92
+#: lib/LedgerSMB/Report/Aging.pm:125 lib/LedgerSMB/Report/GL.pm:91
 #: lib/LedgerSMB/Report/Inventory/History.pm:145
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:199
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:207
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:259
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
 #: lib/LedgerSMB/Report/Orders.pm:204
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:112
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:138
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:95
-#: lib/LedgerSMB/Scripts/asset.pm:465 lib/LedgerSMB/Scripts/payment.pm:192
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
+#: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:192
 #: lib/LedgerSMB/Scripts/payment.pm:930 old/bin/aa.pl:838 old/bin/ir.pl:908
 #: old/bin/is.pl:1008 old/bin/oe.pl:1633 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:134
@@ -2163,8 +2187,8 @@ msgstr ""
 msgid "Date From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:104
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:258
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:103
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:129
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:296
 #: UI/Reports/filters/invoice_outstanding.html:219
@@ -2243,7 +2267,7 @@ msgstr "日"
 msgid "Days"
 msgstr "日"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:86
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
 #: UI/journal/journal_entry.html:143
@@ -2258,7 +2282,7 @@ msgstr ""
 msgid "Debit Note"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:118
+#: lib/LedgerSMB/Report/COA.pm:104 lib/LedgerSMB/Report/GL.pm:117
 #: lib/LedgerSMB/Report/Trial_Balance.pm:170
 #: lib/LedgerSMB/Scripts/payment.pm:203 UI/Reports/co/filter_cd.html:82
 #: UI/reconciliation/report.html:158 UI/reconciliation/report.html:160
@@ -2269,7 +2293,7 @@ msgstr ""
 msgid "Dec"
 msgstr "十二月"
 
-#: lib/LedgerSMB.pm:545 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
+#: lib/LedgerSMB.pm:581 old/bin/aa.pl:78 old/bin/gl.pl:73 old/bin/io.pl:75
 msgid "December"
 msgstr "十二月"
 
@@ -2354,11 +2378,11 @@ msgstr ""
 msgid "Defined exchange rate types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:124 lib/LedgerSMB/Report/COA.pm:163
+#: lib/LedgerSMB/Report/COA.pm:123 lib/LedgerSMB/Report/COA.pm:162
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:131
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:245
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:235 old/bin/aa.pl:1005
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:1005
 #: old/bin/aa.pl:949 old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828
 #: old/bin/ic.pl:850 old/bin/ir.pl:1027 old/bin/is.pl:1127 old/bin/oe.pl:696
 #: old/bin/oe.pl:924 old/bin/pe.pl:156 old/bin/pe.pl:518
@@ -2371,7 +2395,7 @@ msgstr ""
 msgid "Delete"
 msgstr "刪除"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:200
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:203
 msgid "Delete Batch"
 msgstr ""
 
@@ -2384,7 +2408,7 @@ msgstr "刪除時間表"
 msgid "Delete User"
 msgstr "刪除"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:207
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:210
 msgid "Delete Vouchers"
 msgstr ""
 
@@ -2407,21 +2431,21 @@ msgstr ""
 msgid "Delivery"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:108 old/bin/io.pl:265
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:265
 #: UI/Reports/filters/purchase_history.html:314
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: lib/LedgerSMB/Scripts/asset.pm:595
+#: lib/LedgerSMB/Scripts/asset.pm:596
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:584
+#: lib/LedgerSMB/Scripts/asset.pm:585
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:572 lib/LedgerSMB/Scripts/asset.pm:681
-#: lib/LedgerSMB/Scripts/asset.pm:793
+#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
+#: lib/LedgerSMB/Scripts/asset.pm:796
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2429,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:619
+#: lib/LedgerSMB/Scripts/asset.pm:620
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:613
+#: lib/LedgerSMB/Scripts/asset.pm:614
 msgid "Dep. this run"
 msgstr ""
 
@@ -2455,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:505
+#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:505
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2476,15 +2500,15 @@ msgstr ""
 msgid "Depreciation Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:123
+#: lib/LedgerSMB/Report/Aging.pm:120
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:79
-#: lib/LedgerSMB/Report/Budget/Search.pm:88
-#: lib/LedgerSMB/Report/Budget/Variance.pm:121
-#: lib/LedgerSMB/Report/Budget/Variance.pm:72 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/Contact/History.pm:85
-#: lib/LedgerSMB/Report/Contact/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:87
+#: lib/LedgerSMB/Report/Budget/Variance.pm:120
+#: lib/LedgerSMB/Report/Budget/Variance.pm:71 lib/LedgerSMB/Report/COA.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
 #: lib/LedgerSMB/Report/File/Incoming.pm:53
-#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:108
+#: lib/LedgerSMB/Report/File/Internal.pm:51 lib/LedgerSMB/Report/GL.pm:107
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:166
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:97
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:98
@@ -2501,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/Warehouse.pm:46
 #: lib/LedgerSMB/Report/PNL/Product.pm:79 lib/LedgerSMB/Report/Timecards.pm:106
 #: lib/LedgerSMB/Report/Timecards.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:123
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:192
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:111
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:75
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:126
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:148
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:191
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:693 lib/LedgerSMB/Scripts/asset.pm:788
+#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
 #: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:623 old/bin/aa.pl:675
 #: old/bin/am.pl:302 old/bin/ic.pl:1258 old/bin/ic.pl:2013 old/bin/ic.pl:2080
@@ -2575,7 +2599,7 @@ msgstr ""
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:104
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
@@ -2601,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:704
+#: lib/LedgerSMB/Scripts/asset.pm:706
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:799
+#: lib/LedgerSMB/Scripts/asset.pm:802
 msgid "Disposal Date"
 msgstr ""
 
@@ -2618,11 +2642,11 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:861
+#: lib/LedgerSMB/Scripts/asset.pm:859
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:458
+#: lib/LedgerSMB.pm:494
 msgid "Division by 0 error"
 msgstr ""
 
@@ -2654,6 +2678,10 @@ msgstr ""
 msgid "Double vendornumbers"
 msgstr ""
 
+#: UI/src/components/ConfigTable.vue:85
+msgid "Download: "
+msgstr ""
+
 #: sql/Pg-database.sql:705
 msgid "Dr."
 msgstr ""
@@ -2662,11 +2690,11 @@ msgstr ""
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:133
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:144
 msgid "Draft Type"
 msgstr ""
 
@@ -2680,11 +2708,11 @@ msgstr ""
 msgid "Drawing"
 msgstr "圖畫"
 
-#: lib/LedgerSMB/Report/COA.pm:119
+#: lib/LedgerSMB/Report/COA.pm:118
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:100
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:99
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:293
 #: templates/demo/ap_transaction.html:64 templates/demo/ap_transaction.tex:77
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
@@ -2693,9 +2721,9 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:133
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:108
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
+#: lib/LedgerSMB/Report/Aging.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:107
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:651
 #: old/bin/ir.pl:493 old/bin/is.pl:545
 #: UI/Reports/filters/invoice_outstanding.html:234
@@ -2725,7 +2753,7 @@ msgstr "電子郵件"
 msgid "E-mail address missing!"
 msgstr "未指明電子郵件位址！"
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:192
+#: lib/LedgerSMB/Scripts/report_aging.pm:197
 msgid "E-mail aging reminder status"
 msgstr ""
 
@@ -2886,7 +2914,7 @@ msgstr ""
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:55 sql/Pg-database.sql:790
+#: UI/Reports/aging_report.html:54 sql/Pg-database.sql:790
 msgid "Email"
 msgstr ""
 
@@ -2943,14 +2971,14 @@ msgstr ""
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:127
-#: lib/LedgerSMB/Report/Budget/Search.pm:78
-#: lib/LedgerSMB/Report/Budget/Variance.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:156 lib/LedgerSMB/Report/GL.pm:217
+#: lib/LedgerSMB/Report/Budget/Search.pm:126
+#: lib/LedgerSMB/Report/Budget/Search.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:124
+#: lib/LedgerSMB/Report/Contact/History.pm:155 lib/LedgerSMB/Report/GL.pm:216
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:85
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:160
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:71
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:139
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:138
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131 UI/Contact/divs/credit.html:31
 #: UI/Contact/divs/credit.html:121 UI/Contact/divs/credit.html:122
 #: UI/Contact/divs/employee.html:140 UI/Reports/filters/budget_search.html:51
@@ -2994,7 +3022,7 @@ msgstr ""
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:92
+#: lib/LedgerSMB/Report/Budget/Search.pm:91
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:157
 msgid "Entered By"
 msgstr ""
@@ -3003,7 +3031,7 @@ msgstr ""
 msgid "Entered For"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:481
+#: lib/LedgerSMB/Scripts/asset.pm:480
 msgid "Entered at"
 msgstr ""
 
@@ -3012,7 +3040,7 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:296
-#: lib/LedgerSMB/Scripts/report_aging.pm:133 sql/Pg-database.sql:1036
+#: lib/LedgerSMB/Scripts/report_aging.pm:136 sql/Pg-database.sql:1036
 msgid "Entity"
 msgstr ""
 
@@ -3037,7 +3065,7 @@ msgstr ""
 msgid "Entity Name"
 msgstr "公司名稱"
 
-#: lib/LedgerSMB/Report/GL.pm:113
+#: lib/LedgerSMB/Report/GL.pm:112
 msgid "Entry ID"
 msgstr ""
 
@@ -3074,7 +3102,7 @@ msgstr ""
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:462
+#: lib/LedgerSMB.pm:498
 msgid "Error from Function:"
 msgstr ""
 
@@ -3082,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:589
+#: lib/LedgerSMB/Scripts/asset.pm:590
 msgid "Est. Life"
 msgstr ""
 
@@ -3094,7 +3122,7 @@ msgstr "每"
 msgid "Exch"
 msgstr "匯率"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:118
+#: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:940 old/bin/aa.pl:431 old/bin/ir.pl:334
 #: old/bin/is.pl:332 old/bin/oe.pl:1637 old/bin/oe.pl:350 old/bin/oe.pl:358
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
@@ -3203,7 +3231,7 @@ msgstr ""
 msgid "Feb"
 msgstr "二月"
 
-#: lib/LedgerSMB.pm:535 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
+#: lib/LedgerSMB.pm:571 old/bin/aa.pl:68 old/bin/gl.pl:63 old/bin/io.pl:65
 msgid "February"
 msgstr "二月"
 
@@ -3219,7 +3247,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1063
+#: lib/LedgerSMB/Scripts/asset.pm:1067
 msgid "File Imported"
 msgstr ""
 
@@ -3363,7 +3391,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:116
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:110
 #: lib/LedgerSMB/Report/Timecards.pm:147
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:149
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:148
 #: UI/Reports/filters/unapproved.html:35
 msgid "From Date"
 msgstr ""
@@ -3386,11 +3414,11 @@ msgstr ""
 msgid "Full"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1151
+#: lib/LedgerSMB/Scripts/setup.pm:1150
 msgid "Full Permissions"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:165
+#: lib/LedgerSMB/Report/COA.pm:99 lib/LedgerSMB/Report/GL.pm:164
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:48
 #: lib/LedgerSMB/Report/Listings/GIFI.pm:65
 #: lib/LedgerSMB/Report/Trial_Balance.pm:158
@@ -3421,7 +3449,7 @@ msgstr "總帳索引編號"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:834
+#: lib/LedgerSMB/Scripts/asset.pm:837
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3429,7 +3457,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:723
+#: lib/LedgerSMB/Scripts/asset.pm:725
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3441,7 +3469,7 @@ msgstr ""
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:203
+#: lib/LedgerSMB/Report/GL.pm:202
 msgid "General Ledger Report"
 msgstr ""
 
@@ -3449,7 +3477,7 @@ msgstr ""
 msgid "General Ledger Reports"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:84
+#: lib/LedgerSMB/Scripts/order.pm:124 UI/Reports/aging_report.html:83
 #: sql/Pg-database.sql:2541 sql/Pg-database.sql:2579
 msgid "Generate"
 msgstr "生成"
@@ -3536,7 +3564,7 @@ msgstr ""
 msgid "HR"
 msgstr "人事管理"
 
-#: UI/Reports/PNL.html:115 UI/Reports/balance_sheet.html:115
+#: UI/Reports/PNL.html:113 UI/Reports/balance_sheet.html:113
 msgid "HTML"
 msgstr ""
 
@@ -3578,18 +3606,18 @@ msgid "Hundred"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60 lib/LedgerSMB/Report/GL.pm:87
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:59 lib/LedgerSMB/Report/GL.pm:86
 #: lib/LedgerSMB/Report/Inventory/History.pm:116
 #: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:203
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:211
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:256
 #: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:88
 #: lib/LedgerSMB/Report/Orders.pm:200 lib/LedgerSMB/Report/Timecards.pm:97
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:102
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:133
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:90
-#: lib/LedgerSMB/Scripts/asset.pm:459 lib/LedgerSMB/Scripts/report_aging.pm:127
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
+#: lib/LedgerSMB/Scripts/asset.pm:458 lib/LedgerSMB/Scripts/report_aging.pm:130
 #: old/bin/am.pl:301 UI/Reports/filters/gl.html:196
 #: UI/Reports/filters/invoice_outstanding.html:131
 #: UI/Reports/filters/invoice_search.html:255 UI/Reports/filters/orders.html:121
@@ -3742,7 +3770,7 @@ msgid ""
 "charge."
 msgstr ""
 
-#: lib/LedgerSMB.pm:454
+#: lib/LedgerSMB.pm:490
 msgid "Internal Database Error"
 msgstr ""
 
@@ -3763,7 +3791,7 @@ msgstr ""
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:457
+#: lib/LedgerSMB.pm:493
 msgid "Invalid date/time entered"
 msgstr ""
 
@@ -3817,9 +3845,9 @@ msgstr "已儲存存貨！"
 msgid "Inventory transferred!"
 msgstr "轉移的存貨！"
 
-#: lib/LedgerSMB/Report/Aging.pm:117
+#: lib/LedgerSMB/Report/Aging.pm:114
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:181
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
 #: lib/LedgerSMB/Scripts/payment.pm:929 old/bin/am.pl:958 old/bin/io.pl:1142
 #: old/bin/is.pl:1484 old/bin/is.pl:251 old/bin/printer.pl:48
@@ -3848,7 +3876,7 @@ msgstr ""
 msgid "Invoice Created Date missing!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:647 old/bin/ir.pl:489
 #: old/bin/is.pl:541 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
@@ -3863,10 +3891,10 @@ msgstr "未指明發票日期！"
 msgid "Invoice No."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:70
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:68
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:81
 #: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:634
 #: old/bin/ir.pl:475 old/bin/is.pl:528
 #: UI/Reports/filters/invoice_outstanding.html:137
@@ -3959,7 +3987,7 @@ msgstr ""
 msgid "Jan"
 msgstr "一月"
 
-#: lib/LedgerSMB.pm:534 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
+#: lib/LedgerSMB.pm:570 old/bin/aa.pl:67 old/bin/gl.pl:62 old/bin/io.pl:64
 msgid "January"
 msgstr "一月"
 
@@ -3991,7 +4019,7 @@ msgstr ""
 msgid "Jul"
 msgstr "七月"
 
-#: lib/LedgerSMB.pm:540 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
+#: lib/LedgerSMB.pm:576 old/bin/aa.pl:73 old/bin/gl.pl:68 old/bin/io.pl:70
 msgid "July"
 msgstr "七月"
 
@@ -3999,7 +4027,7 @@ msgstr "七月"
 msgid "Jun"
 msgstr "六月"
 
-#: lib/LedgerSMB.pm:539 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
+#: lib/LedgerSMB.pm:575 old/bin/aa.pl:72 old/bin/gl.pl:67 old/bin/io.pl:69
 #: t/data/04-strings-for-translation.html:6
 msgid "June"
 msgstr "六月"
@@ -4032,7 +4060,7 @@ msgstr "直接人工/經常費用"
 msgid "Labor/Service Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:109
+#: lib/LedgerSMB/Report/Aging.pm:106
 #: lib/LedgerSMB/Report/Listings/Language.pm:65
 #: lib/LedgerSMB/Report/Listings/Templates.pm:72 old/bin/pe.pl:300
 #: old/bin/pe.pl:473 UI/Contact/divs/credit.html:275
@@ -4260,7 +4288,7 @@ msgid "Loaded"
 msgstr ""
 
 #: UI/src/components/ServerUI.js:25 UI/src/components/ServerUI.js:39
-#: UI/src/components/ConfigTable.vue:71
+#: UI/src/components/ConfigTable.vue:78
 msgid "Loading..."
 msgstr ""
 
@@ -4349,11 +4377,11 @@ msgid ""
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1150
+#: lib/LedgerSMB/Scripts/setup.pm:1149
 msgid "Manage Users"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:258 UI/Contact/divs/employee.html:83
 #: UI/Contact/divs/employee.html:107
@@ -4374,7 +4402,7 @@ msgstr ""
 msgid "Mar"
 msgstr "三月"
 
-#: lib/LedgerSMB.pm:536 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
+#: lib/LedgerSMB.pm:572 old/bin/aa.pl:69 old/bin/gl.pl:64 old/bin/io.pl:66
 msgid "March"
 msgstr "三月"
 
@@ -4391,12 +4419,12 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: lib/LedgerSMB.pm:538 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
+#: lib/LedgerSMB.pm:574 old/bin/aa.pl:71 old/bin/aa.pl:85 old/bin/gl.pl:66
 #: old/bin/gl.pl:80 old/bin/io.pl:68 old/bin/io.pl:82
 msgid "May"
 msgstr "五月"
 
-#: lib/LedgerSMB/Report/GL.pm:135 lib/LedgerSMB/Scripts/payment.pm:935
+#: lib/LedgerSMB/Report/GL.pm:134 lib/LedgerSMB/Scripts/payment.pm:935
 #: old/bin/aa.pl:844 old/bin/ir.pl:694 old/bin/ir.pl:914 old/bin/is.pl:1014
 #: old/bin/is.pl:792 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:253 UI/journal/journal_entry.html:146
@@ -4491,7 +4519,7 @@ msgstr "月"
 msgid "Months"
 msgstr ""
 
-#: lib/LedgerSMB.pm:470
+#: lib/LedgerSMB.pm:506
 msgid "More information has been reported in the error logs"
 msgstr ""
 
@@ -4525,15 +4553,14 @@ msgstr ""
 msgid "NONE"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:148
-#: lib/LedgerSMB/Report/Contact/History.pm:58
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:145
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:63
-#: lib/LedgerSMB/Report/Contact/Search.pm:105
-#: lib/LedgerSMB/Report/Contact/Search.pm:62 lib/LedgerSMB/Report/Orders.pm:221
-#: lib/LedgerSMB/Report/PNL/ECA.pm:86 lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: old/bin/arap.pl:163 UI/Contact/divs/company.html:75
-#: UI/Reports/filters/contact_search.html:33
+#: lib/LedgerSMB/Report/Contact/History.pm:147
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:62
+#: lib/LedgerSMB/Report/Contact/Search.pm:104
+#: lib/LedgerSMB/Report/Contact/Search.pm:61 lib/LedgerSMB/Report/Orders.pm:221
+#: lib/LedgerSMB/Report/PNL/ECA.pm:86 old/bin/arap.pl:163
+#: UI/Contact/divs/company.html:75 UI/Reports/filters/contact_search.html:33
 #: UI/Reports/filters/overpayments.html:31 UI/payments/payments_detail.html:225
 msgid "Name"
 msgstr "名稱"
@@ -4593,7 +4620,7 @@ msgid "Next Number"
 msgstr "下一個號碼"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: lib/LedgerSMB/Scripts/configuration.pm:344
+#: lib/LedgerSMB/Scripts/configuration.pm:342
 msgid "Next in Sequence"
 msgstr ""
 
@@ -4645,7 +4672,7 @@ msgstr ""
 msgid "No Old Password"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1152
+#: lib/LedgerSMB/Scripts/setup.pm:1151
 msgid "No changes"
 msgstr ""
 
@@ -4677,7 +4704,7 @@ msgstr ""
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:126
+#: lib/LedgerSMB/Scripts/taxform.pm:129
 msgid "No tax form selected"
 msgstr ""
 
@@ -4748,9 +4775,9 @@ msgstr ""
 msgid "Note that the process invoked by hitting the button below might "
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:112
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:111
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:266
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
 #: lib/LedgerSMB/Scripts/contact.pm:195 old/bin/aa.pl:809 old/bin/ic.pl:764
 #: old/bin/ir.pl:804 old/bin/is.pl:902 old/bin/oe.pl:832
@@ -4790,7 +4817,7 @@ msgstr "沒有可轉移的項目！"
 msgid "Nov"
 msgstr "十一月"
 
-#: lib/LedgerSMB.pm:544 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
+#: lib/LedgerSMB.pm:580 old/bin/aa.pl:77 old/bin/gl.pl:72 old/bin/io.pl:74
 msgid "November"
 msgstr "十一月"
 
@@ -4835,8 +4862,8 @@ msgstr ""
 msgid "Number:"
 msgstr "編號"
 
-#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:114
-#: UI/Reports/display_report.html:90
+#: UI/Contact/pricelist.html:123 UI/Reports/aging_report.html:113
+#: UI/Reports/display_report.html:63
 msgid "ODS"
 msgstr ""
 
@@ -4853,7 +4880,7 @@ msgstr ""
 msgid "Obsolete"
 msgstr "停用"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:100
+#: lib/LedgerSMB/Report/Budget/Search.pm:99
 msgid "Obsolete By"
 msgstr ""
 
@@ -4861,7 +4888,7 @@ msgstr ""
 msgid "Oct"
 msgstr "十月"
 
-#: lib/LedgerSMB.pm:543 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
+#: lib/LedgerSMB.pm:579 old/bin/aa.pl:76 old/bin/gl.pl:71 old/bin/io.pl:73
 msgid "October"
 msgstr "十月"
 
@@ -4936,7 +4963,7 @@ msgid "Or Add To Batch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:212
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2510
 msgid "Order"
 msgstr "訂單"
@@ -4968,7 +4995,7 @@ msgstr "未指明下單日期！"
 msgid "Order Entry"
 msgstr "下單項目"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:72 old/bin/aa.pl:639
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:639
 #: old/bin/ir.pl:480 old/bin/is.pl:532 old/bin/oe.pl:1903 old/bin/oe.pl:397
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
@@ -5059,9 +5086,9 @@ msgstr ""
 msgid "Overpayments"
 msgstr ""
 
-#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:111
-#: UI/Reports/aging_report.html:97 UI/Reports/balance_sheet.html:112
-#: UI/Reports/display_report.html:82
+#: UI/Contact/pricelist.html:105 UI/Reports/PNL.html:109
+#: UI/Reports/aging_report.html:96 UI/Reports/balance_sheet.html:110
+#: UI/Reports/display_report.html:55
 msgid "PDF"
 msgstr "PDF"
 
@@ -5070,8 +5097,8 @@ msgstr "PDF"
 msgid "PO #"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:76
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:216
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:75
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
 #: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:655 old/bin/is.pl:549
 #: old/bin/oe.pl:1914 old/bin/oe.pl:412
@@ -5111,8 +5138,8 @@ msgstr "未指明出貨單編號！"
 msgid "Packing list"
 msgstr "出貨單"
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:94
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:290
 #: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 #: lib/LedgerSMB/Scripts/payment.pm:932
@@ -5140,7 +5167,7 @@ msgstr ""
 msgid "Part Group"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:81
+#: lib/LedgerSMB/Report/Contact/History.pm:80
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:95
 #: lib/LedgerSMB/Report/Inventory/History.pm:121
 #: lib/LedgerSMB/Report/Inventory/Search.pm:219
@@ -5169,7 +5196,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:728
+#: lib/LedgerSMB/Scripts/asset.pm:730
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5237,7 +5264,7 @@ msgstr "應付科目"
 msgid "Payment"
 msgstr "付款"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
 msgid "Payment Amount"
 msgstr ""
 
@@ -5299,11 +5326,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:698
+#: lib/LedgerSMB/Scripts/asset.pm:700
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:710
+#: lib/LedgerSMB/Scripts/asset.pm:712
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5470,7 +5497,7 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:238 old/bin/aa.pl:945
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:945
 #: old/bin/aa.pl:990 old/bin/aa.pl:994 old/bin/aa.pl:998 old/bin/gl.pl:244
 #: old/bin/gl.pl:246 old/bin/ir.pl:1023 old/bin/ir.pl:539 old/bin/ir.pl:585
 #: old/bin/is.pl:1122 old/bin/is.pl:606 old/bin/is.pl:656
@@ -5478,7 +5505,7 @@ msgstr ""
 msgid "Post"
 msgstr "加入"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:193
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:196
 msgid "Post Batch"
 msgstr ""
 
@@ -5600,7 +5627,7 @@ msgstr ""
 msgid "Print"
 msgstr "列印"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:221
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
 msgid "Print Batch"
 msgstr ""
 
@@ -5660,15 +5687,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:607
+#: lib/LedgerSMB/Scripts/asset.pm:608
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:601
+#: lib/LedgerSMB/Scripts/asset.pm:602
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:828
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
 msgid "Proceeds"
 msgstr ""
 
@@ -5728,7 +5755,7 @@ msgstr ""
 msgid "Purchase Date:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:137
+#: lib/LedgerSMB/Report/Contact/History.pm:136
 #: UI/Reports/filters/purchase_history.html:9
 msgid "Purchase History"
 msgstr ""
@@ -5754,7 +5781,7 @@ msgid "Purchase Orders"
 msgstr "採購單"
 
 #: lib/LedgerSMB/Report/Listings/Asset.pm:100
-#: lib/LedgerSMB/Report/Listings/Asset.pm:132 lib/LedgerSMB/Scripts/asset.pm:341
+#: lib/LedgerSMB/Report/Listings/Asset.pm:131 lib/LedgerSMB/Scripts/asset.pm:341
 msgid "Purchase Value"
 msgstr ""
 
@@ -5771,7 +5798,7 @@ msgstr "採購單"
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1250
 #: old/bin/ic.pl:2087 old/bin/io.pl:237 old/bin/oe.pl:1959 old/bin/oe.pl:2241
@@ -5986,13 +6013,13 @@ msgstr ""
 msgid "Recurring Transactions"
 msgstr "重覆出現的交易"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:131
-#: lib/LedgerSMB/Report/Budget/Search.pm:83 lib/LedgerSMB/Report/GL.pm:221
-#: lib/LedgerSMB/Report/GL.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:130
+#: lib/LedgerSMB/Report/Budget/Search.pm:82 lib/LedgerSMB/Report/GL.pm:220
+#: lib/LedgerSMB/Report/GL.pm:96
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:117
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:147 old/bin/am.pl:297
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:99 old/bin/am.pl:297
 #: old/bin/arap.pl:572 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
@@ -6062,12 +6089,12 @@ msgstr ""
 msgid "Report Generated By:"
 msgstr ""
 
-#: UI/Reports/aging_report.html:11 UI/Reports/display_report.html:25
+#: UI/Reports/aging_report.html:9 UI/Reports/display_report.html:16
 #: templates/demo/display_report.html:29 templates/demo/display_report.tex:34
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:441
+#: lib/LedgerSMB/Scripts/asset.pm:541
 msgid "Report Results"
 msgstr ""
 
@@ -6079,7 +6106,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:632
+#: lib/LedgerSMB/Scripts/asset.pm:633
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6147,7 +6174,7 @@ msgstr ""
 msgid "Required by"
 msgstr "要求交付日期"
 
-#: lib/LedgerSMB.pm:459 lib/LedgerSMB.pm:460
+#: lib/LedgerSMB.pm:495 lib/LedgerSMB.pm:496
 msgid "Required input not provided"
 msgstr ""
 
@@ -6325,8 +6352,8 @@ msgstr "銷售報價單編號"
 msgid "Sales:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:308 old/bin/aa.pl:480
 #: old/bin/is.pl:380 old/bin/oe.pl:539 UI/Reports/filters/contact_search.html:61
 #: UI/Reports/filters/invoice_outstanding.html:178
@@ -6504,7 +6531,7 @@ msgstr "時間表"
 msgid "Scheduled"
 msgstr "編排了時間"
 
-#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:137
+#: lib/LedgerSMB/Scripts/payment.pm:691 lib/LedgerSMB/Template/UI.pm:124
 #: old/bin/printer.pl:129 UI/lib/utilities.html:44
 msgid "Screen"
 msgstr "螢幕"
@@ -6688,7 +6715,7 @@ msgstr ""
 msgid "Sell"
 msgstr "售賣"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:99
+#: lib/LedgerSMB/Report/Contact/History.pm:98
 #: lib/LedgerSMB/Report/Inventory/History.pm:154
 #: lib/LedgerSMB/Report/Inventory/Search.pm:253 old/bin/ic.pl:1112
 #: old/bin/ic.pl:431 UI/Contact/pricelist.csv:31 UI/Contact/pricelist.html:43
@@ -6745,7 +6772,7 @@ msgstr "九月"
 msgid "Separate Duties"
 msgstr ""
 
-#: lib/LedgerSMB.pm:542 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
+#: lib/LedgerSMB.pm:578 old/bin/aa.pl:75 old/bin/gl.pl:70 old/bin/io.pl:72
 msgid "September"
 msgstr "九月"
 
@@ -6765,7 +6792,7 @@ msgstr ""
 msgid "Serial No."
 msgstr "序號"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:112
+#: lib/LedgerSMB/Report/Contact/History.pm:111
 #: lib/LedgerSMB/Report/Inventory/History.pm:167
 #: lib/LedgerSMB/Report/Inventory/Search.pm:328
 #: UI/Reports/filters/purchase_history.html:332
@@ -6851,8 +6878,8 @@ msgstr ""
 msgid "Ship To:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:286
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:119
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:294
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:317
 #: lib/LedgerSMB/Report/Orders.pm:250
 #: UI/Reports/filters/invoice_outstanding.html:60
@@ -6899,8 +6926,8 @@ msgstr "未指明付運日期！"
 msgid "Shipping Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:116
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:282
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:115
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
 #: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:513 old/bin/oe.pl:1887
 #: old/bin/oe.pl:602 UI/Reports/filters/invoice_outstanding.html:261
@@ -6971,8 +6998,8 @@ msgstr ""
 msgid "Some"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:133 lib/LedgerSMB/Report/GL.pm:130
-#: lib/LedgerSMB/Report/GL.pm:223
+#: lib/LedgerSMB/Report/Budget/Search.pm:132 lib/LedgerSMB/Report/GL.pm:129
+#: lib/LedgerSMB/Report/GL.pm:222
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:198 lib/LedgerSMB/Scripts/recon.pm:489
@@ -7018,14 +7045,14 @@ msgstr "標準"
 msgid "Standard Industrial Codes"
 msgstr "標準工業編碼"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:125
-#: lib/LedgerSMB/Report/Budget/Search.pm:73
-#: lib/LedgerSMB/Report/Budget/Variance.pm:123
-#: lib/LedgerSMB/Report/Contact/History.pm:153 lib/LedgerSMB/Report/GL.pm:215
+#: lib/LedgerSMB/Report/Budget/Search.pm:124
+#: lib/LedgerSMB/Report/Budget/Search.pm:72
+#: lib/LedgerSMB/Report/Budget/Variance.pm:122
+#: lib/LedgerSMB/Report/Contact/History.pm:152 lib/LedgerSMB/Report/GL.pm:214
 #: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:158
 #: lib/LedgerSMB/Report/Listings/Business_Unit.pm:67
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:137
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/employee.html:132 UI/Reports/filters/budget_search.html:41
 #: UI/budgetting/budget_entry.html:38 UI/business_units/edit.html:55
@@ -7049,7 +7076,7 @@ msgid "Startdate"
 msgstr "開始日期"
 
 #: lib/LedgerSMB/Report/Trial_Balance.pm:164
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:80 UI/Reports/co/filter_bm.html:91
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:79 UI/Reports/co/filter_bm.html:91
 msgid "Starting Balance"
 msgstr ""
 
@@ -7101,8 +7128,8 @@ msgstr ""
 msgid "Statement Date To"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/report_aging.pm:143
-#: lib/LedgerSMB/Scripts/report_aging.pm:187
+#: lib/LedgerSMB/Scripts/report_aging.pm:146
+#: lib/LedgerSMB/Scripts/report_aging.pm:192
 #: UI/Reports/filters/search_goods.html:25
 #, fuzzy
 msgid "Status"
@@ -7214,8 +7241,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:567
-#: lib/LedgerSMB/Scripts/asset.pm:676 lib/LedgerSMB/Scripts/asset.pm:783
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
+#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
 msgid "Tag"
 msgstr ""
 
@@ -7223,8 +7250,8 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:90
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:89
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:242
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:284 old/bin/ic.pl:535
 #: old/bin/ic.pl:664 UI/Reports/filters/invoice_outstanding.html:199
 #: UI/Reports/filters/invoice_search.html:323 UI/Reports/filters/orders.html:185
@@ -7545,8 +7572,8 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:145
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
+#: lib/LedgerSMB/Report/GL.pm:144
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:278
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:305
 #: UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/invoice_outstanding.html:253
@@ -7625,7 +7652,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:111
 #: lib/LedgerSMB/Report/Timecards.pm:149
 #: lib/LedgerSMB/Report/Trial_Balance.pm:198
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:151
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:150
 #: UI/Reports/filters/unapproved.html:43
 msgid "To Date"
 msgstr ""
@@ -7671,14 +7698,14 @@ msgstr ""
 msgid "Top-level"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:164
+#: lib/LedgerSMB/Report/Aging.pm:161
 #: lib/LedgerSMB/Report/Inventory/History.pm:163
 #: lib/LedgerSMB/Report/Inventory/Search.pm:324
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:122
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:287
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:493
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:99 lib/LedgerSMB/Scripts/asset.pm:492
 #: lib/LedgerSMB/Scripts/payment.pm:931 old/bin/ir.pl:840 old/bin/is.pl:940
 #: old/bin/oe.pl:846 UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
@@ -7700,7 +7727,7 @@ msgstr ""
 msgid "Total"
 msgstr "總計"
 
-#: lib/LedgerSMB/Scripts/asset.pm:625
+#: lib/LedgerSMB/Scripts/asset.pm:626
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,7 +7755,7 @@ msgstr "交易"
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:85
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:83
 #: UI/Reports/filters/purchase_history.html:129
 #: UI/Reports/filters/purchase_history.html:342
 msgid "Transaction Date"
@@ -7742,7 +7769,7 @@ msgstr "未指明交易日期！"
 msgid "Transaction Dates"
 msgstr "交易日期"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:190
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:189
 #: UI/Reports/filters/batches.html:12 UI/Reports/filters/unapproved.html:20
 #: UI/reconciliation/report.html:114 UI/reconciliation/report.html:249
 msgid "Transaction Type"
@@ -7851,9 +7878,9 @@ msgid "Two"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:129
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
-#: lib/LedgerSMB/Scripts/asset.pm:471 old/bin/io.pl:1707
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1707
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:118
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7911,7 +7938,7 @@ msgstr ""
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:93
+#: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1252
 #: old/bin/ic.pl:783 old/bin/io.pl:239 old/bin/oe.pl:1961
@@ -7952,11 +7979,11 @@ msgstr ""
 msgid "Unknown error preventing login"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:252
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:251
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:214
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:217
 msgid "Unlock Batch"
 msgstr ""
 
@@ -8085,7 +8112,7 @@ msgstr ""
 msgid "Use web service for current exchange rates"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:90
+#: lib/LedgerSMB/Report/Budget/Variance.pm:89
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:132
 msgid "Used"
 msgstr ""
@@ -8099,7 +8126,7 @@ msgstr "使用者"
 msgid "User Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1229
+#: lib/LedgerSMB/Scripts/setup.pm:1228
 msgid "User already exists. Import?"
 msgstr ""
 
@@ -8147,7 +8174,7 @@ msgstr ""
 msgid "Variable"
 msgstr "應稅"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:95
+#: lib/LedgerSMB/Report/Budget/Variance.pm:94
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:107
 msgid "Variance"
 msgstr ""
@@ -8156,8 +8183,8 @@ msgstr ""
 msgid "Variance:"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:187
+#: lib/LedgerSMB/Report/Aging.pm:86
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
 #: old/bin/aa.pl:519 old/bin/ic.pl:1014 old/bin/ir.pl:404 old/bin/oe.pl:2508
@@ -8231,7 +8258,7 @@ msgstr ""
 msgid "Vendor not on file!"
 msgstr "沒有此供應商的記錄！"
 
-#: lib/LedgerSMB/Report/GL.pm:103 lib/LedgerSMB/Report/Unapproved/Drafts.pm:106
+#: lib/LedgerSMB/Report/GL.pm:102 lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
 #: UI/Reports/filters/gl.html:217
 #, fuzzy
 msgid "Vendor/Customer"
@@ -8245,7 +8272,7 @@ msgstr ""
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:145
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:148
 msgid "Voucher List"
 msgstr ""
 
@@ -8374,13 +8401,13 @@ msgstr ""
 msgid "Would you like to upgrade the database?"
 msgstr ""
 
-#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:106
-#: UI/Reports/display_report.html:94
+#: UI/Contact/pricelist.html:111 UI/Reports/aging_report.html:105
+#: UI/Reports/display_report.html:67
 msgid "XLS"
 msgstr ""
 
-#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:110
-#: UI/Reports/display_report.html:98
+#: UI/Contact/pricelist.html:117 UI/Reports/aging_report.html:109
+#: UI/Reports/display_report.html:71
 msgid "XLSX"
 msgstr ""
 
@@ -8619,7 +8646,7 @@ msgstr ""
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:93 UI/Reports/display_report.html:79
+#: UI/Reports/aging_report.html:92 UI/Reports/display_report.html:52
 msgid "permalink"
 msgstr ""
 

--- a/old/lib/LedgerSMB/DBObject/TaxForm.pm
+++ b/old/lib/LedgerSMB/DBObject/TaxForm.pm
@@ -133,42 +133,12 @@ sub get_forms
     return @{$self->{forms}};
 }
 
-=item get_metadata
-
-Gets metadata for the screen.
-
-Sets the following hashref properties
-
-=over
-
-=item countries
-A list of all countries, for drop down box purposes.
-
-=item default_country
-The default country of the organization, to set the dropdown box.
-
-=back
-
-=cut
-
-sub get_metadata
-{
-    my ($self) = @_;
-
-    @{$self->{countries}} =
-        LedgerSMB::I18N::location_list_country_localized($self);
-
-    my ($ref) = $self->call_procedure(funcname => 'setting_get', args => ['default_country']);
-    return $self->{default_country} = $ref->{setting_get};
-}
-
-
 
 =back
 
 =head1 COPYRIGHT
 
-Copyright (C) 2009 LedgerSMB Core Team.  This file is licensed under the GNU
+Copyright (C) 2009-2022 LedgerSMB Core Team.  This file is licensed under the GNU
 General Public License version 2, or at your option any later version.  Please
 see the included License.txt for details.
 

--- a/t/02-number-handling.t
+++ b/t/02-number-handling.t
@@ -25,37 +25,37 @@ like(
     dies { $form->format_amount({'apples' => '1000.00'}, 'foo', 2) },
     qr/LedgerSMB::PGNumber No Format Set/,
     'lsmb: No numberformat set, invalid amount message (NaN check)');
-my $expected;
-foreach my $value (
-    '0.01', '0.05', '0.015', '0.025', '1.1', '1.5', '1.9',
-    '10.01', '4', '5', '5.1', '5.4', '5.5', '5.6', '6', '0',
-    '0.000', '10.155', '55', '0.001', '14.5', '15.5', '4.5'
-) {
-    foreach my $places ('3', '2', '1', '0') {
-        Math::BigFloat->round_mode('+inf');
-        $expected = Math::BigFloat->new($value)->ffround(-$places);
-        $expected->precision(undef);
-        is($form->round_amount($value, $places), $expected,
-           "form: $value to $places decimal places - $expected");
+my  $expected;
+# foreach my $value (
+#     '0.01', '0.05', '0.015', '0.025', '1.1', '1.5', '1.9',
+#     '10.01', '4', '5', '5.1', '5.4', '5.5', '5.6', '6', '0',
+#     '0.000', '10.155', '55', '0.001', '14.5', '15.5', '4.5'
+# ) {
+#     foreach my $places ('3', '2', '1', '0') {
+#         Math::BigFloat->round_mode('+inf');
+#         $expected = Math::BigFloat->new($value)->ffround(-$places);
+#         $expected->precision(undef);
+#         is($form->round_amount($value, $places), $expected,
+#            "form: $value to $places decimal places - $expected");
 
-        Math::BigFloat->round_mode('-inf');
-        $expected = Math::BigFloat->new(-$value)->ffround(-$places);
-        $expected->precision(undef);
-        is($form->round_amount(-$value, $places), $expected,
-           "form: -$value to $places decimal places - $expected");
-    }
-    foreach my $places ('-1', '-2') {
-        Math::BigFloat->round_mode('+inf');
-        $expected = Math::BigFloat->new($value)->ffround(-($places-1));
-        ok($form->round_amount($value, $places) == $expected,
-           "form: $value to $places decimal places - $expected");
+#         Math::BigFloat->round_mode('-inf');
+#         $expected = Math::BigFloat->new(-$value)->ffround(-$places);
+#         $expected->precision(undef);
+#         is($form->round_amount(-$value, $places), $expected,
+#            "form: -$value to $places decimal places - $expected");
+#     }
+#     foreach my $places ('-1', '-2') {
+#         Math::BigFloat->round_mode('+inf');
+#         $expected = Math::BigFloat->new($value)->ffround(-($places-1));
+#         ok($form->round_amount($value, $places) == $expected,
+#            "form: $value to $places decimal places - $expected");
 
-        Math::BigFloat->round_mode('-inf');
-        $expected = Math::BigFloat->new(-$value)->ffround(-($places-1));
-        ok($form->round_amount(-$value, $places) == $expected,
-           "form: -$value to $places decimal places - $expected");
-    }
-}
+#         Math::BigFloat->round_mode('-inf');
+#         $expected = Math::BigFloat->new(-$value)->ffround(-($places-1));
+#         ok($form->round_amount(-$value, $places) == $expected,
+#            "form: -$value to $places decimal places - $expected");
+#     }
+# }
 
 # TODO Number formatting still needs work for l10n
 my @formats = (#['1,000.00', ',', '.'], ["1'000.00", "'", '.'],

--- a/t/03-date-handling.t
+++ b/t/03-date-handling.t
@@ -34,7 +34,7 @@ my $locale_es = LedgerSMB::Locale->get_handle('es');
 my %myconfig;
 ok(defined $form);
 isa_ok($form, 'Form');
-my $request = Plack::Request->new({});
+my $request = Plack::Request->new({ 'lsmb.script' => 'test.pl' });
 my $lsmb = LedgerSMB->new($request, $wire);
 ok(defined $lsmb);
 isa_ok($lsmb, 'LedgerSMB');

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -19,7 +19,7 @@ Log::Log4perl->easy_init($OFF);
 
 
 my $lsmb;
-my $request = Plack::Request->new({});
+my $request = Plack::Request->new({ 'lsmb.script' => 'test.pl' });
 
 
 ##table of subroutine tests

--- a/t/14-report-dates.t
+++ b/t/14-report-dates.t
@@ -3,6 +3,7 @@
 use Test2::V0;
 
 use Data::Dumper;
+use URI;
 
 use LedgerSMB::App_State;
 use LedgerSMB::Report::PNL::Income_Statement;
@@ -25,6 +26,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 1: PNL, from & to dates, no comparison periods
     my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_date => '2016-01-01',
@@ -40,6 +42,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 2: PNL, from & to dates, 1 comparison period (by dates)
     my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_date => '2016-01-01',
@@ -62,6 +65,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 3: PNL, from date, 1 comparison period (by periods/year/date)
     my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_date => '2016-01-05',
@@ -83,6 +87,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 4: PNL, from month & year, 1 comparison period (by periods/year)
     my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_date => '2016-01-01',
@@ -106,6 +111,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 5: PNL, from month & year, 1 comparison period (by periods/quarter)
     my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_month => '01',
@@ -128,6 +134,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 6: PNL, from date, 1 comparison period (by periods/month)
     my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_month => '01',
@@ -150,6 +157,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 7: PNL, from date, 9 comparisons period (by periods/month)
     my $rpt = LedgerSMB::Report::PNL::Income_Statement->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_month => '01',
@@ -208,6 +216,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 1: B/S, from & to dates, no comparison periods
     my $rpt = LedgerSMB::Report::Balance_Sheet->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_date => '2016-01-01',
@@ -223,6 +232,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 2: B/S, from & to dates, 1 comparison period (by dates)
     my $rpt = LedgerSMB::Report::Balance_Sheet->new(
+        _uri => URI->new,
         ignore_yearend => 'all',
         from_date => '2016-01-01',
         to_date => '2016-12-31',
@@ -246,6 +256,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 3: B/S, from & to dates, 1 comparison period (by periods)
     my $rpt = LedgerSMB::Report::Balance_Sheet->new(
+        _uri => URI->new,
         ignore_yearend => 'all',
         from_date => '2016-01-01',
         to_date => '2016-12-31',
@@ -267,6 +278,7 @@ LedgerSMB::App_State::set_User({});
 
 {  # Scenario 4: B/S, from month & year, 1 comparison period (by periods)
     my $rpt = LedgerSMB::Report::Balance_Sheet->new(
+        _uri => URI->new,
         basis => 'accrual',
         ignore_yearend => 'all',
         from_month => '01',

--- a/t/14-report-hierarchical.t
+++ b/t/14-report-hierarchical.t
@@ -3,10 +3,11 @@
 use Test2::V0;
 
 use Data::Dumper;
+use URI;
 
 use LedgerSMB::Report::Hierarchical;
 
-my $report = LedgerSMB::Report::Hierarchical->new;
+my $report = LedgerSMB::Report::Hierarchical->new(_uri => URI->new);
 
 # all we need to test now is the addition of comparisons, the rest
 # requires a database connection
@@ -29,7 +30,7 @@ is($report->cells, {'1' => { '1' => 15 },
                            '3' => { '1' => 3 },
           }, 'report accumulates cell value');
 
-my $compared = LedgerSMB::Report::Hierarchical->new;
+my $compared = LedgerSMB::Report::Hierarchical->new(_uri => URI->new);
 
 # all we need to test now is the addition of comparisons, the rest
 # requires a database connection

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -1,4 +1,4 @@
-# Database schema upgrade pre-checks
+# Database schema upgrade pre-checks                         -*- mode: perl; -*-
 
 use Test2::V0;
 use Text::Diff;
@@ -39,6 +39,7 @@ sub test_request {
                 }
             },
         });
+    $plack_req->env->{'lsmb.script'}   = 'script.pl';
     my $req = LedgerSMB->new($plack_req, $wire);
 
     $req->{script}          = 'script.pl';

--- a/templates/demo/1099-INT.tex
+++ b/templates/demo/1099-INT.tex
@@ -23,7 +23,7 @@ Version   Changes
 
 <?lsmb BLOCK taxformpart ?>
 \begin{textblock}{4}[0,1](1, 1.5)
-<?lsmb company_name ?>\\
+<?lsmb SETTINGS.company_name ?>\\
 <?lsmb company_address ?>\\
 Tel: <?lsmb company_telephone ?>
 \end{textblock}

--- a/templates/demo/1099-MISC.tex
+++ b/templates/demo/1099-MISC.tex
@@ -25,7 +25,7 @@ Version   Changes
  # Defines a repeatable block of TeX commands
 ?>
 \begin{textblock}{4}[0,1](1, 1.5)
-<?lsmb company_name ?>\\
+<?lsmb SETTINGS.company_name ?>\\
 <?lsmb company_address ?>\\
 Tel: <?lsmb company_telephone ?>
 \end{textblock}

--- a/templates/demo/PNL.html
+++ b/templates/demo/PNL.html
@@ -255,7 +255,7 @@ END ;
     <!-- Also used in balance sheet! -->
     <h1><?lsmb name ?></h1>
     <div class="company-name">
-      <?lsmb company_name ?>
+      <?lsmb SETTINGS.company_name ?>
     </div>
     <div class="company-address">
       <?lsmb company_address ?>

--- a/templates/demo/PNL.tex
+++ b/templates/demo/PNL.tex
@@ -43,7 +43,7 @@ Version   Changes
 \Huge{<?lsmb text('Income Statement') ?>}
 
 \small{
-\texttt{<?lsmb company_name ?>}
+\texttt{<?lsmb SETTINGS.company_name ?>}
 
 
 \texttt{<?lsmb company_address ?>}

--- a/templates/demo/balance_sheet.html
+++ b/templates/demo/balance_sheet.html
@@ -255,7 +255,7 @@ END ;
     <h1><?lsmb text('Balance Sheet') ?></h1>
     <h2><?lsmb HLINES.1 ?></h2>
     <div class="company-name">
-      <?lsmb company_name ?>
+      <?lsmb SETTINGS.company_name ?>
     </div>
     <div class="company-address">
       <?lsmb company_address ?>

--- a/templates/demo/balance_sheet.tex
+++ b/templates/demo/balance_sheet.tex
@@ -45,7 +45,7 @@ Version   Changes
 <?lsmb HLINES.1 ?>
 
 \small{
-\texttt{<?lsmb company_name ?>}
+\texttt{<?lsmb SETTINGS.company_name ?>}
 
 
 \texttt{<?lsmb company_address ?>}

--- a/templates/demo/display_report.html
+++ b/templates/demo/display_report.html
@@ -11,31 +11,47 @@ releases. No explicit versioning was applied before 2021-01-04.
 -?>
 <?lsmb
 
-PROCESS "ui-header.html"
-   stylesheet = USER.stylesheet;
-
 PROCESS "dynatable.html";
 
 ?>
 <!DOCTYPE html>
 <html>
 <head>
-  <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.6.0">
   <title></title>
+  <style>
+    table tbody tr:nth-child(2n) {
+        background-color: #e6e6fa;
+    }
+    table tbody tr:nth-child(2n+1) {
+        background-color: #ffeeec;
+    }
+    table td, table th {
+        padding: 0.2em 1ex;
+    }
+    table thead {
+        background-color: #bcd8f4;
+    }
+    label {
+        font-weight: bold;
+    }
+    div.heading-section {
+        margin-bottom: 2em;
+    }
+  </style>
 </head>
-<body class="lsmb <?lsmb dojo_theme ?>">
-  <div class="heading_section">
-    <div class="report_header">
+<body>
+  <div class="heading-section">
+    <div class="report-header">
       <label><?lsmb text('Report Name') ?>:</label>
-      <span class="report_header"><?lsmb name ?></span>
+      <span class="report-header"><?lsmb name ?></span>
     </div>
-    <div class="report_header">
-      <label><?lsmb text('Company') ?>:</label> <span class=
-      "report_header"><?lsmb SETTINGS.company_name ?></span>
+    <div class="report-header">
+      <label><?lsmb text('Company') ?>:</label>
+      <span class="report-header"><?lsmb SETTINGS.company_name ?></span>
     </div><?lsmb FOREACH LINE IN hlines ?>
-    <div class="report_header">
+    <div class="report-header">
       <label><?lsmb LINE.text ?>:</label>
-      <span class="report_header"><?lsmb LINE.value ?></span>
+      <span class="report-header"><?lsmb LINE.value ?></span>
     </div><?lsmb END ?>
   </div><?lsmb PROCESS dynatable tbody = {rows = rows }
                  attributes = {class = 'report', order_url = order_url } ?>

--- a/templates/demo/display_report.html
+++ b/templates/demo/display_report.html
@@ -31,7 +31,7 @@ PROCESS "dynatable.html";
     </div>
     <div class="report_header">
       <label><?lsmb text('Company') ?>:</label> <span class=
-      "report_header"><?lsmb company_name ?></span>
+      "report_header"><?lsmb SETTINGS.company_name ?></span>
     </div><?lsmb FOREACH LINE IN hlines ?>
     <div class="report_header">
       <label><?lsmb LINE.text ?>:</label>

--- a/templates/demo/display_report.html
+++ b/templates/demo/display_report.html
@@ -26,21 +26,16 @@ PROCESS "dynatable.html";
 <body class="lsmb <?lsmb dojo_theme ?>">
   <div class="heading_section">
     <div class="report_header">
-      <label><?lsmb text('Report Name') ?>:</label> <span class=
-      "report_header"><?lsmb name ?></span>
+      <label><?lsmb text('Report Name') ?>:</label>
+      <span class="report_header"><?lsmb name ?></span>
     </div>
     <div class="report_header">
       <label><?lsmb text('Company') ?>:</label> <span class=
-      "report_header"><?lsmb request.company ?></span>
+      "report_header"><?lsmb company_name ?></span>
     </div><?lsmb FOREACH LINE IN hlines ?>
     <div class="report_header">
-      <label><?lsmb LINE.text ?>:</label> <span class="report_header"><?lsmb
-           IF request.${LINE.name};
-              request.${LINE.name};
-           ELSE;
-              report.${LINE.name};
-           END;
-           ?></span>
+      <label><?lsmb LINE.text ?>:</label>
+      <span class="report_header"><?lsmb LINE.value ?></span>
     </div><?lsmb END ?>
   </div><?lsmb PROCESS dynatable tbody = {rows = rows }
                  attributes = {class = 'report', order_url = order_url } ?>

--- a/templates/demo/display_report.odst
+++ b/templates/demo/display_report.odst
@@ -27,11 +27,11 @@ END;
      <cell text="<?lsmb name | html ?>" />
 </row>
 <row><cell text="<?lsmb text('Company') | html ?>:" />
-     <cell text="<?lsmb request.company | html ?>" />
+     <cell text="<?lsmb company_name | html ?>" />
 </row>
 <?lsmb FOREACH HLINE IN hlines -?>
 <row><cell text="<?lsmb HLINE.text | html ?>:" />
-     <cell text="<?lsmb request.${HLINE.name} | html ?>" />
+     <cell text="<?lsmb HLINE.value | html ?>" />
 </row>
 <?lsmb END -?>
 </worksheet>

--- a/templates/demo/display_report.odst
+++ b/templates/demo/display_report.odst
@@ -27,7 +27,7 @@ END;
      <cell text="<?lsmb name | html ?>" />
 </row>
 <row><cell text="<?lsmb text('Company') | html ?>:" />
-     <cell text="<?lsmb company_name | html ?>" />
+     <cell text="<?lsmb SETTINGS.company_name | html ?>" />
 </row>
 <?lsmb FOREACH HLINE IN hlines -?>
 <row><cell text="<?lsmb HLINE.text | html ?>:" />

--- a/templates/demo/display_report.xlst
+++ b/templates/demo/display_report.xlst
@@ -27,11 +27,11 @@ END;
      <cell text="<?lsmb name | html ?>" />
 </row>
 <row><cell text="<?lsmb text('Company') | html ?>:" />
-     <cell text="<?lsmb request.company | html ?>" />
+     <cell text="<?lsmb company_name | html ?>" />
 </row>
 <?lsmb FOREACH HLINE IN hlines -?>
 <row><cell text="<?lsmb HLINE.text | html ?>:" />
-     <cell text="<?lsmb request.${HLINE.name} | html ?>" />
+     <cell text="<?lsmb HLINE.value | html ?>" />
 </row>
 <?lsmb END -?>
 </worksheet>

--- a/templates/demo/display_report.xlst
+++ b/templates/demo/display_report.xlst
@@ -27,7 +27,7 @@ END;
      <cell text="<?lsmb name | html ?>" />
 </row>
 <row><cell text="<?lsmb text('Company') | html ?>:" />
-     <cell text="<?lsmb company_name | html ?>" />
+     <cell text="<?lsmb SETTINGS.company_name | html ?>" />
 </row>
 <?lsmb FOREACH HLINE IN hlines -?>
 <row><cell text="<?lsmb HLINE.text | html ?>:" />

--- a/templates/lib/dynatable.html
+++ b/templates/lib/dynatable.html
@@ -85,15 +85,7 @@ releases. No explicit versioning was applied before 2021-01-04.
    <tr>
    <?lsmb- FOREACH COL IN columns;
    IF COL.type != 'hidden'; -?>
-   <th class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type ?>"><?lsmb
-
-IF attributes.order_url
-?> <a href="<?lsmb order_url | url ?>&amp;order_by=<?lsmb COL.col_id ?>"><?lsmb
-END;
-COL.name;
-IF attributes.order_url
-?></a><?lsmb
-END; ?>
+   <th class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type ?>"><?lsmb COL.name ?>
    </th>
    <?lsmb- END; END; -?>
    </tr>
@@ -123,41 +115,27 @@ END; ?>
               TYPE = 'text';
             END;
 
-            NEXT IF TYPE == 'hidden';
+            NEXT IF TYPE == 'hidden'; -?>
       <td class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type ?>"<?lsmb ROWSPAN ?>>
           <?lsmb- IF TYPE == 'boolean_checkmark' OR TYPE == 'checkbox' OR TYPE == 'radio';
                    IF ROW.${COL.col_id};
-                       ?>✓<?lsmb
+                      '✓';
                    END;
 
-         <?lsmb- ELSIF TYPE == 'select';
-                 # ROW is passed as an argument if COL.options is a callback
-                 # function, which allows dropdown options to be dynamically
-                 # customised to each row. The ROW argument is harmlessly
-                 # ignored by Template Toolkit if COL.options is a static
-                 # arrayref common to every row.
-                 OPTION_LIST = COL.options(ROW);
+                  ELSIF TYPE == 'select';
+                  # ROW is passed as an argument if COL.options is a callback
+                  # function, which allows dropdown options to be dynamically
+                  # customised to each row. The ROW argument is harmlessly
+                  # ignored by Template Toolkit if COL.options is a static
+                  # arrayref common to every row.
+                  OPTION_LIST = COL.options(ROW);
 
-                 FOREACH option IN OPTION_LIST
-                    IF option.value == ROW.${COL.col_id}
-                       option.text
-                    END
-                 END
-                 ?>
-         <?lsmb- ELSIF TYPE == 'href';
-                   HREF_SFX = COL.col_id _ "_href_suffix";
-                   IF ROW.$HREF_SFX;
-                      ESCAPED_HREF = COL.href_base _ ROW.$HREF_SFX | url;
-                   ELSE;
-                      ESCAPED_BASE = COL.href_base | url;
-                      ESCAPED_PARAM = UNESCAPE(ROW.row_id) | uri;
-                      ESCAPED_HREF = ESCAPED_BASE _ ESCAPED_PARAM;
-                   END;
-                   IF COL.href_target;
-                      HREF_TGT = ' target="' _ COL.href_target _ '"';
-                   END;
-          ?><a href="<?lsmb ESCAPED_HREF ?>"<?lsmb HREF_TGT ?>><?lsmb ROW.${COL.col_id} ?></a>
-         <?lsmb- ELSE -?>
+                  FOREACH option IN OPTION_LIST;
+                    IF option.value == ROW.${COL.col_id};
+                       option.text;
+                    END;
+                  END;
+                 ELSE -?>
             <?lsmb ROW.${COL.col_id} ?>
          <?lsmb- END -?>
       </td>
@@ -187,21 +165,13 @@ END; ?>
                 <td colspan="<?lsmb SPACECOUNT ?>">&nbsp;</td>
              <?lsmb END;
        NEXT IF TYPE == 'hidden';
-
+       -?>
        <td class="<?lsmb COL.col_id ?>">
           <?lsmb- IF TYPE == 'boolean_checkmark' OR TYPE == 'checkbox' OR TYPE == 'radio';
                    IF ROW.${COL.col_id};
-                       ?>✓<?lsmb
+                       '✓';
                    END;
-         <?lsmb- ELSIF TYPE == 'href';
-                   HREF_SFX = COL.col_id _ "_href_suffix";
-                   IF row.$HREF_SFX;
-                      HREF = COL.href_base _ ROW.$HREF_SFX;
-                   ELSE;
-                      HREF = COL.href_base _ ROW.row_id;
-                   END
-          ?><a href="<?lsmb HREF ?>"><?lsmb ROW.${COL.col_id} ?></a>
-         <?lsmb- ELSE -?>
+                 ELSE -?>
             <?lsmb ROW.${COL.col_id} ?>
          <?lsmb- END -?>
      </td>

--- a/xt/40-ledgersmb.t
+++ b/xt/40-ledgersmb.t
@@ -51,12 +51,6 @@ is($#r, 0, 'call_procedure: correct return length (one row)');
 is($r[0]->{'character_length'}, 5,
         'call_procedure: single arg, non-numeric return');
 
-@r = $lsmb->call_procedure('procname' => 'trunc',
-        'funcschema' => 'pg_catalog',
-        'args' => ['57.12', 1]);
-is($r[0]->{'trunc'} , Math::BigFloat->new('57.1'),
-        'call_procedure: two args, numeric return');
-
 @r = $lsmb->call_procedure('procname' => 'pi',
         'funcschema' => 'pg_catalog',
         'args' => []);

--- a/xt/40-ledgersmb.t
+++ b/xt/40-ledgersmb.t
@@ -12,6 +12,7 @@ use Plack::Request;
 
 use LedgerSMB;
 use LedgerSMB::Locale;
+use LedgerSMB::PGNumber;
 
 
 my $wire = Beam::Wire->new(file => 't/ledgersmb.yaml');

--- a/xt/40-ledgersmb.t
+++ b/xt/40-ledgersmb.t
@@ -53,8 +53,8 @@ is($r[0]->{'character_length'}, 5,
 
 @r = $lsmb->call_procedure('procname' => 'trunc',
         'funcschema' => 'pg_catalog',
-        'args' => [57.1, 0]);
-is($r[0]->{'trunc'}, Math::BigFloat->new('57'),
+        'args' => ['57.12', 1]);
+is($r[0]->{'trunc'} , Math::BigFloat->new('57.1'),
         'call_procedure: two args, numeric return');
 
 @r = $lsmb->call_procedure('procname' => 'pi',

--- a/xt/40-ledgersmb.t
+++ b/xt/40-ledgersmb.t
@@ -28,7 +28,7 @@ $wire = Beam::Wire->new(
             },
         }
     });
-my $request = Plack::Request->new({});
+my $request = Plack::Request->new({ 'lsmb.script' => 'test.pl' });
 
 my $lsmb = LedgerSMB->new($request, $wire);
 my @r;

--- a/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
+++ b/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
@@ -10,6 +10,8 @@ that exercise interaction with a test database.
 use Test2::V0;
 
 use DBI;
+use URI;
+
 use LedgerSMB::Batch;
 use LedgerSMB::Report::Unapproved::Batch_Overview
 
@@ -76,7 +78,9 @@ foreach my $batch_data(@test_batches) {
 
 
 # Initialise Object
-$report = LedgerSMB::Report::Unapproved::Batch_Overview->new();
+$report = LedgerSMB::Report::Unapproved::Batch_Overview->new(
+    _uri => URI->new,
+    );
 isa_ok($report, ['LedgerSMB::Report::Unapproved::Batch_Overview'], 'instantiated object');
 ok($report->set_dbh($dbh), 'set dbh');
 


### PR DESCRIPTION
In order to be able to use our reports from the web services implementations - which we want in order to generate other-than-JSON representations - we need to be able to evaluate our reports in a context which does *not* provide a `$request` instance.

This PR also adds download links to `ConfigTable` based configuration components and fixes (and simplifies) the PDF/PS as well as the HTML `display_report` and `dynatable` "document templates" (i.e. the ones which don't go in the UI). It finishes the first of the two main bullets in #6606.