### PR TITLE
Fix 'New' button on invoice and transaction screens

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -106,7 +106,7 @@ sub copy_to_new{
 }
 
 sub new_screen {
-    my @reqprops = qw(ARAP vc dbh stylesheet batch_id script _locale);
+    my @reqprops = qw(ARAP vc dbh stylesheet batch_id script type _locale _wire);
     $oldform = $form;
     $form = {};
     bless $form, 'Form';

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -91,7 +91,7 @@ sub approve {
 }
 
 sub new_screen {
-    my @reqprops = qw(ARAP vc dbh stylesheet type _locale);
+    my @reqprops = qw(ARAP vc dbh stylesheet batch_id script type _locale _wire);
     $oldform = $form;
     $form = {};
     bless $form, 'Form';

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -82,7 +82,7 @@ sub edit_and_save {
 }
 
 sub new_screen {
-    my @reqprops = qw(ARAP vc dbh stylesheet type _locale);
+    my @reqprops = qw(ARAP vc dbh stylesheet batch_id script type _locale _wire);
     $oldform = $form;
     $form = {};
     bless $form, 'Form';


### PR DESCRIPTION
This commit fixes multiple issues with the handling of the New button:

 * the configuration context isn't passed in all cases (_wire)
 * the type of transaction isn't passed in all cases (type)
 * the name of the invoking script isn't passed in all cases
