### PR TITLE
Add spacing after login.pl labels

### DIFF
--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -666,6 +666,7 @@ h2 {
 
 #logindiv #company_div {
     display: grid;
+    grid-column-gap: 1ex;
     grid-row-gap: 4px;
     grid-template: none / auto auto;
     margin-bottom: 1em;


### PR DESCRIPTION
The label texts were directly next to the input boxes, without separating
white space. It's much more appealing if there is at least *some* white space,
so use one 'average letter width' white space region between the widest label
and the text boxes.
