### PR TITLE
Show all applicable tax accounts in invoices, transactions and orders

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1913,6 +1913,7 @@ sub create_links {
     $self->{accounts} = "";
 
     while ( my $ref = $sth->fetchrow_hashref('NAME_lc') ) {
+        $self->{_accno_descriptions}->{$ref->{accno}} = $ref->{description};
         my $link = $ref->{link};
 
         push(@$link,"${module}_tax") if $tax_accounts{$ref->{accno}};

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1916,12 +1916,11 @@ sub create_links {
         $self->{_accno_descriptions}->{$ref->{accno}} = $ref->{description};
         my $link = $ref->{link};
 
-        push(@$link,"${module}_tax") if $tax_accounts{$ref->{accno}};
+        push(@$link,"${module}_tax") # there's no "${module}_tax" link; only a tax boolean
+            if $tax_accounts{$ref->{accno}};
 
         foreach my $key ( @$link ) {
-
-            if ( $key =~ /$module/ ) {
-
+            if ( $key =~ /$module/ ) { # *all* tax accounts selected in query above
                 # cross reference for keys
                 $xkeyref{ $ref->{accno} } = $key;
 

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -542,7 +542,7 @@ sub invoice_details {
             );
 
             push( @{ $form->{taxdescription} },
-                $form->{"${item}_description"} );
+                $form->{_accno_descriptions}->{$item} );
 
             $form->{"${item}_taxrate"} =
               $form->format_amount( $myconfig, $form->{"${item}_rate"} * 100 );

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -1204,7 +1204,7 @@ sub order_details {
             );
 
             push( @{ $form->{taxdescription} },
-                $form->{"${item}_description"} );
+                $form->{_accno_descriptions}->{$item} );
 
             $form->{"${item}_taxrate"} =
               $form->format_amount( $myconfig, $form->{"${item}_rate"} * 100 );


### PR DESCRIPTION
Applicable is defined as the union between the taxes currently marked
applicable for the customer and the taxes used in the transaction.
Before this commit, the latter category was silently dropped.

Closes #2322.