### PR TITLE
Fix the '<< Return' link on the e-mail screen

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -837,6 +837,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                 my ($id, $workflow) = split(/,/, $items{spawned_workflow}, 2);
                 $link = ($links{$workflow}
                          // $links{"$workflow|$form->{vc}"}) . $id;
+                $link .= "&amp;callback=$form->{script}%3Faction%3D$form->{action}%26id%3D$form->{id}";
             }
             if ($link) {
                 print qq|<tr><td><a href="$link">$desc</a></td></tr>|;

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -935,6 +935,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
                 my ($id, $workflow) = split(/,/, $items{spawned_workflow}, 2);
                 $link = ($links{$workflow}
                          // $links{"$workflow|$form->{vc}"}) . $id;
+                $link .= "&amp;callback=$form->{script}%3Faction%3D$form->{action}%26id%3D$form->{id}";
             }
             if ($link) {
                 print qq|<tr><td><a href="$link">$desc</a></td></tr>|;

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -882,6 +882,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                 my ($id, $workflow) = split(/,/, $items{spawned_workflow}, 2);
                 $link = ($links{$workflow}
                          // $links{"$workflow|$form->{vc}"}) . $id;
+                $link .= "&amp;callback=$form->{script}%3Faction%3D$form->{action}%26id%3D$form->{id}";
             }
             if ($link) {
                 print qq|<tr><td><a href="$link">$desc</a></td></tr>|;


### PR DESCRIPTION
For invoices and orders loaded from a saved or posted document, the callback value isn't correctly provided, causing the '<< Return' link on the e-mail screen to return to the main page instead of to the "invoking" document.

Fixes #6858.
