### PR TITLE
Re #6788: Fix line removal breaking UI interaction

### DIFF
--- a/UI/js-src/lsmb/Form.js
+++ b/UI/js-src/lsmb/Form.js
@@ -29,7 +29,8 @@ define([
             this.submit();
         },
         submit: function () {
-            if (!this.validate()) {
+            const widget = registry.getEnclosingWidget(this.clickedAction);
+            if (!this.validate() || widget === null) {
                 return;
             }
 
@@ -37,7 +38,6 @@ define([
                 typeof this.method === "undefined" ? "GET" : this.method;
             var url = this.action;
             var options = { handleAs: "text" };
-            const widget = registry.getEnclosingWidget(this.clickedAction);
             options.doing = widget["data-lsmb-doing"];
             options.done = widget["data-lsmb-done"];
             if (method.toLowerCase() === "get") {

--- a/UI/js-src/lsmb/InvoiceLines.js
+++ b/UI/js-src/lsmb/InvoiceLines.js
@@ -8,7 +8,7 @@ define([
 ], function (declare, registry, _WidgetBase, _Container) {
     return declare("lsmb/InvoiceLines", [_WidgetBase, _Container], {
         removeLine: function (widgetid) {
-            this.removeChild(registry.byId(widgetid));
+            registry.byId(widgetid).destroyRecursive(false);
 
             this.emit("changed", { action: "removed" });
         } // removeLine


### PR DESCRIPTION
Because the widget was removed from the DOM, but not actually destroyed, the next attempt to insert the widget fails hard, breaking the UI rendering and dojo-ification.
