### PR TITLE
Fix e-mail sending

### DIFF
--- a/lib/LedgerSMB/Scripts/email.pm
+++ b/lib/LedgerSMB/Scripts/email.pm
@@ -94,9 +94,9 @@ sub render {
     return $template->render($request, 'email', {
         callback    => uri_unescape($request->{callback}),
         id          => $wf->id,
-        ( map { $_ => scalar $wf->context->param($_) }
+        ( map { (s/^_//r) => scalar $wf->context->param($_) }
           qw( from to cc bcc notify subject body sent_date
-              attachments expansions ) ),
+              _attachments expansions ) ),
         actions     => [ map { { text  => $_->text,
                                  value => $_->name } }
                          sort { $a->{order} <=> $b->{order} }

--- a/lib/LedgerSMB/Workflow/Persister/Email.pm
+++ b/lib/LedgerSMB/Workflow/Persister/Email.pm
@@ -83,7 +83,7 @@ sub _fetch_attachments {
     my $rows = $sth->fetchall_arrayref( {} );
     $sth->finish;
 
-    $wf->context->param( 'attachments' => $rows);
+    $wf->context->param( '_attachments' => $rows);
 }
 
 

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1443,7 +1443,7 @@ sub print_form {
             from          => $form->get_setting( 'default_email_from' ),
             subject       => ($form->{subject}
                               // qq|$form->{label} $form->{"${inv}number"}|),
-            attachments   => [
+            _attachments   => [
                 { content => $body,
                   mime_type => $template->{mimetype},
                   file_name => ($form->{formname} . '-'
@@ -1494,7 +1494,7 @@ sub print_form {
             }
         }
 
-        $trans_wf->context->param( 'email-data' => $email_data );
+        $trans_wf->context->param( '_email_data' => $email_data );
         $trans_wf->execute_action( 'e_mail' );
         my $id = $trans_wf->context->param( 'spawned_workflow' );
         if (not $form->{header}) {

--- a/workflows/ar-ap.actions.xml
+++ b/workflows/ar-ap.actions.xml
@@ -31,7 +31,7 @@ TODO! Check workflow when 'separate duties' is false!
           text="E-mail"
           class="LedgerSMB::Workflow::Action::SpawnWorkflow"
           spawn_type="Email"
-          context_param="email-data" />
+          context_param="_email_data" />
   <action name="print_and_save"
           text="Print and Save"
           description="Printed and saved"

--- a/workflows/email.actions.xml
+++ b/workflows/email.actions.xml
@@ -1,5 +1,8 @@
 <actions type="Email">
   <description>Actions for Email workflow</description>
+  <action name="initial-save"
+          class="LedgerSMB::Workflow::Action::Email"
+          action="initial-save" />
   <action name="update"
           text="Update"
           class="LedgerSMB::Workflow::Action::Email"

--- a/workflows/email.workflow.xml
+++ b/workflows/email.workflow.xml
@@ -4,6 +4,9 @@
   <persister>Email</persister>
  <description>Handles lifecycle of e-mail</description>
  <state name="INITIAL" autorun="yes">
+   <action name="initial-save" resulting_state="INITIALIZED" />
+ </state>
+ <state name="INITIALIZED" autorun="yes">
    <action name="send"    resulting_state="EXPANDED">
      <condition name="sendImmediately" />
    </action>


### PR DESCRIPTION
Sending e-mail was broken by serialization of workflow context into the database: object instances and attachment data are stored in the context, but not meant to be serialized; they are loaded upon instantiation.
