### PR TITLE
Disable false warning vue/no-ref-as-operand

### DIFF
--- a/UI/src/robot-vue.js
+++ b/UI/src/robot-vue.js
@@ -75,9 +75,11 @@ function contextRef(service, key) {
         typeof service.context[key] === typeof {}
     ) {
         const s = service;
+        // eslint-disable-next-line vue/no-ref-as-operand
         ref = reactive(service.context[key]);
         s.context[key] = ref;
     } else {
+        // eslint-disable-next-line vue/no-ref-as-operand
         ref = allocRef(service.context[key]);
     }
     const ctxRef = {


### PR DESCRIPTION
Fixes false error in linter (https://github.com/vuejs/eslint-plugin-vue/issues/1980)