### PR TITLE
Adding openrc configuration.

### DIFF
--- a/doc/conf/openrc/conf.d/ledgersmb_starman
+++ b/doc/conf/openrc/conf.d/ledgersmb_starman
@@ -3,7 +3,10 @@
 host=localhost
 port=5762
 # If you want to specify workers you could do so here, like
-# starman_args="--workers 32 --preload_app"
+# starman_args="--workers 32 --preload-app"
 # but note --reload_app if used must be at the end
-starman_args=--preload_app
+#
+# Note further if you are *not* using --preload-app that you need to set
+# a shared secret in the ledgersmb.conf
+starman_args=--preload-app
 working_dir=/usr/local/share/ledgersmb

--- a/doc/conf/openrc/conf.d/ledgersmb_starman
+++ b/doc/conf/openrc/conf.d/ledgersmb_starman
@@ -1,0 +1,9 @@
+# Startup configuration for LedgerSMB on Starman
+
+host=localhost
+port=5762
+# If you want to specify workers you could do so here, like
+# starman_args="--workers 32 --preload_app"
+# but note --reload_app if used must be at the end
+starman_args=--preload_app
+working_dir=/usr/local/share/ledgersmb

--- a/doc/conf/openrc/init.d/ledgersmb_starman
+++ b/doc/conf/openrc/init.d/ledgersmb_starman
@@ -12,7 +12,7 @@ output_log="/var/log/ledgersmb/starman.log"
 error_log="/var/log/ledgersmb/starman.err"
 start_stop_daemon_args="-d $working_dir -u ledgersmb -g ledgersmb -b\
     -p ${pidfile} -S -x $command"
-command_args="-Ilib -Iold/lib --listen ${host}:${port} ${ledgersmb_args} \
+command_args="-Ilib -Iold/lib --listen ${host}:${port} ${starman_args} \
     bin/ledgersmb-server.psgi"
 
 

--- a/doc/conf/openrc/init.d/ledgersmb_starman
+++ b/doc/conf/openrc/init.d/ledgersmb_starman
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="ledgersmb daemon, running via starman"
+description=""
+command=/usr/bin/starman
+command_background="yes"
+ssd=/sbin/start-stop-daemon
+pidfile=/var/run/ledgersmb
+output_log="/var/log/ledgersmb/starman.log"
+error_log="/var/log/ledgersmb/starman.err"
+start_stop_daemon_args="-d $working_dir -u ledgersmb -g ledgersmb -b\
+    -p ${pidfile} -S -x $command"
+command_args="-Ilib -Iold/lib --listen ${host}:${port} ${ledgersmb_args} \
+    bin/ledgersmb-server.psgi"
+
+
+


### PR DESCRIPTION
I am proposing adding an openrc configuration to the documentation section.

OpenRC users are likely to understand these as is so there is not a lot that needs to be described for the public, but for review purposes:

1.  OpenRC divides init scripts into two sections:  the init script itself defines the system-specified behavior and is not intended to be sysadmin-modified.   the conf.d file is sourced into the init script and is used by administrators to set parameters.  In a user installed system, things like the working directory would be set there, but in a distro package, this would be moved into the init script.
2. this script uses start-stop-daemon to start and stop ledgersmb via starman with proper pidfile tracking.  I chose no to use supervisor-daemon because if starman actually crashes that tends to be immediately and not something you can simply recover from by restarting the daemon.
3. I would be happy to put up an article on the site as to the design of this if it is accepted.
4. It would also facilitate packaging of LedgerSMB for openrc distros (like Alpine Linux, or Gentoo without the systemd option) to have this backported all the way to 1.9.  If that is acceptable, I will submit additional PRs for that.

These files are tested on my system and will be found with the above-discussed modification (of moving working directory into the init script) in my Gentoo package.