### PR TITLE
Disable coverage reporting from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,14 +291,14 @@ jobs:
       postgres: '11'
       browser: chrome
       selenium: selenium/node-chrome:3.141.59-20210607
-      coverage: 1
+#      coverage: 1
     steps:
       - prep_env:
           perl: '5.34'
       - start_starman
       - start_proxy
       - prove
- 
+
     # The resource_class feature allows configuring CPU and RAM resources for each job.
     # Different resource classes are available for different executors.
     # https://circleci.com/docs/2.0/configuration-reference/#resourceclass

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -289,7 +289,7 @@ jobs:
           cover -report text > logs/coverage.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ matrix.COVERAGE && github.repository != 'ledgersmb/LedgerSMB'}}
+        if: ${{ matrix.COVERAGE }}
 
       - name: Collect docker logs
         uses: jwalton/gh-docker-logs@v2


### PR DESCRIPTION
For some as of yet unknown reason, CCI reports lower numbers than GitHub.
To be investigated, but to prevent "flip-flopping", choosing a single source
for now.
