### PR TITLE
In case of a dismissable toast, wait for dismissal

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -35,8 +35,8 @@ export default {
     },
     methods: {
         async updateContent(tgt, options = {}) {
+            let dismiss;
             try {
-                let dismiss;
                 this.notify({
                     title: options.doing || this.$t("Loading..."),
                     type: "info",
@@ -83,9 +83,15 @@ export default {
                         });
                     });
                 } else {
+                    if (dismiss) {
+                        dismiss();
+                    }
                     this._report_error(r);
                 }
             } catch (e) {
+                if (dismiss) {
+                    dismiss();
+                }
                 this._report_error(e);
             }
         },

--- a/UI/src/components/Toast.vue
+++ b/UI/src/components/Toast.vue
@@ -18,14 +18,14 @@ const { send, state } = createToastMachine(
         cb: {
             removed: () => { emit("remove", { item: props.data }) }
         }
-    });
+});
 
-window.setTimeout(() => { send('dismiss') }, duration * 1000);
 if (props.data.dismissReceiver) {
     props.data.dismissReceiver( () => send('dismiss') );
     window.setTimeout(() => { send('show') }, 250);
 } else {
     send('show');
+    window.setTimeout(() => { send('dismiss') }, duration * 1000);
 }
 
 </script>


### PR DESCRIPTION
When the caller has declared to want to be able to dismiss a toast (i.e. it's a 'progress toast'), don't proactively dismiss the toast. Instead let the caller dismiss when it's done.

Fixes #6810
