### PR TITLE
Can't delete draft transactions with attachments (#6787)

### DIFF
--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -4331,7 +4331,7 @@ CREATE TABLE file_transaction (
        check (file_class = 1),
        unique(id),
        primary key (ref_key, file_name, file_class),
-       foreign key (ref_key) REFERENCES transactions(id)
+       foreign key (ref_key) REFERENCES transactions(id) on delete cascade
 ) inherits (file_base);
 
 COMMENT ON TABLE file_transaction IS


### PR DESCRIPTION
This fixes a problem where deleting transactions was failing due to a foreign key constraint coming from file_transactions. Adding ON DELETE CASCADE causes the attachments to also be deleted at the same time as the old transaction.

