### PR TITLE
Compatibility with Pg14 for upgraded databases

### DIFF
--- a/sql/changes/1.7/pg14-compatible-agg.sql
+++ b/sql/changes/1.7/pg14-compatible-agg.sql
@@ -1,0 +1,52 @@
+
+
+drop aggregate as_array(anyelement) cascade;
+drop aggregate compound_array(anyarray) cascade;
+
+
+
+CREATE OR REPLACE FUNCTION lsmb_array_append(ary anyarray, elm anyelement)
+RETURNS anyarray
+AS $$
+   SELECT array_append(ary, elm);
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION lsmb_array_append(anyarray, anyelement)
+IS $$PostgreSQL 14 vs pre-14 compatibility measure.$$;
+
+CREATE AGGREGATE as_array (
+        BASETYPE = ANYELEMENT,
+        STYPE = ANYARRAY,
+        SFUNC = LSMB_ARRAY_APPEND,
+        INITCOND = '{}'
+);
+
+COMMENT ON AGGREGATE as_array(ANYELEMENT) IS
+$$ A basic array aggregate to take elements and return a one-dimensional array.
+
+Example:  SELECT as_array(id) from entity_class;
+$$;
+
+
+CREATE OR REPLACE FUNCTION compound_array(ary anyarray, elm anyarray)
+RETURNS anyarray
+AS $$
+   SELECT array_cat(ary, elm);
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION compound_array(anyarray, anyarray)
+IS $$PostgreSQL 14 vs pre-14 compatibility measure.$$;
+
+
+CREATE AGGREGATE compound_array (
+        BASETYPE = ANYARRAY,
+        STYPE = ANYARRAY,
+        SFUNC = COMPOUND_ARRAY,
+        INITCOND = '{}'
+);
+
+COMMENT ON AGGREGATE compound_array(ANYARRAY) is
+$$ Returns an n dimensional array.
+
+Example: SELECT as_array(ARRAY[id::text, class]) from contact_class
+$$;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -113,6 +113,7 @@ mc/delete-migration-validation-data.sql
 1.7/create-trans_id-index.sql
 1.7/fix-oe-person_id-fkey.sql
 1.7/new_shipto-fkey.sql
+1.7/pg14-compatible-agg.sql
 # 1.8 changes
 1.8/add-transdate-to-transactions.sql
 1.8/update-payment-tables-documentation.sql


### PR DESCRIPTION
Prior fixes for Pg14 compatibility only applied to newly created
databases. This one targets existing databases being upgraded.

After the upgrade, the database dump will be restorable on Pg14.
