### PR TITLE
Multiple uploads through '[Attach]' link fail

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -129,10 +129,11 @@ export default {
                 return;
             }
 
+            let i = 0;
             dnode.addEventListener("click", function (e) {
                 if (!e.ctrlKey && !e.shiftKey && e.button === 0) {
                     e.preventDefault();
-                    window.__lsmbLoadLink(href);
+                    window.__lsmbLoadLink(href + `#${i++}`);
                 }
             });
 


### PR DESCRIPTION
Clicking the [Attach] link after uploading one file, to upload a second one, fails due to the fact that the URL hash component doesn't change.

Fixes #6855
