### PR TITLE
Fix timing issue between Vue and Dojo

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -72,7 +72,9 @@ export default {
                             if (dismiss) {
                                 dismiss();
                             }
-                            this.notify({ title: options.done || this.$t("Loaded") });
+                            this.notify({
+                                title: options.done || this.$t("Loaded")
+                            });
                             topic.publish("lsmb/page-fresh-content");
                             maindiv.setAttribute("data-lsmb-done", "true");
                         });

--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -59,13 +59,26 @@ export default {
                 let b = await r.text();
                 if (r.ok && !domReject(r)) {
                     this.content = b;
+                    this.$nextTick(() => {
+                        let maindiv = document.getElementById("maindiv");
+                        parser.parse(maindiv).then(() => {
+                            registry.findWidgets(maindiv).forEach((child) => {
+                                this._recursively_resize(child);
+                            });
+                            maindiv.setAttribute("data-lsmb-done", "true");
+                            maindiv
+                                .querySelectorAll("a")
+                                .forEach((node) => this._interceptClick(node));
+                            if (dismiss) {
+                                dismiss();
+                            }
+                            this.notify({ title: options.done || this.$t("Loaded") });
+                            maindiv.setAttribute("data-lsmb-done", "true");
+                        });
+                    });
                 } else {
                     this._report_error(r);
                 }
-                if (dismiss) {
-                    dismiss();
-                }
-                this.notify({ title: options.done || this.$t("Loaded") });
             } catch (e) {
                 this._report_error(e);
             }
@@ -133,8 +146,6 @@ export default {
             }
         }
     },
-    beforeRouteEnter() {},
-    beforeRouteUpdate() {},
     beforeRouteLeave() {
         this._cleanWidgets();
     },
@@ -148,23 +159,6 @@ export default {
     },
     beforeUpdate() {
         this._cleanWidgets();
-    },
-    updated() {
-        if (!document.getElementById("maindiv")) {
-            return;
-        }
-        this.$nextTick(() => {
-            let maindiv = document.getElementById("maindiv");
-            parser.parse(maindiv).then(() => {
-                registry.findWidgets(maindiv).forEach((child) => {
-                    this._recursively_resize(child);
-                });
-                maindiv.setAttribute("data-lsmb-done", "true");
-            });
-            maindiv
-                .querySelectorAll("a")
-                .forEach((node) => this._interceptClick(node));
-        });
     },
     render() {
         let body = this.content.match(/<body[^>]*>([\s\S]*)(<\/body>)?/i);

--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -6,6 +6,7 @@ import { useI18n } from "vue-i18n";
 const registry = require("dijit/registry");
 const parser = require("dojo/parser");
 const query = require("dojo/query");
+const topic = require("dojo/topic");
 
 function domReject(response) {
     return (
@@ -65,7 +66,6 @@ export default {
                             registry.findWidgets(maindiv).forEach((child) => {
                                 this._recursively_resize(child);
                             });
-                            maindiv.setAttribute("data-lsmb-done", "true");
                             maindiv
                                 .querySelectorAll("a")
                                 .forEach((node) => this._interceptClick(node));
@@ -73,6 +73,7 @@ export default {
                                 dismiss();
                             }
                             this.notify({ title: options.done || this.$t("Loaded") });
+                            topic.publish("lsmb/page-fresh-content");
                             maindiv.setAttribute("data-lsmb-done", "true");
                         });
                     });

--- a/UI/src/elements/lsmb-file.js
+++ b/UI/src/elements/lsmb-file.js
@@ -55,10 +55,13 @@ export class LsmbFile extends HTMLElement {
         }
 
         if (name === "disabled" || name === "required") {
-            if (newValue === null) {
-                document.getElementById(this.elmId).removeAttribute(name);
-            } else {
-                document.getElementById(this.elmId).setAttribute(name, "");
+            let elm = document.getElementById(this.elmId);
+            if (elm) {
+                if (newValue === null) {
+                    document.getElementById(this.elmId).removeAttribute(name);
+                } else {
+                    document.getElementById(this.elmId).setAttribute(name, "");
+                }
             }
         }
     }
@@ -68,6 +71,12 @@ export class LsmbFile extends HTMLElement {
         let label = "";
         if (this.hasAttribute("name")) {
             options += ` name="${escHTML(this.getAttribute("name"))}"`;
+        }
+        if (this.required) {
+            options += " required";
+        }
+        if (this.disabled) {
+            options += " disabled";
         }
         if (this.hasAttribute("accept")) {
             options += ` accept="${escHTML(this.getAttribute("accept"))}"`;


### PR DESCRIPTION
Vue fires the 'updated()' event before the 'beforeUpdate' event sets
the `content`. Instead of trying to get the two to align, hook onto
the `nextTick()` (DOM update) event inside `beforeUpdate` so Dojo
can parse the DOM after it updates.
