### PR TITLE
Fix middle-click opened pages missing JS

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -122,13 +122,17 @@ export default {
                 return;
             }
 
-            var href = dnode.href;
+            let href = dnode.href;
             dnode.addEventListener("click", function (e) {
                 if (!e.ctrlKey && !e.shiftKey && e.button === 0) {
                     e.preventDefault();
                     window.__lsmbLoadLink(href);
                 }
             });
+
+            let url = new URL(href);
+            let anode = dnode;
+            anode.href = '#' + url.pathname + url.search;
         },
         _cleanWidgets() {
             try {


### PR DESCRIPTION
Pages opened through middle-click mouse events miss the encapsulation in the page with the JS and CSS to make them render correctly and "be" a LedgerSMB application page.
