### PR TITLE
Can't save draft transactions with attachments (#6787)

### DIFF
--- a/sql/changes/1.10/file-tranaction-cascade-delete.sql
+++ b/sql/changes/1.10/file-tranaction-cascade-delete.sql
@@ -1,9 +1,9 @@
-
 -- adding cascade deletes
-alter table file_transaction 
-	drop constraint file_transaction_ref_key_fkey;
+alter table file_transaction
+  drop constraint file_transaction_ref_key_fkey;
 
-alter table file_transaction 
-	add constraint file_transaction_ref_key_fkey 
-	foreign key (ref_key) references transactions(id) 
-		on delete cascade;
+alter table file_transaction
+  add constraint file_transaction_ref_key_fkey
+     foreign key ( ref_key )
+      references transactions( id )
+       on delete cascade;

--- a/sql/changes/1.10/file-tranaction-cascade-delete.sql
+++ b/sql/changes/1.10/file-tranaction-cascade-delete.sql
@@ -1,0 +1,9 @@
+
+-- adding cascade deletes
+alter table file_transaction 
+	drop constraint file_transaction_ref_key_fkey;
+
+alter table file_transaction 
+	add constraint file_transaction_ref_key_fkey 
+	foreign key (ref_key) references transactions(id) 
+		on delete cascade;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -167,3 +167,4 @@ mc/delete-migration-validation-data.sql
 1.10/reconciliation-columns-cleanup.sql
 1.10/unique-transaction-reconciliation.sql
 1.10/missing-fkeys.sql
+1.10/file-tranaction-cascade-delete.sql


### PR DESCRIPTION
Adds cascading deletes to the file_transaction@ref_key => transaction foreign key
