### PR TITLE
Following OpenAPI standards, parameters are indicated using curlies

### DIFF
--- a/lib/LedgerSMB/Routes/ERP/API/Accounts.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Accounts.pm
@@ -59,7 +59,7 @@ get '/accounts/', sub {
 };
 
 
-get '/accounts/:id', sub {
+get '/accounts/{id}', sub {
     my ($env, %p) = @_;
 };
 
@@ -67,7 +67,7 @@ post '/accounts/', sub {
 
 };
 
-del '/accounts/:id', sub {
+del '/accounts/{id}', sub {
 
 };
 

--- a/lib/LedgerSMB/Routes/ERP/API/Contacts.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Contacts.pm
@@ -189,7 +189,7 @@ post api '/contacts/sic' => sub {
         $response ];
 };
 
-del api '/contacts/sic/:id' => sub {
+del api '/contacts/sic/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my $response = _del_sic( $c, $params->{id} );
@@ -198,7 +198,7 @@ del api '/contacts/sic/:id' => sub {
     return $response && [ HTTP_OK, [ ], [ '' ] ];
 };
 
-get api '/contacts/sic/:id' => sub {
+get api '/contacts/sic/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($response, $meta) = _get_sic( $c, $params->{id} );
@@ -210,7 +210,7 @@ get api '/contacts/sic/:id' => sub {
 };
 
 
-put api '/contacts/sic/:id' => sub {
+put api '/contacts/sic/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($ETag) = ($r->headers->header('If-Match') =~ m/^\s*"(.*)"\s*$/);
@@ -232,7 +232,7 @@ put api '/contacts/sic/:id' => sub {
              $response ];
 };
 
-patch api '/contacts/sic/:id' => sub {
+patch api '/contacts/sic/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
     my $type = ($r->parameters->{type} // '') =~ s/[*]//gr;
     my $partnumber = ($r->parameters->{partnumber} // '') =~ s/[*]//gr;
@@ -406,7 +406,7 @@ post api '/contacts/business-types' => sub {
         $response ];
 };
 
-del api '/contacts/business-types/:id' => sub {
+del api '/contacts/business-types/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my $response = _del_businesstype( $c, $params->{id} );
@@ -415,7 +415,7 @@ del api '/contacts/business-types/:id' => sub {
     return $response && [ HTTP_OK, [ ], [ '' ] ];
 };
 
-get api '/contacts/business-types/:id' => sub {
+get api '/contacts/business-types/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($response, $meta) = _get_businesstype( $c, $params->{id} );
@@ -427,7 +427,7 @@ get api '/contacts/business-types/:id' => sub {
 };
 
 
-put api '/contacts/business-types/:id' => sub {
+put api '/contacts/business-types/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($ETag) = ($r->headers->header('If-Match') =~ m/^\s*"(.*)"\s*$/);
@@ -450,7 +450,7 @@ put api '/contacts/business-types/:id' => sub {
              $response ];
 };
 
-patch api '/contacts/business-types/:id' => sub {
+patch api '/contacts/business-types/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
     my $type = ($r->parameters->{type} // '') =~ s/[*]//gr;
     my $partnumber = ($r->parameters->{partnumber} // '') =~ s/[*]//gr;

--- a/lib/LedgerSMB/Routes/ERP/API/GeneralLedger.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/GeneralLedger.pm
@@ -188,7 +188,7 @@ post api '/gl/gifi' => sub {
         $response ];
 };
 
-del api '/gl/gifi/:id' => sub {
+del api '/gl/gifi/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my $response = _del_sic( $c, $params->{id} );
@@ -197,7 +197,7 @@ del api '/gl/gifi/:id' => sub {
     return $response && [ HTTP_OK, [ ], [ '' ] ];
 };
 
-get api '/gl/gifi/:id' => sub {
+get api '/gl/gifi/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($response, $meta) = _get_gifi( $c, $params->{id} );
@@ -209,7 +209,7 @@ get api '/gl/gifi/:id' => sub {
 };
 
 
-put api '/gl/gifi/:id' => sub {
+put api '/gl/gifi/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($ETag) = ($r->headers->header('If-Match') =~ m/^\s*"(.*)"\s*$/);
@@ -231,7 +231,7 @@ put api '/gl/gifi/:id' => sub {
              $response ];
 };
 
-patch api '/gl/gifi/:id' => sub {
+patch api '/gl/gifi/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
     my $type = ($r->parameters->{type} // '') =~ s/[*]//gr;
     my $partnumber = ($r->parameters->{partnumber} // '') =~ s/[*]//gr;

--- a/lib/LedgerSMB/Routes/ERP/API/Languages.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Languages.pm
@@ -189,7 +189,7 @@ post api '/languages' => sub {
         $response ];
 };
 
-del api '/languages/:id' => sub {
+del api '/languages/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my $response = _del_language( $c, $params->{id} );
@@ -198,7 +198,7 @@ del api '/languages/:id' => sub {
     return $response && [ HTTP_OK, [ ], [ '' ] ];
 };
 
-get api '/languages/:id' => sub {
+get api '/languages/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($response, $meta) = _get_language( $c, $params->{id} );
@@ -210,7 +210,7 @@ get api '/languages/:id' => sub {
 };
 
 
-put api '/languages/:id' => sub {
+put api '/languages/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($ETag) = ($r->headers->header('If-Match') =~ m/^\s*"(.*)"\s*$/);
@@ -232,7 +232,7 @@ put api '/languages/:id' => sub {
              $response ];
 };
 
-patch api '/languages/:id' => sub {
+patch api '/languages/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
     my $type = ($r->parameters->{type} // '') =~ s/[*]//gr;
     my $partnumber = ($r->parameters->{partnumber} // '') =~ s/[*]//gr;

--- a/lib/LedgerSMB/Routes/ERP/API/Products.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Products.pm
@@ -189,7 +189,7 @@ post api '/products/pricegroups' => sub {
         $response ];
 };
 
-del api '/products/pricegroups/:id' => sub {
+del api '/products/pricegroups/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my $response = _del_pricegroup( $c, $params->{id} );
@@ -198,7 +198,7 @@ del api '/products/pricegroups/:id' => sub {
     return $response && [ HTTP_OK, [ ], [ '' ] ];
 };
 
-get api '/products/pricegroups/:id' => sub {
+get api '/products/pricegroups/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($response, $meta) = _get_pricegroup( $c, $params->{id} );
@@ -210,7 +210,7 @@ get api '/products/pricegroups/:id' => sub {
 };
 
 
-put api '/products/pricegroups/:id' => sub {
+put api '/products/pricegroups/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($ETag) = ($r->headers->header('If-Match') =~ m/^\s*"(.*)"\s*$/);
@@ -232,7 +232,7 @@ put api '/products/pricegroups/:id' => sub {
              $response ];
 };
 
-patch api '/products/pricegroups/:id' => sub {
+patch api '/products/pricegroups/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
     my $type = ($r->parameters->{type} // '') =~ s/[*]//gr;
     my $partnumber = ($r->parameters->{partnumber} // '') =~ s/[*]//gr;
@@ -401,7 +401,7 @@ post api '/products/warehouses' => sub {
         $response ];
 };
 
-del api '/products/warehouses/:id' => sub {
+del api '/products/warehouses/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my $response = _del_warehouse( $c, $params->{id} );
@@ -410,7 +410,7 @@ del api '/products/warehouses/:id' => sub {
     return $response && [ HTTP_OK, [ ], [ '' ] ];
 };
 
-get api '/products/warehouses/:id' => sub {
+get api '/products/warehouses/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($response, $meta) = _get_warehouse( $c, $params->{id} );
@@ -422,7 +422,7 @@ get api '/products/warehouses/:id' => sub {
 };
 
 
-put api '/products/warehouses/:id' => sub {
+put api '/products/warehouses/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
     my ($ETag) = ($r->headers->header('If-Match') =~ m/^\s*"(.*)"\s*$/);
@@ -444,7 +444,7 @@ put api '/products/warehouses/:id' => sub {
              $response ];
 };
 
-patch api '/products/warehouses/:id' => sub {
+patch api '/products/warehouses/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
     my $type = ($r->parameters->{type} // '') =~ s/[*]//gr;
     my $partnumber = ($r->parameters->{partnumber} // '') =~ s/[*]//gr;

--- a/lib/LedgerSMB/Routes/ERP/API/Templates.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Templates.pm
@@ -82,7 +82,7 @@ sub _query_template {
 }
 
 
-get '/templates/:id/content' => sub {
+get '/templates/{id}/content' => sub {
     my ($env, $match) = @_;
     return [ HTTP_NOT_FOUND, [], [] ]
         unless $match->{id} =~ m/^\d+$/;
@@ -90,7 +90,7 @@ get '/templates/:id/content' => sub {
     return _query_template($env, id => $match->{id});
 };
 
-get '/templates/:name/:format/:language' => sub {
+get '/templates/{name}/{format}/{language}' => sub {
     my ($env, $match) = @_;
     delete $match->{language} if $match->{language} eq '__all__';
 
@@ -100,7 +100,7 @@ get '/templates/:name/:format/:language' => sub {
                            language      => $match->{language});
 };
 
-put '/templates/:id/content' => sub {
+put '/templates/{id}/content' => sub {
     my ($env, $match) = @_;
     return [ HTTP_NOT_FOUND, [], [] ]
         unless $match->{id} =~ m/^\d+$/;
@@ -124,7 +124,7 @@ put '/templates/:id/content' => sub {
         [ ], [ ] ];
 };
 
-put '/templates/:name/:format/:language' => sub {
+put '/templates/{name}/{format}/{language}' => sub {
     my ($env, $match) = @_;
     delete $match->{language} if $match->{language} eq '__all__';
 


### PR DESCRIPTION
Also retain the actual route specification in the routing table so it can
be used by the hooks to act upon. An example of such a hook could be an
OpenAPI request or response validator...
