### PR TITLE
Fix the '<< Return' link on the e-mail screen

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -806,6 +806,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                 my ($id, $workflow) = split(/,/, $items{spawned_workflow}, 2);
                 $link = ($links{$workflow}
                          // $links{"$workflow|$form->{vc}"}) . $id;
+                $link .= "&amp;callback=$form->{script}%3Faction%3D$form->{action}%26id%3D$form->{id}";
             }
             if ($link) {
                 print qq|<tr><td><a href="$link">$desc</a></td></tr>|;

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -911,6 +911,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
                 my ($id, $workflow) = split(/,/, $items{spawned_workflow}, 2);
                 $link = ($links{$workflow}
                          // $links{"$workflow|$form->{vc}"}) . $id;
+                $link .= "&amp;callback=$form->{script}%3Faction%3D$form->{action}%26id%3D$form->{id}";
             }
             if ($link) {
                 print qq|<tr><td><a href="$link">$desc</a></td></tr>|;

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -875,6 +875,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                 my ($id, $workflow) = split(/,/, $items{spawned_workflow}, 2);
                 $link = ($links{$workflow}
                          // $links{"$workflow|$form->{vc}"}) . $id;
+                $link .= "&amp;callback=$form->{script}%3Faction%3D$form->{action}%26id%3D$form->{id}";
             }
             if ($link) {
                 print qq|<tr><td><a href="$link">$desc</a></td></tr>|;


### PR DESCRIPTION
For invoices and orders loaded from a saved or posted document, the callback value isn't correctly provided, causing the '<< Return' link on the e-mail screen to return to the main page instead of to the "invoking" document.

Fixes #6858.
