### PR TITLE
Fix Form->redirect() loosing configuration

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -525,9 +525,10 @@ sub _redirect {
     }
 
     my $form = Form->new($argv);
-    $form->{$_} = $self->{$_} for qw(
-      dbh login favicon stylesheet titlebar password vc header _auth _locale
-    );
+    $form->{$_} = $self->{$_} for (
+        qw( dbh login favicon stylesheet titlebar password vc header ),
+        grep { /^_/ } keys %$self
+        );
     $form->{action} ||= $self->{action}; # default to old action if not set
     $form->{script} = $script;
 


### PR DESCRIPTION
Redirect is creating a new request, but fails to pass all private data into the new request variable. Pass the private variables into the new request variable unconditionally, to prevent future breakage when a new private value is added.
