### PR TITLE
Restore 'id' generation with a simpler algorithm

### DIFF
--- a/tests/specs/API-contacts-business_types.spec.js
+++ b/tests/specs/API-contacts-business_types.spec.js
@@ -20,7 +20,8 @@ jestOpenAPI(process.env.PWD + "/openapi/API.yaml");
 const api = "erp/api/v0";
 
 // Access to the database test user
-const id = [...Array(6)].map(() => Math.random().toString(12)[2]).join("");
+const id = Math.random().toString(36).substr(2, 6);
+
 const username = `Jest${id}`;
 const password = "Tester";
 const company = `lsmb_test_api_${id}`;

--- a/tests/specs/API-contacts-sic.spec.js
+++ b/tests/specs/API-contacts-sic.spec.js
@@ -20,7 +20,8 @@ jestOpenAPI(process.env.PWD + "/openapi/API.yaml");
 const api = "erp/api/v0";
 
 // Access to the database test user
-const id = [...Array(6)].map(() => Math.random().toString(12)[2]).join("");
+const id = Math.random().toString(36).substr(2, 6);
+
 const username = `Jest${id}`;
 const password = "Tester";
 const company = `lsmb_test_api_${id}`;

--- a/tests/specs/API-gifi.spec.js
+++ b/tests/specs/API-gifi.spec.js
@@ -21,7 +21,8 @@ const api = "erp/api/v0";
 
 // Access to the database test user
 
-const id = [...Array(6)].map(() => Math.random().toString(12)[2]).join("");
+const id = Math.random().toString(36).substr(2, 6);
+
 const username = `Jest${id}`;
 const password = "Tester";
 const company = `lsmb_test_api_${id}`;

--- a/tests/specs/API-invoices.spec.js
+++ b/tests/specs/API-invoices.spec.js
@@ -20,9 +20,10 @@ jestOpenAPI(process.env.PWD + "/openapi/API.yaml");
 const api = "erp/api/v0";
 
 // Access to the database test user
-const username = `Jest`;
+const id = Math.random().toString(36).substr(2, 6);
+const username = `Jest${id}`;
 const password = "Tester";
-const company = "lsmb_test_api";
+const company = `lsmb_test_api_${id}`;
 const server = process.env.LSMB_BASE_URL;
 
 let headers = {};

--- a/tests/specs/API-languages.spec.js
+++ b/tests/specs/API-languages.spec.js
@@ -20,7 +20,8 @@ jestOpenAPI(process.env.PWD + "/openapi/API.yaml");
 const api = "erp/api/v0";
 
 // Access to the database test user
-const id = [...Array(6)].map(() => Math.random().toString(12)[2]).join("");
+const id = Math.random().toString(36).substr(2, 6);
+
 const username = `Jest${id}`;
 const password = "Tester";
 const company = `lsmb_test_api_${id}`;

--- a/tests/specs/API-products-pricegroups.spec.js
+++ b/tests/specs/API-products-pricegroups.spec.js
@@ -20,7 +20,8 @@ jestOpenAPI(process.env.PWD + "/openapi/API.yaml");
 const api = "erp/api/v0";
 
 // Access to the database test user
-const id = [...Array(6)].map(() => Math.random().toString(12)[2]).join("");
+const id = Math.random().toString(36).substr(2, 6);
+
 const username = `Jest${id}`;
 const password = "Tester";
 const company = `lsmb_test_api_${id}`;

--- a/tests/specs/API-products-warehouses.spec.js
+++ b/tests/specs/API-products-warehouses.spec.js
@@ -20,7 +20,8 @@ jestOpenAPI(process.env.PWD + "/openapi/API.yaml");
 const api = "erp/api/v0";
 
 // Access to the database test user
-const id = [...Array(6)].map(() => Math.random().toString(12)[2]).join("");
+const id = Math.random().toString(36).substr(2, 6);
+
 const username = `Jest${id}`;
 const password = "Tester";
 const company = `lsmb_test_api_${id}`;


### PR DESCRIPTION
Restore "id" generation to ensure that OpenAPI tests can run in parallel but with a simpler algorithm.
This effectively reverses #6874