### PR TITLE
Remove deprecated warnings

### DIFF
--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -665,12 +665,12 @@ h2 {
 }
 
 #logindiv #company_div {
+    column-gap: 1ex;
     display: grid;
-    grid-column-gap: 1ex;
-    grid-row-gap: 4px;
     grid-template: none / auto auto;
     margin-bottom: 1em;
     margin-top: 2em;
+    row-gap: 4px;
 }
 
 #logindiv #company_div lsmb-text,


### PR DESCRIPTION
Removes webpack compilation warnings:
`grid-column-gap` is deprecated in favor of `column-gap`
