### PR TITLE
Remove aggregate definition from schema

### DIFF
--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -3389,29 +3389,6 @@ CREATE INDEX menu_acl_node_id_idx ON menu_acl (node_id);
 -- PostgreSQL database dump complete
 --
 
-CREATE OR REPLACE FUNCTION compound_array(ary anyarray, elm anyarray)
-RETURNS anyarray
-AS $$
-   SELECT array_cat(ary, elm);
-$$ LANGUAGE sql;
-
-COMMENT ON FUNCTION compound_array(anyarray, anyarray)
-IS $$PostgreSQL 14 vs pre-14 compatibility measure.$$;
-
-
-CREATE AGGREGATE compound_array (
-        BASETYPE = ANYARRAY,
-        STYPE = ANYARRAY,
-        SFUNC = COMPOUND_ARRAY,
-        INITCOND = '{}'
-);
-
-COMMENT ON AGGREGATE compound_array(ANYARRAY) is
-$$ Returns an n dimensional array.
-
-Example: SELECT as_array(ARRAY[id::text, class]) from contact_class
-$$;
-
 CREATE TABLE new_shipto (
         id serial primary key,
         trans_id int references transactions(id),

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -140,6 +140,7 @@ company__get_by_cc
 company__next_id
 company__save
 company_get_billing_info
+compound_array
 config_currency__delete
 config_currency__save
 config_gifi__delete

--- a/sql/modules/Duplicates_Functions.sql
+++ b/sql/modules/Duplicates_Functions.sql
@@ -18,6 +18,7 @@ BEGIN
         WHERE pg_catalog.pg_function_is_visible(p.oid)
               AND n.nspname <> 'pg_catalog'
               AND n.nspname <> 'information_schema'
+              AND p.prokind NOT IN ('a', 'w') -- not aggregates or window funcs
               AND p.proname IN (
                   SELECT funcname from blacklisted_funcs
               )

--- a/sql/modules/LOADORDER
+++ b/sql/modules/LOADORDER
@@ -4,6 +4,7 @@
 # Note: These files all adhere to the protocol where
 #  they change the value of the setting_key 'module_load_ok'
 #  from 'no' to 'yes' on success.
+aggregates.sql
 triggers.sql
 old.sql
 Settings.sql

--- a/sql/modules/aggregates.sql
+++ b/sql/modules/aggregates.sql
@@ -1,0 +1,34 @@
+
+
+set client_min_messages = 'warning';
+
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION compound_array(ary anyarray, elm anyarray)
+RETURNS anyarray
+AS $$
+   SELECT array_cat(ary, elm);
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION compound_array(anyarray, anyarray)
+IS $$PostgreSQL 14 vs pre-14 compatibility measure.$$;
+
+
+DROP AGGREGATE IF EXISTS compound_array(ANYARRAY) CASCADE;
+CREATE AGGREGATE compound_array (
+        BASETYPE = ANYARRAY,
+        STYPE = ANYARRAY,
+        SFUNC = COMPOUND_ARRAY,
+        INITCOND = '{}'
+);
+
+COMMENT ON AGGREGATE compound_array(ANYARRAY) is
+$$ Returns an n dimensional array.
+$$;
+
+
+
+update defaults set value = 'yes' where setting_key = 'module_load_ok';
+
+COMMIT;

--- a/xt/42-system.pg
+++ b/xt/42-system.pg
@@ -18,8 +18,9 @@ BEGIN;
                     FROM (select proname FROM pg_proc
                             WHERE pronamespace =
                                     (select oid from pg_namespace
-                                    where nspname = current_schema())
-                                    AND proname IN (select funcname FROM blacklisted_funcs)
+                                      where nspname = current_schema())
+                                            AND prokind NOT IN ('a', 'w')
+                                            AND proname IN (select funcname FROM blacklisted_funcs)
                             group by proname
                             having count(*) > 1
                     ) t;


### PR DESCRIPTION
Aggregates can be repeatedly created, just like functions. So move
their creation from the schema file to the function definition modules.
