### PR TITLE
Remove unused infrastructure: projects are now reporting units

### DIFF
--- a/UI/journal/journal_entry.html
+++ b/UI/journal/journal_entry.html
@@ -144,9 +144,6 @@
           <th class="listheading">[% text('Credit') %]</th>
           <th class="listheading">[% text('Source') %]</th>
           <th class="listheading">[% text('Memo') %]</th>
-          [% IF form.projectset == 1 %]
-          <th class="listheading">[% text('Project') %]</th>
-          [% END %]
           [% FOREACH cls IN form.bu_class %]
               [% IF form.b_units.${cls.id} %]
           <th>[% maketext(cls.label)
@@ -237,31 +234,6 @@
                                      }  %]
 
                    </td>
-                  [% IF form.projectset == 1 %]
-                   <td>
-
-                        [% IF displayrow.projectset == 1 %]
-                                        [% PROCESS label element_data = {
-                                              text = displayrow.projectnumber
-                                              align = 'right'
-                                              id = "pro_$INDEX"
-                                     } %]
-
-
-                        [% ELSE %]
-                                [% INCLUDE select element_data = {
-                                        text_attr = "projectnumber"
-                                        value_attr = "projectstyle"
-                                        default_values = []
-                                        options = form.all_project
-                                        name = "projectnumber_$INDEX"
-                                        id = "pro_$INDEX"
-                                     } %]
-
-                        [% END %]
-
-                   </td>
-                       [% END %]
                    [% FOREACH cls IN form.bu_class %]
                       [% IF form.b_units.${cls.id} %]
                    <td>
@@ -324,9 +296,6 @@
           </th>
           <th>&nbsp;</th>
           <th>&nbsp;</th>
-          [% IF form.projectset == 1 %]
-          <th class="listheading">&nbsp;</th>
-          [% END %]
           [% FOREACH cls IN form.bu_class %]
               [% IF form.b_units.${cls.id} %]
           <th>&nbsp;</th>

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -169,9 +169,6 @@ sub display_form
     if ($form->{all_department}){
         unshift @{ $form->{all_department} }, {};
     }
-    if ($form->{all_project}){
-       unshift @{ $form->{all_project} }, {};
-    }
     $title = $locale->maketext($form->{title});
     if ( $form->{transfer} ) {
         $form->{title} = $locale->text("[_1] Cash Transfer Transaction", $title);
@@ -373,7 +370,6 @@ sub display_row {
         $temphash1->{fx_transactionset} = 1;
         if (!defined $form->{"accno_$i"} || ! $form->{"accno_$i"}) {
                   $temphash1->{accnoset}=0;   #use  @{ $form->{all_accno} }
-                  $temphash1->{projectset}=0; #use  @{ $form->{all_project} }
                   $temphash1->{fx_transactionset}=0;    #use checkbox and value=1 if transfer=1
 
         }

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1053,28 +1053,6 @@ sub generate_selects {
         }
     }
 
-     # projects
-    if ( $form->{all_project} && @{ $form->{all_project} } ) {
-        $form->{selectprojectnumber} = "<option></option>\n";
-          $form->{selectprojectnumber} = "";
-
-        for ( @{ $form->{all_project} } ) {
-            my $value = "$_->{projectnumber}--$_->{id}";
-            $form->{selectprojectnumber} .=
-                     # change the format here, then change it below!
-                     qq|<option value="$value">$_->{projectnumber}</option>\n|;
-        }
-
-          if ($form->{rowcount}) {
-                for my $i ( 1 .. $form->{rowcount} ) {
-                     $form->{"selectprojectnumber_$i"} =
-                          $form->{"selectprojectnumber"};
-                     $form->{"selectprojectnumber_$i"} =~
-                          s/(value="\Q$form->{"projectnumber_$i"}\E")/$1 selected="selected"/;
-                }
-          }
-    }
-
     # departments
     if ( $form->{all_department} && @{ $form->{all_department} } ) {
         $form->{selectdepartment} = "<option></option>\n";


### PR DESCRIPTION
Projects used to be a separate entity. Nowadays, they're just a class
of reporting unit. Remove code that can't be triggered as a result.
