### PR TITLE
Fix voiding invoices sometimes not being exact reversals

### DIFF
--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -681,9 +681,6 @@ sub void {
            "Can't void a voided invoice!"
        ));
     }
-    for my $i (1 .. $form->{rowcount}){
-        $form->{"qty_$_"} *= -1;
-    }
     $form->{invnumber} .= '-VOID';
     $form->{reverse} = 1;
     $form->{paidaccounts} = 1;


### PR DESCRIPTION
Under some circumstances (accidental value of '$_' and
'$form->{rowcount}' being an odd number), invoices have
a random line sign-inversed when voided.
