### PR TITLE
Simplify and improve dynatable LaTeX template

### DIFF
--- a/templates/demo/display_report.tex
+++ b/templates/demo/display_report.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.1
-   Date:     2022-07-22
+   Version:  1.2
+   Date:     2022-07-27
    File:     display_report.tex
    Set:      demo
 
@@ -10,6 +10,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
 1.1       Merged xelatex targetting templates with those targetting pdflatex
+1.2       Simplified report header generation factored out of dynatable
 
 -?>
 <?lsmb- PROCESS 'dynatable.tex';
@@ -29,32 +30,20 @@ FILTER latex { format="$FORMAT($PROCESSOR)" };
 \usepackage{longtable}
 \usepackage[margin=1cm]{geometry}
 \begin{document}
-<?lsmb
 
-FIRSTHEAD = '\\multicolumn{2}{r}{' _ text('Report Name') _ ':} & ' _
-            '\\multicolumn{' _ (COLNUMBER - 2) _ '}{l}{ ' _ name _ '}\\\\
-             \\multicolumn{2}{r}{' _ text('Company') _ ':} & ' _
-            '\\multicolumn{' _ (COLNUMBER - 2) _ '}{l}{ ' _ request.company
-            _ '} \\\\
-            ';
+\begin{center}
+\begin{tabular}{rl}
+  \textbf{<?lsmb text('Report Name') ?>}: & <?lsmb name ?> \\
+  \textbf{<?lsmb text('Company') ?>}: & <?lsmb SETTINGS.company_name ?> \\
+  <?lsmb- newlines = new_heads(hlines);
+  FOREACH LINE IN newlines -?>
+  \textbf{<?lsmb LINE.text ?>}: & <?lsmb LINE.value ?> \\
+  <?lsmb- END -?>
+\end{tabular}
+\end{center}
 
-# use new_heads to get around variable name escaping
-newlines = new_heads(hlines);
-FOREACH LINE IN newlines;
-    IF request.${LINE.name}; #$
-        headval = request.${LINE.name}; #$
-    ELSE;
-         headval = report.${LINE.name};
-    END;
-    FIRSTHEAD = FIRSTHEAD _ '\\multicolumn{2}{r}{ ' _ LINE.text _ ':} & ';
-    FIRSTHEAD = FIRSTHEAD _ '\\multicolumn{' _ (COLNUMBER - 2) _ '}{l}{ ' _ headval;
-    FIRSTHEAD = FIRSTHEAD _ '}\\\\
-             ';
-END;
-
-PROCESS dynatable 
-      tbody = { rows = rows }
-      firsthead = FIRSTHEAD;
+<?lsmb PROCESS dynatable
+      tbody = { rows = rows };
 ?>
 \end{document}
 <?lsmb END -?>

--- a/templates/lib/dynatable.tex
+++ b/templates/lib/dynatable.tex
@@ -1,12 +1,18 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2022-07-27
    File:     dynatable.tex
    Set:      none; shared
 
 Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
+
+Version   Changes
+1.1       Simplified version which also works without columns of pre-declared
+          width by using tabular environments to capture 'intentionally multi-
+          line output' into a single cell.
+
 
 -?>
 <?lsmb- BLOCK dynatable;
@@ -14,14 +20,14 @@ releases. No explicit versioning was applied before 2021-01-04.
 TOTAL_WIDTH=14; # cm. using A4 as a basis because it is slightly narrower than
                 # US Letter. This way the dynatable works for both paper sizes.
                 # This assumes a 1cm margin on either side. --CT
-DECLARED_WIDTH=0; 
+DECLARED_WIDTH=0;
 
 SKIP_TYPES = ['hidden', 'radio', 'checkbox'];
 
 
 FOREACH COL IN columns;
     DECLARED_WIDTH = DECLARED_WIDTH + COL.pwidth; # pwidth is arbitrary scale
-END; 
+END;
 
 IF DECLARED_WIDTH > 0;
     WIDTH_PER_P = TOTAL_WIDTH / DECLARED_WIDTH;
@@ -47,12 +53,8 @@ FOREACH COL IN columns;
    IF COL.psep_after;
       '|';
    END;
-END; 
+END;
 -?>}
-<?lsmb IF firsthead; firsthead ?>\\
-<?lsmb- END ?>
-<?lsmb IF head; head ?>\\<?lsmb- END ?>
-<?lsmb- -?>
 <?lsmb
 FOREACH COL IN columns;
     IF 0 == SKIP_TYPES.grep(COL.type).size() AND ! COL.html_only;
@@ -82,14 +84,13 @@ END;
 
 FOREACH ROW IN tbody.rows;
     FOREACH COL IN columns;
-        COLID =  COL.col_id.replace('\\\\');
         IF 0 == SKIP_TYPES.grep(COL.type).size() AND ! COL.html_only;
             UNLESS loop.first();
                ' & ';
             END;
-            ?>\begin{minipage}{<?lsmb (COL.pwidth * WIDTH_PER_P) _ "cm"; ?>}<?lsmb
-                ROW.${COLID}; #$
-            ?>\end{minipage}<?lsmb
+            ?>\begin{tabular}[t]{@{}l@{}}<?lsmb
+                ROW.${COL.col_id};
+            ?>\end{tabular}<?lsmb
         END;
     END;
     ?>\tabularnewline


### PR DESCRIPTION
 1. Replace `firsthead` with a stand-alone 'tabular'
 2. Remove `head` since `display_report` doesn't use it
 3. Support 2-column reports in the process of (1) and (2)
 4. Support cells with linebreaks without the need to specify
    explicit cell width (replacing `minipage` with nested
    `tabular`)
