### PR TITLE
Change missing 'security' in API to be a warning

### DIFF
--- a/openapi/.redocly.yaml
+++ b/openapi/.redocly.yaml
@@ -12,3 +12,5 @@ lint:
   rules:
     no-empty-servers:
       severity: off
+    security-defined:
+      severity: warn


### PR DESCRIPTION
Currently, we don't have it and we're not going to add it for 1.10...
