### PR TITLE
Fix saving of parts without a partsgroup

### DIFF
--- a/old/lib/LedgerSMB/IC.pm
+++ b/old/lib/LedgerSMB/IC.pm
@@ -420,7 +420,6 @@ sub save {
 
     my $partsgroup_id;
     ( $null, $partsgroup_id ) = split /--/, $form->{partsgroup};
-    $partsgroup_id *= 1;
 
 
     if ( !$form->{priceupdate} ) {


### PR DESCRIPTION
Following up to 4c4ba5ff3ec0787876568eba90b08faf693428a3, which introduces
a foreign key on the parts table to the partgroups table, it's no longer
possible to set a value of zero. However, the removed instruction causes
the value to be zero if there's no partsgroup selected.
