### PR TITLE
Separate save/submit concerns for recon reports

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -93,7 +93,7 @@ Submits the reconciliation set for approval.
 
 sub submit {
     my $self = shift @_;
-    $self->_pre_save;
+    $self->save;
     return $self->call_dbmethod(funcname=>'reconciliation__submit_set');
 }
 

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -150,6 +150,9 @@ contact__search
 contact_class__list
 cr_coa_to_account_save
 cr_report_block_changing_approved
+cr_report_line_cleared_update
+cr_report_line_link_insert
+cr_report_submitted_update
 credit_limit__used
 currency__delete
 currency__get

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -48,7 +48,7 @@ BEGIN;
     SELECT has_function('reconciliation__report_summary',array['integer']);
     SELECT has_function('reconciliation__save_set',array['integer', 'integer[]']);
     SELECT has_function('reconciliation__search',array['date', 'date', 'numeric', 'numeric', 'integer', 'boolean', 'boolean']);
-    SELECT has_function('reconciliation__submit_set',array['integer', 'integer[]']);
+    SELECT has_function('reconciliation__submit_set',array['integer']);
 
     -- Run tests
 
@@ -116,7 +116,12 @@ BEGIN;
     SELECT results_eq('test',ARRAY[6],'Correct number of report lines');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select array_agg(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int));
+    select reconciliation__save_set(
+           currval('cr_report_id_seq')::int,
+           (select array_agg(id::int) from cr_report_line
+             where report_id = currval('cr_report_id_seq')::int)
+    );
+    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int);
     SELECT results_eq('test',ARRAY[true],'Report Submitted');
     DEALLOCATE test;
 
@@ -190,7 +195,7 @@ BEGIN;
     SELECT results_eq('test',ARRAY[2],'1 Correct number of report lines');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, '{}');
+    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int);
     SELECT results_eq('test',ARRAY[true],'1 Report Submitted');
     DEALLOCATE test;
 
@@ -238,9 +243,13 @@ BEGIN;
     SELECT results_eq('test',ARRAY[12],'Correct number of transactions 4');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select array_agg(id::int)
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int));
+
+    select reconciliation__save_set(
+           currval('cr_report_id_seq')::int,
+           (select array_agg(id::int) from cr_report_line
+             where report_id = currval('cr_report_id_seq')::int)
+    );
+    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int);
     SELECT results_eq('test',ARRAY[true],'Report Submitted');
     DEALLOCATE test;
 

--- a/xt/66-cucumber/13-cash/step_definitions/basic_steps.pl
+++ b/xt/66-cucumber/13-cash/step_definitions/basic_steps.pl
@@ -164,7 +164,7 @@ When qr/I create (a|one|two) reconciliations? ending on (\d{4}-\d\d-\d\d)/ => su
     S->{'the second reconciliation'} = _create_recon($end_date)
 };
 
-When qr/(the (first |second )?reconciliation) is submitted/ => sub {
+When qr/(the (?:first |second )?reconciliation) is submitted/ => sub {
     my $recon_name = $1;
     my $recon_id   = S->{$recon_name};
     my $dbh        = S->{ext_lsmb}->admin_dbh;
@@ -189,8 +189,8 @@ When qr/(the (first |second )?reconciliation) is submitted/ => sub {
     ok(1);
 };
 
-Then qr/(the (first |second )?reconciliation) can( also| not|'t)? be submitted/ => sub {
-    my $negate     = $2 and ($2 eq ' not' or $2 eq q{'t});
+Then qr/(the (?:first |second )?reconciliation) can( also| not|'t)? be submitted/ => sub {
+    my $negate     = ($2 and ($2 eq ' not' or $2 eq q{'t}));
     my $recon_name = $1;
     my $recon_id   = S->{$recon_name};
     my $dbh        = S->{ext_lsmb}->admin_dbh;
@@ -224,8 +224,8 @@ Then qr/(the (first |second )?reconciliation) can( also| not|'t)? be submitted/ 
     }
 };
 
-When qr/the journal line is cleared in (the (first |second )?reconciliation)/ => sub {
-    my $recon_name = $2;
+When qr/the journal line is cleared in (the (?:first |second )?reconciliation)/ => sub {
+    my $recon_name = $1;
     my $recon_id   = S->{$recon_name};
     my $dbh        = S->{ext_lsmb}->admin_dbh;
 
@@ -249,7 +249,7 @@ When qr/the journal line is cleared in (the (first |second )?reconciliation)/ =>
     ok(1);
 };
 
-Then qr/the journal line is (not )?in (the (first |second )?reconciliation)/ => sub {
+Then qr/the journal line is (not )?in (the (?:first |second )?reconciliation)/ => sub {
     my $negate     = $1;
     my $recon_name = $2;
     my $recon_id   = S->{$recon_name};


### PR DESCRIPTION
This PR also fixes a warning caused by operator precedence mismatches (and actually, that's what this was about initially).