### PR TITLE
Render approved transactions as read-only forms

### DIFF
--- a/UI/journal/journal_entry.html
+++ b/UI/journal/journal_entry.html
@@ -153,14 +153,15 @@
                         [% IF displayrow.accnoset == 0 %]
                                 [% PROCESS input element_data = {
                                       name = "accno_$INDEX"
-                                                                         type = "text"
+                                      type = "text"
                                       initial_value = ${"accno_$INDEX"}
                                       value = ${"accno_$INDEX"}
                                       text_attr = 'accno'
                                       value_attr = 'id'
-                                                                         class = 'AccountBox'
-                                                                         'data-dojo-type' = 'lsmb/accounts/AccountSelector'
-                            'data-dojo-props' = 'required: false'
+                                      class = 'AccountBox'
+                                      readonly = form.approved
+                                      'data-dojo-type' = 'lsmb/accounts/AccountSelector'
+                                      'data-dojo-props' = 'required: false'
                               } %]
 
                           [% ELSE %]
@@ -186,6 +187,7 @@
                                   value = displayrow.debit
                                   name = "debit_$INDEX"
                                   type = "text"
+                                  readonly = form.approved
                                   size = 12
                                   id = "deb_$INDEX"
                                               }  %]
@@ -197,6 +199,7 @@
                                   value = displayrow.credit
                                   name = "credit_$INDEX"
                                   type = "text"
+                                  readonly = form.approved
                                   size = 12
                                   id = "cre_$INDEX"
                                       }  %]
@@ -208,6 +211,7 @@
                                   value = displayrow.source
                                   name = "source_$INDEX"
                                   type = "text"
+                                  readonly = form.approved
                                   size = 10
                                   id = "sou_$INDEX"
 
@@ -219,6 +223,7 @@
                           [% PROCESS textarea element_data = {
                                   value = displayrow.memo
                                   name = "memo_$INDEX"
+                                  readonly = form.approved
                                   size = 30
                                   id = "mem_$INDEX"
                                      }  %]
@@ -235,6 +240,7 @@
                        INCLUDE select element_data = {
                               text_attr = "control_code"
                              value_attr = "id"
+                               readonly = form.approved
                          default_values = [displayrow.${bucid}]
                           default_blank = 1
                                    name = "$burow"
@@ -251,6 +257,7 @@
                   options = curr
                   name = "curr_$INDEX"
                   default_values = [displayrow.curr]
+                  readonly = form.approved
                   } %]</td>
 
        <td>
@@ -258,6 +265,7 @@
                         value = displayrow.debit_fx
                         name = "debit_fx_$INDEX"
                         type = "text"
+                                  readonly = form.approved
                                   size = 12
                                   id = "deb_fx_$INDEX"
                                               }  %]
@@ -268,6 +276,7 @@
                                   value = displayrow.credit_fx
                                   name = "credit_fx_$INDEX"
                                   type = "text"
+                                  readonly = form.approved
                                   size = 12
                                   id = "cre_fx_$INDEX"
                                       }  %]

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -20,7 +20,7 @@
 
   textarea_keys           = default_input_keys.merge(['cols', 'rows',
                                                       'readonly', 'style', 'wrap' ])
-  select_keys             = default_input_keys.merge(['multiple'])
+  select_keys             = default_input_keys.merge(['multiple', 'readonly'])
   option_keys             = default_keys.merge(['tabindex', 'disabled', 'value', 'selected'])
   button_keys             = default_input_keys.merge(['data-lsmb-doing',
                                                       'data-lsmb-done'])

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -380,6 +380,7 @@ sub create_links {
 
 sub form_header {
     my $min_lines = $form->get_setting('min_empty') // 0;
+    my $readonly = $form->{approved} ? 'readonly="readonly"' : '';
 
     $form->generate_selects(\%myconfig) unless $form->{"select$form->{ARAP}"};
 
@@ -461,14 +462,14 @@ sub form_header {
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
                 <th align=right nowrap><label for="currency">| . $locale->text('Currency') . qq|</label></th>
-        <td><select data-dojo-type="dijit/form/Select" id=currency name=currency>$form->{selectcurrency}</select></td> |
+        <td><select data-dojo-type="dijit/form/Select" id=currency name=currency $readonly>$form->{selectcurrency}</select></td> |
       if $form->{defaultcurrency};
     if (   $form->{defaultcurrency}
         && $form->{currency} ne $form->{defaultcurrency} )
     {
             $exchangerate .= qq|
         <th align=right><label for="exchangerate">| . $locale->text('Exchange Rate') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name=exchangerate id=exchangerate size=10 value=$formatted_exchangerate></td>
+        <td><input data-dojo-type="dijit/form/TextBox" name=exchangerate id=exchangerate size=10 value=$formatted_exchangerate $readonly></td>
 |;
     }
      else {
@@ -483,7 +484,7 @@ sub form_header {
     }
     $form->{notes} //= '';
     $notes =
-qq|<textarea data-dojo-type="dijit/form/Textarea" name=notes rows=$rows cols=50 wrap=soft>$form->{notes}</textarea>|;
+qq|<textarea data-dojo-type="dijit/form/Textarea" name=notes rows=$rows cols=50 wrap=soft $readonly>$form->{notes}</textarea>|;
     $form->{intnotes} //= '';
     $intnotes =
 qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=35 wrap=soft>$form->{intnotes}</textarea>|;
@@ -491,7 +492,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=
     $department = qq|
           <tr>
         <th align="right" nowrap>| . $locale->text('Department') . qq|</th>
-        <td colspan=3><select data-dojo-type="dijit/form/Select" id=department name=department>$form->{selectdepartment}</select>
+        <td colspan=3><select data-dojo-type="dijit/form/Select" id=department name=department $readonly>$form->{selectdepartment}</select>
         <input type=hidden name=selectdepartment value="|
       . $form->escape( $form->{selectdepartment}, 1 ) . qq|">
         </td>
@@ -503,8 +504,8 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=
 
     $name =
       ( $form->{"select$form->{vc}"} )
-      ? qq|<select data-dojo-type="lsmb/FilteringSelect" id="$form->{vc}" name="$form->{vc}"><option></option>$form->{"select$form->{vc}"}</select>|
-      : qq|<input data-dojo-type="dijit/form/TextBox" id="$form->{vc}" name="$form->{vc}" value="$form->{$form->{vc}}" size=35>
+      ? qq|<select data-dojo-type="lsmb/FilteringSelect" id="$form->{vc}" name="$form->{vc}" $readonly><option></option>$form->{"select$form->{vc}"}</select>|
+      : qq|<input data-dojo-type="dijit/form/TextBox" id="$form->{vc}" name="$form->{vc}" value="$form->{$form->{vc}}" size=35 $readonly>
                  <a href="erp.pl?action=root#contact.pl?action=add&entity_class=$eclass"
                     id="new-contact" target="_blank">[|
                  .  $locale->text('New') . qq|]</a>|;
@@ -659,7 +660,7 @@ $form->open_status_div($status_div_id) . qq|
                <th align="right" nowrap><label for="description">| . $locale->text('Description') . qq|</label>
                </th>
                <td><input data-dojo-type="dijit/form/TextBox" type="text" name="description" id="description" size="40"
-                   value="| . ($form->{description} // '') . qq|" /></td>
+                   value="| . ($form->{description} // '') . qq|" $readonly /></td>
             </tr>
         </table>
       </td>
@@ -668,28 +669,28 @@ $form->open_status_div($status_div_id) . qq|
           $employee
           <tr>
         <th align=right nowrap><label for="invnum">| . $locale->text('Invoice Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name=invnumber id=invnum size=20 value="$form->{invnumber}">
+        <td><input data-dojo-type="dijit/form/TextBox" name=invnumber id=invnum size=20 value="$form->{invnumber}" $readonly>
                       $form->{sequence_select}</td>
           </tr>
           <tr>
         <th align=right nowrap><label for="ordnum">| . $locale->text('Order Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name=ordnumber id=ordnum size=20 value="$form->{ordnumber}"></td>
+        <td><input data-dojo-type="dijit/form/TextBox" name=ordnumber id=ordnum size=20 value="$form->{ordnumber}" $readonly></td>
           </tr>
               <tr>
                 <th align=right nowrap><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>
-                <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=crdate id=crdate size=11 title="($myconfig{'dateformat'})" value="$form->{crdate}" data-dojo-props="defaultIsToday:true"></td>
+                <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=crdate id=crdate size=11 title="($myconfig{'dateformat'})" value="$form->{crdate}" data-dojo-props="defaultIsToday:true" $readonly></td>
               </tr>
           <tr>
         <th align=right nowrap><label for="transdate">| . $locale->text('Invoice Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value="$form->{transdate}" data-dojo-props="defaultIsToday:true"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value="$form->{transdate}" data-dojo-props="defaultIsToday:true" $readonly></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="duedate">| . $locale->text('Due Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=duedate id=duedate size=11 title="$myconfig{'dateformat'}" value=$form->{duedate}></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=duedate id=duedate size=11 title="$myconfig{'dateformat'}" value=$form->{duedate} $readonly></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="ponum">| . $locale->text('PO Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name=ponumber id=ponum size=20 value="$form->{ponumber}"></td>
+        <td><input data-dojo-type="dijit/form/TextBox" name=ponumber id=ponum size=20 value="$form->{ponumber}" $readonly></td>
           </tr>
           <tr>
           <th align=right nowrap>| . $locale->text('State') . qq|</th>
@@ -728,13 +729,14 @@ $form->open_status_div($status_div_id) . qq|
     # Display rows
 
     foreach my $i ( 1 .. $form->{rowcount} + $min_lines) {
+        next if $readonly and not $form->{"$form->{ARAP}_amount_$i"};
 
         # format amounts
         $form->{"amount_$i"} =
           $form->format_amount( \%myconfig,$form->{"amount_$i"}, LedgerSMB::Setting->new(%$form)->get('decimal_places') );
 
         $project = qq|
-      <td align=right><select data-dojo-type="dijit/form/Select" id="projectnumber_$i" name="projectnumber_$i">$form->{"selectprojectnumber_$i"}</select></td>
+      <td align=right><select data-dojo-type="dijit/form/Select" id="projectnumber_$i" name="projectnumber_$i" $readonly>$form->{"selectprojectnumber_$i"}</select></td>
             | if $form->{selectprojectnumber};
         $project //= '';
 
@@ -743,11 +745,11 @@ $form->open_status_div($status_div_id) . qq|
             1 )
         {
             $description =
-qq|<td><textarea data-dojo-type="dijit/form/Textarea" name="description_$i" rows=$rows cols=40>$form->{"description_$i"}</textarea></td>|;
+qq|<td><textarea data-dojo-type="dijit/form/Textarea" name="description_$i" rows=$rows cols=40 $readonly>$form->{"description_$i"}</textarea></td>|;
         }
         else {
             $description =
-qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 value="$form->{"description_$i"}"></td>|;
+qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 value="$form->{"description_$i"}" $readonly></td>|;
         }
 
     $taxchecked="";
@@ -757,22 +759,22 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
 
     }
 
-    $taxformcheck=qq|<td><input type="checkbox" data-dojo-type="dijit/form/CheckBox" name="taxformcheck_$i" value="1" $taxchecked></td>|;
+    $taxformcheck=qq|<td><input type="checkbox" data-dojo-type="dijit/form/CheckBox" name="taxformcheck_$i" value="1" $taxchecked $readonly></td>|;
         print qq|
     <tr valign=top class="transaction-line $form->{ARAP}" id="line-$i">
-     <td><input data-dojo-type="dijit/form/TextBox" name="amount_$i" size=10 value="$form->{"amount_$i"}"></td>
+     <td><input data-dojo-type="dijit/form/TextBox" name="amount_$i" size=10 value="$form->{"amount_$i"}" $readonly></td>
      <td>| . (($form->{currency} ne $form->{defaultcurrency})
               ? $form->format_amount(\%myconfig, $form->parse_amount( \%myconfig, $form->{"amount_$i"} )
                                                   * $form->{exchangerate}, LedgerSMB::Setting->new(%$form)->get('decimal_places'))
               : '')  . qq|</td>
-     <td><select data-dojo-type="lsmb/FilteringSelect" id="$form->{ARAP}_amount_$i" name="$form->{ARAP}_amount_$i"><option></option>$form->{"select$form->{ARAP}_amount_$i"}</select></td>
+     <td><select data-dojo-type="lsmb/FilteringSelect" id="$form->{ARAP}_amount_$i" name="$form->{ARAP}_amount_$i" $readonly><option></option>$form->{"select$form->{ARAP}_amount_$i"}</select></td>
       $description
           $taxformcheck
       $project|;
 
         for my $cls (@{$form->{bu_class}}){
             if (scalar @{$form->{b_units}->{"$cls->{id}"}}){
-                print qq|<td><select data-dojo-type="dijit/form/Select" id="b_unit_$cls->{id}_$i" name="b_unit_$cls->{id}_$i">
+                print qq|<td><select data-dojo-type="dijit/form/Select" id="b_unit_$cls->{id}_$i" name="b_unit_$cls->{id}_$i" $readonly>
                                     <option>&nbsp;</option>|;
                       for my $bu (@{$form->{b_units}->{"$cls->{id}"}}){
                          my $selected = '';
@@ -804,10 +806,10 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         print qq|
         <tr class="transaction-row $form->{ARAP} tax" id="taxrow_$item">
       <td><input data-dojo-type="dijit/form/TextBox" name="tax_$item" id="tax_$item"
-                     size=10 value=$form->{"tax_$item"} /></td>
+                     size=10 value=$form->{"tax_$item"} $readonly /></td>
       <td align=right><input id="calctax_$item" name="calctax_$item"
                                  class="checkbox" type="checkbox" data-dojo-type="dijit/form/CheckBox" value=1
-                                 $form->{"calctax_$item"}
+                                 $form->{"calctax_$item"} $readonly
                             title="Calculate automatically"></td>
           <td><input type="hidden" name="$form->{ARAP}_tax_$item"
                 id="$form->{ARAP}_tax_$item"
@@ -839,7 +841,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
                   \%myconfig,
                   $form->{invtotal} * $form->{exchangerate},
                   LedgerSMB::Setting->new(%$form)->get('decimal_places')) : '') . qq|</td>
-     <td><select data-dojo-type="dijit/form/Select" name="$form->{ARAP}" id="$form->{ARAP}">
+     <td><select data-dojo-type="dijit/form/Select" name="$form->{ARAP}" id="$form->{ARAP}" $readonly>
                  $selectARAP
               </select></td>
         </tr>
@@ -901,6 +903,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         $form->{"$form->{ARAP}_paid_$form->{paidaccounts}"} = $1;
     }
     foreach my $i ( 1 .. $form->{paidaccounts} ) {
+        next if $readonly and not $form->{"datepaid_$i"};
 
         $form->hide_form("cleared_$i");
 
@@ -912,7 +915,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
             $form->{"select$form->{ARAP}_paid"};
         if ($form->{"$form->{ARAP}_paid_$i"}) {
             $form->{"select$form->{ARAP}_paid_$i"} =~
-                s/(value="\Q$form->{"$form->{ARAP}_paid_$i"}\E")/$1 selected="selected"/;
+                s/(value="\Q$form->{"$form->{ARAP}_paid_$i"}\E")/$1 $readonly selected="selected"/;
         }
 
         # format amounts
@@ -932,7 +935,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
             }
             else {
                 $exchangerate =
-qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" size=10 value=$form->{"exchangerate_$i"}>|;
+qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" size=10 value=$form->{"exchangerate_$i"} $readonly>|;
             }
         }
 
@@ -942,17 +945,17 @@ qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" size=10 val
         $form->{"source_$i"} //= '';
         $form->{"memo_$i"} //= '';
         $column_data{paid} =
-qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size=11 value=$form->{"paid_$i"}></td>|;
+qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size=11 value=$form->{"paid_$i"} $readonly></td>|;
         $column_data{ARAP_paid} =
-qq|<td align=center><select data-dojo-type="lsmb/FilteringSelect" name="$form->{ARAP}_paid_$i" id="$form->{ARAP}_paid_$i">$form->{"select$form->{ARAP}_paid_$i"}</select></td>|;
+qq|<td align=center><select data-dojo-type="lsmb/FilteringSelect" name="$form->{ARAP}_paid_$i" id="$form->{ARAP}_paid_$i" $readonly>$form->{"select$form->{ARAP}_paid_$i"}</select></td>|;
         $column_data{exchangerate} = qq|<td align=center>$exchangerate</td>|;
         $column_data{paidfx} = qq|<td align=center>$form->{"paidfx_$i"}</td>|;
         $column_data{datepaid} =
-qq|<td align=center><input class="date" data-dojo-type="lsmb/DateTextBox" name="datepaid_$i" id="datepaid_$i" size=11 value=$form->{"datepaid_$i"}></td>|;
+qq|<td align=center><input class="date" data-dojo-type="lsmb/DateTextBox" name="datepaid_$i" id="datepaid_$i" size=11 value=$form->{"datepaid_$i"} $readonly></td>|;
         $column_data{source} =
-qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="source_$i" id="source_$i" size=11 value="$form->{"source_$i"}"></td>|;
+qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="source_$i" id="source_$i" size=11 value="$form->{"source_$i"}" $readonly></td>|;
         $column_data{memo} =
-qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id="memo_$i" size=11 value="$form->{"memo_$i"}"></td>|;
+qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id="memo_$i" size=11 value="$form->{"memo_$i"}" $readonly></td>|;
 
         for (@column_index) { print qq|$column_data{$_}\n| }
 

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -289,7 +289,7 @@ sub prepare_invoice {
 }
 
 sub form_header {
-
+    my $readonly = $form->{approved} ? 'readonly="readonly"' : '';
     $form->{nextsub} = 'update';
 
     $status_div_id = 'AP-invoice';
@@ -313,11 +313,11 @@ sub form_header {
     $form->{exchangerate} =
       $form->format_amount( \%myconfig, $form->{exchangerate} );
 
-    $form->{selectAP} =~ s/(\Qoption value="$form->{AP}"\E)/$1 selected="selected"/;
+    $form->{selectAP} =~ s/(\Qoption value="$form->{AP}"\E)/$1 $readonly selected="selected"/;
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
                 <th align=right nowrap>| . $locale->text('Currency') . qq|</th>
-        <td><select data-dojo-type="dijit/form/Select" id=currency name=currency>$form->{selectcurrency}</select></td> |
+        <td><select data-dojo-type="dijit/form/Select" id=currency name=currency $readonly>$form->{selectcurrency}</select></td> |
       if $form->{defaultcurrency};
 
     if (   $form->{defaultcurrency}
@@ -327,7 +327,7 @@ sub form_header {
                 <th align=right nowrap>|
               . $locale->text('Exchange Rate')
               . qq|</th>
-                <td><input data-dojo-type="dijit/form/TextBox" name=exchangerate size=10 value=$form->{exchangerate}></td>
+                <td><input data-dojo-type="dijit/form/TextBox" name=exchangerate size=10 value=$form->{exchangerate} $readonly></td>
 |;
     }
     $exchangerate .= qq|
@@ -336,10 +336,10 @@ sub form_header {
 |;
 
     if ( $form->{selectvendor} ) {
-        $vendor = qq|<select data-dojo-type="lsmb/FilteringSelect" id=vendor name=vendor><option></option>$form->{selectvendor}</select>|;
+        $vendor = qq|<select data-dojo-type="lsmb/FilteringSelect" id=vendor name=vendor $readonly><option></option>$form->{selectvendor}</select>|;
     }
     else {
-        $vendor = qq|<input data-dojo-type="dijit/form/TextBox" name=vendor id=vendor value="$form->{vendor}" size=35>
+        $vendor = qq|<input data-dojo-type="dijit/form/TextBox" name=vendor id=vendor value="$form->{vendor}" size=35 $roadonly>
                  <a href="erp.pl?action=root#contact.pl?action=add&entity_class=1"
                   id="new-contact" target="_blank">[|
                  .  $locale->text('New') . qq|]</a>|;
@@ -348,7 +348,7 @@ sub form_header {
     $department = qq|
               <tr>
           <th align="right" nowrap>| . $locale->text('Department') . qq|</th>
-          <td colspan=3><select data-dojo-type="dijit/form/Select" id=department name=department>$form->{selectdepartment}</select>
+          <td colspan=3><select data-dojo-type="dijit/form/Select" id=department name=department $readonly>$form->{selectdepartment}</select>
           <input type=hidden name=selectdepartment value="|
       . $form->escape( $form->{selectdepartment}, 1 ) . qq|">
           </td>
@@ -452,14 +452,14 @@ sub form_header {
         </td>
           <tr>
         <th align=right><label for="AP">| . $locale->text('Record in') . qq|</label></th>
-        <td colspan=3><select data-dojo-type="dijit/form/Select" id=AP name=AP>$form->{selectAP}</select></td>
+        <td colspan=3><select data-dojo-type="dijit/form/Select" id=AP name=AP $readonly>$form->{selectAP}</select></td>
           </tr>
               $department
           $exchangerate
             <tr>
                <th align="right" nowrap><label for="description">| . $locale->text('Description') . qq|</label></th>
                <td><input data-dojo-type="dijit/form/TextBox" type="text" id="description" name="description" size="40"
-                   value="| . $form->{description} . qq|" /></td>
+                   value="| . $form->{description} . qq|" $readonly /></td>
             </tr>
         </table>
       </td>
@@ -467,29 +467,29 @@ sub form_header {
         <table>
           <tr>
         <th align=right nowrap><label for="invnumber">| . $locale->text('Invoice Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" id=invnumber name=invnumber size=20 value="$form->{invnumber}">
+        <td><input data-dojo-type="dijit/form/TextBox" id=invnumber name=invnumber size=20 value="$form->{invnumber}" $readonly>
                    | .  $form->sequence_dropdown('vinumber') . qq|</td>
           </tr>
           <tr>
         <th align=right nowrap><label for="ordnumber">| . $locale->text('Order Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" id=ordnumber name=ordnumber size=20 value="$form->{ordnumber}"></td>
+        <td><input data-dojo-type="dijit/form/TextBox" id=ordnumber name=ordnumber size=20 value="$form->{ordnumber}" $readonly></td>
 <input type=hidden name=quonumber value="$form->{quonumber}">
           </tr>
               <tr>
                 <th align=right nowrap><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>
-                <td><input class="date" data-dojo-type="lsmb/DateTextBox" id=crdate name=crdate size=11 title="$myconfig{dateformat}" value=$form->{crdate} data-dojo-props="defaultIsToday:true"></td>
+                <td><input class="date" data-dojo-type="lsmb/DateTextBox" id=crdate name=crdate size=11 title="$myconfig{dateformat}" value=$form->{crdate} data-dojo-props="defaultIsToday:true" $readonly></td>
               </tr>
           <tr>
         <th align=right nowrap><label for="transdate">| . $locale->text('Invoice Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate" data-dojo-props="defaultIsToday:true"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate" data-dojo-props="defaultIsToday:true" $readonly></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="duedate">| . $locale->text('Due Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=duedate size=11 title="$myconfig{dateformat}" value="$form->{duedate}" id="duedate"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=duedate size=11 title="$myconfig{dateformat}" value="$form->{duedate}" id="duedate" $readonly></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="ponumber">| . $locale->text('SO Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" id=ponumber name=ponumber size=20 value="$form->{ponumber}"></td>
+        <td><input data-dojo-type="dijit/form/TextBox" id=ponumber name=ponumber size=20 value="$form->{ponumber}" $readonly></td>
           </tr>
           <tr>
           <th align=right nowrap>| . $locale->text('State') . qq|</th>
@@ -541,6 +541,7 @@ sub form_header {
 }
 
 sub form_footer {
+    my $readonly = $form->{approved} ? 'readonly="readonly"' : '';
     my $manual_tax;
     if ($form->{approved}){
         $manual_tax =
@@ -560,11 +561,11 @@ sub form_footer {
                     qq|<label for="manual-tax-0">|.
                        $locale->text("Automatic"). qq|</label>
                        <input type="radio" data-dojo-type="dijit/form/RadioButton" name="manual_tax" value="0"
-                              id="manual-tax-0" $checked0 />
+                              id="manual-tax-0" $checked0 $readonly />
                         <label for="manual-tax-1">|.
                         $locale->text("Manual"). qq|</label>
                       <input type="radio" data-dojo-type="dijit/form/RadioButton" name="manual_tax" value="1"
-                              id="manual-tax-1" $checked1 />|;
+                              id="manual-tax-1" $checked1 $readonly />|;
     }
     _calc_taxes();
     $form->{invtotal} = $form->{invsubtotal};
@@ -577,7 +578,7 @@ sub form_footer {
     }
     $rows = ( $rows > $introws ) ? $rows : $introws;
     $notes =
-qq|<textarea data-dojo-type="dijit/form/Textarea" id=notes name=notes rows=$rows cols=35 wrap=soft>$form->{notes}</textarea>|;
+qq|<textarea data-dojo-type="dijit/form/Textarea" id=notes name=notes rows=$rows cols=35 wrap=soft $readonly>$form->{notes}</textarea>|;
     $intnotes =
 qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows=$rows cols=35 wrap=soft>$form->{intnotes}</textarea>|;
     $tax = "";
@@ -586,7 +587,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
     $taxincluded = "";
     if ($form->{taxaccounts} ) {
         $taxincluded = qq|
-        <input id=taxincluded name=taxincluded class=checkbox type=checkbox data-dojo-type="dijit/form/CheckBox" value=1 $form->{taxincluded}> <b>|
+        <input id=taxincluded name=taxincluded class=checkbox type=checkbox data-dojo-type="dijit/form/CheckBox" value=1 $form->{taxincluded} $readonly> <b>|
           . $locale->text('Tax Included') . qq|</b>
 |;
     }
@@ -644,19 +645,19 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                 <th align=right>$form->{_accno_descriptions}->{$taccno}</th>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_amount_$item"
                         id="mt-amount-$item" value="|
-                        .$form->format_amount(\%myconfig,$form->{"mt_amount_$item"}).qq|" size="10"/></td>
+                        .$form->format_amount(\%myconfig,$form->{"mt_amount_$item"}).qq|" size="10" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_rate_$item"
                          id="mt-rate-$item" value="|
-                        .$form->format_amount(\%myconfig,$form->{"mt_rate_$item"}).qq|" size="6"/></td>
+                        .$form->format_amount(\%myconfig,$form->{"mt_rate_$item"}).qq|" size="6" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_basis_$item"
                          id="mt-basis-$item" value="|
-                        .$form->format_amount(\%myconfig,$form->{"mt_basis_$item"}).qq|" size="10" /></td>
+                        .$form->format_amount(\%myconfig,$form->{"mt_basis_$item"}).qq|" size="10" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_ref_$item"
                          id="mt-ref-$item" value="|
-                        .$form->{"mt_ref_$item"} .qq|" size="10"/></td>
+                        .$form->{"mt_ref_$item"} .qq|" size="10" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_memo_$item"
                          id="mt-memo-$item" value="|
-                        .$form->{"mt_memo_$item"} .qq|" size="10"/></td>
+                        .$form->{"mt_memo_$item"} .qq|" size="10" $readonly /></td>
                </tr>|;
             }  else {
                 $form->{invtotal} += $form->round_amount($form->{taxes}{$item}, 2);
@@ -837,6 +838,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
         $form->{"AP_paid_$form->{paidaccounts}"} = $1;
     }
     foreach my $i ( 1 .. $form->{paidaccounts} ) {
+        next if $readonly and not $form->{"datepaid_$i"};
 
         $form->hide_form("cleared_$i");
 
@@ -869,7 +871,7 @@ qq|<input type=hidden name="exchangerate_$i" value=$form->{"exchangerate_$i"}>$f
             }
             else {
                 $exchangerate =
-qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchangerate_$i" size=10 value=$form->{"exchangerate_$i"}>|;
+qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchangerate_$i" size=10 value=$form->{"exchangerate_$i"} $readonly>|;
             }
         }
         $exchangerate .= qq|
@@ -878,18 +880,18 @@ qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchang
 
         $form->{"${_}_$i"} //= '' for (qw(memo source datepaid));
         $column_data{"paid_$i"} =
-qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size=11 value=$form->{"paid_$i"}></td>|;
+qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size=11 value=$form->{"paid_$i"} $readonly></td>|;
         $column_data{"exchangerate_$i"} =
           qq|<td align=center>$exchangerate</td>|;
         $column_data{"paidfx_$i"} = qq|<td align="center">$form->{"paidfx_$i"}</td>|;
         $column_data{"AP_paid_$i"} =
-            qq|<td align=center><select data-dojo-type="dijit/form/Select" id="AP-paid-$i" name="AP_paid_$i" id="AP_paid_$i">$form->{"selectAP_paid_$i"}</select></td>|;
+            qq|<td align=center><select data-dojo-type="dijit/form/Select" id="AP-paid-$i" name="AP_paid_$i" id="AP_paid_$i" $readonly>$form->{"selectAP_paid_$i"}</select></td>|;
         $column_data{"datepaid_$i"} =
-qq|<td align=center><input class="date" data-dojo-type="lsmb/DateTextBox" name="datepaid_$i" id="datepaid_$i" size=11 title="$myconfig{dateformat}" value=$form->{"datepaid_$i"}></td>|;
+qq|<td align=center><input class="date" data-dojo-type="lsmb/DateTextBox" name="datepaid_$i" id="datepaid_$i" size=11 title="$myconfig{dateformat}" value=$form->{"datepaid_$i"} $readonly></td>|;
         $column_data{"source_$i"} =
-qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="source_$i" id="source_$i" size=11 value="$form->{"source_$i"}"></td>|;
+qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="source_$i" id="source_$i" size=11 value="$form->{"source_$i"}" $readonly></td>|;
         $column_data{"memo_$i"} =
-qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id="memo_$i" size=11 value="$form->{"memo_$i"}"></td>|;
+qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id="memo_$i" size=11 value="$form->{"memo_$i"}" $readonly></td>|;
 
         for (@column_index) { print qq|$column_data{"${_}_$i"}\n| }
 

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -286,6 +286,7 @@ sub prepare_invoice {
 }
 
 sub form_header {
+    my $readonly = $form->{approved} ? 'readonly="readonly"' : '';
     $form->{nextsub} = 'update';
     $form->{ARAP} = 'AR';
     $form->generate_selects(\%myconfig) unless $form->{selectAR};
@@ -315,7 +316,7 @@ sub form_header {
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
         <th align=right nowrap>| . $locale->text('Currency') . qq|</th>
-        <td><select data-dojo-type="dijit/form/Select" id="currency" name="currency">$form->{selectcurrency}</select></td>
+        <td><select data-dojo-type="dijit/form/Select" id="currency" name="currency" $readonly>$form->{selectcurrency}</select></td>
 | if $form->{defaultcurrency};
 
     if (   $form->{defaultcurrency}
@@ -324,7 +325,7 @@ sub form_header {
         $exchangerate .=
                 qq|<th align=right>|
               . $locale->text('Exchange Rate')
-              . qq|</th><td><input data-dojo-type="dijit/form/TextBox" name="exchangerate" size="10" value="$form->{exchangerate}"></td>|;
+              . qq|</th><td><input data-dojo-type="dijit/form/TextBox" name="exchangerate" size="10" value="$form->{exchangerate}" $readonly></td>|;
     }
     $exchangerate .= qq|
 <input type=hidden name="forex" value="$form->{forex}">
@@ -332,10 +333,10 @@ sub form_header {
 |;
 
     if ( $form->{selectcustomer} ) {
-        $customer = qq|<select data-dojo-type="lsmb/FilteringSelect" id="customer" name="customer"><option></option>$form->{selectcustomer}</select>|;
+        $customer = qq|<select data-dojo-type="lsmb/FilteringSelect" id="customer" name="customer" $readonly><option></option>$form->{selectcustomer}</select>|;
     }
     else {
-        $customer = qq|<input data-dojo-type="dijit/form/TextBox" id="customer" name="customer" value="$form->{customer}" size="35">
+        $customer = qq|<input data-dojo-type="dijit/form/TextBox" id="customer" name="customer" value="$form->{customer}" size="35" $readonly>
      <a id="new-contact" target="_blank"
         href="erp.pl?action=root#contact.pl?action=add&entity_class=2">[| .
         $locale->text('New') . qq|]</a> |;
@@ -344,7 +345,7 @@ sub form_header {
     $department = qq|
               <tr>
             <th align="right" nowrap>| . $locale->text('Department') . qq|</th>
-        <td colspan="3"><select data-dojo-type="dijit/form/Select" id="department" name="department">$form->{selectdepartment}</select>
+        <td colspan="3"><select data-dojo-type="dijit/form/Select" id="department" name="department" $readonly>$form->{selectdepartment}</select>
         </td>
           </tr>
 | if $form->{selectdepartment};
@@ -411,11 +412,11 @@ sub form_header {
                     qq|<label for="manual-tax-0">|.
                        $locale->text("Automatic"). qq|</label>
                        <input type="radio" data-dojo-type="dijit/form/RadioButton" name="manual_tax" value="0"
-                              id="manual-tax-0">
+                              id="manual-tax-0" $readonly >
                         <label for="manual-tax-1">|.
                         $locale->text("Manual"). qq|</label>
                       <input type="radio" data-dojo-type="dijit/form/RadioButton" name="manual_tax" value="1"
-                              id="manual-tax-1">|;
+                              id="manual-tax-1" $readonly >|;
     }
     print qq|
 <table width=100%>
@@ -493,7 +494,7 @@ sub form_header {
 
           <tr>
         <th align="right" nowrap><label for="AR">| . $locale->text('Record in') . qq|</label></th>
-        <td colspan="3"><select data-dojo-type="dijit/form/Select" name="AR" id="AR">$form->{selectAR}</select></td>
+        <td colspan="3"><select data-dojo-type="dijit/form/Select" name="AR" id="AR" $readonly>$form->{selectAR}</select></td>
           </tr>
           $department
           $exchangerate
@@ -501,16 +502,16 @@ sub form_header {
                <th align="right" nowrap><label for="description">| . $locale->text('Description') . qq|</label>
                </th>
                <td><input data-dojo-type="dijit/form/TextBox" type="text" id="description" name="description" size="40"
-                   value="| . $form->{description} . qq|" /></td>
+                   value="| . $form->{description} . qq|" $readonly /></td>
             </tr>
           <tr>
         <th align=right nowrap><label for="shippingpoint">| . $locale->text('Shipping Point') . qq|</label></th>
-        <td colspan=3><input data-dojo-type="dijit/form/TextBox" id="shippingpoint" name="shippingpoint" size="35" value="$form->{shippingpoint}"></td>
+        <td colspan=3><input data-dojo-type="dijit/form/TextBox" id="shippingpoint" name="shippingpoint" size="35" value="$form->{shippingpoint}" $readonly></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="shipvia">| . $locale->text('Ship via') . qq|</label></th>
         <td colspan=3>
-                   <textarea data-dojo-type="dijit/form/Textarea" id="shipvia" name="shipvia" cols="35" rows="3"
+                   <textarea data-dojo-type="dijit/form/Textarea" id="shipvia" name="shipvia" cols="35" rows="3" $readonly
                        >$form->{shipvia}</textarea></td>
           </tr>
         </table>
@@ -520,28 +521,28 @@ sub form_header {
           $employee
           <tr>
         <th align=right nowrap><label for="invnumber">| . $locale->text('Invoice Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name="invnumber" id="invnumber" size="20" value="$form->{invnumber}">| .  $form->sequence_dropdown('sinumber') . qq|</td>
+        <td><input data-dojo-type="dijit/form/TextBox" name="invnumber" id="invnumber" size="20" value="$form->{invnumber}" $readonly>| .  $form->sequence_dropdown('sinumber') . qq|</td>
           </tr>
           <tr>
         <th align=right nowrap><label for="ordnumber">| . $locale->text('Order Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name="ordnumber" id="ordnumber" size="20" value="$form->{ordnumber}"></td>
+        <td><input data-dojo-type="dijit/form/TextBox" name="ordnumber" id="ordnumber" size="20" value="$form->{ordnumber}" $readonly></td>
 <input type=hidden name="quonumber" value="$form->{quonumber}">
           </tr>
           <tr class="crdate-row">
         <th align=right><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="crdate" size="11" title="$myconfig{dateformat}" value="$form->{crdate}" id="crdate" data-dojo-props="defaultIsToday:true"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="crdate" size="11" title="$myconfig{dateformat}" value="$form->{crdate}" id="crdate" data-dojo-props="defaultIsToday:true" $readonly ></td>
           </tr>
           <tr class="transdate-row">
         <th align=right><label for="transdate">| . $locale->text('Invoice Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="transdate" id="transdate" size="11" title="$myconfig{dateformat}" value="$form->{transdate}" data-dojo-props="defaultIsToday:true"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="transdate" id="transdate" size="11" title="$myconfig{dateformat}" value="$form->{transdate}" data-dojo-props="defaultIsToday:true" $readonly ></td>
           </tr>
           <tr>
         <th align=right><label for="duedate">| . $locale->text('Due Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="duedate" id="duedate" size="11" title="$myconfig{dateformat}" value="$form->{duedate}"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="duedate" id="duedate" size="11" title="$myconfig{dateformat}" value="$form->{duedate}" $readonly ></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="ponumber">| . $locale->text('PO Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name="ponumber" id="ponumber" size="20" value="$form->{ponumber}"></td>
+        <td><input data-dojo-type="dijit/form/TextBox" name="ponumber" id="ponumber" size="20" value="$form->{ponumber}" $readonly ></td>
           </tr>
           <tr>
           <th align=right nowrap>| . $locale->text('State') . qq|</th>
@@ -626,6 +627,7 @@ sub void {
 }
 
 sub form_footer {
+    my $readonly = $form->{approved} ? 'readonly="readonly"' : '';
     my $manual_tax;
     if ($form->{approved}){
         $manual_tax =
@@ -645,11 +647,11 @@ sub form_footer {
                     qq|<label for="manual-tax-0">|.
                        $locale->text("Automatic"). qq|</label>
                        <input type="radio" data-dojo-type="dijit/form/RadioButton" name="manual_tax" value="0"
-                              id="manual-tax-0" $checked0 />
+                              id="manual-tax-0" $checked0 $readonly />
                         <label for="manual-tax-1">|.
                         $locale->text("Manual"). qq|</label>
                       <input type="radio" data-dojo-type="dijit/form/RadioButton" name="manual_tax" value="1"
-                              id="manual-tax-1" $checked1 >|;
+                              id="manual-tax-1" $checked1 $readonly >|;
     }
     _calc_taxes();
     $form->{invtotal} = $form->{invsubtotal};
@@ -663,7 +665,7 @@ sub form_footer {
     $rows = ( $rows > $introws ) ? $rows : $introws;
     $form->{notes} //= '';
     $notes =
-        qq|<textarea data-dojo-type="dijit/form/Textarea" id="notes" name="notes" rows="$rows" cols="40" wrap="soft">$form->{notes}</textarea>|;
+        qq|<textarea data-dojo-type="dijit/form/Textarea" id="notes" name="notes" rows="$rows" cols="40" wrap="soft" $readonly>$form->{notes}</textarea>|;
     $form->{intnotes} //= '';
     $intnotes =
 qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" rows="$rows" cols="40" wrap="soft">$form->{intnotes}</textarea>|;
@@ -676,7 +678,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
               <tr height="5"></tr>
               <tr>
             <td align=right>
-            <input id="taxincluded" name="taxincluded" class="checkbox" type="checkbox" data-dojo-type="dijit/form/CheckBox" value="1" $form->{taxincluded}></td><th align=left>|
+            <input id="taxincluded" name="taxincluded" class="checkbox" type="checkbox" data-dojo-type="dijit/form/CheckBox" value="1" $form->{taxincluded} $readonly></td><th align=left>|
           . $locale->text('Tax Included')
           . qq|</th>
          </tr>
@@ -724,21 +726,21 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_amount_$item"
                         id="mt-amount-$item" value="|
                         .$form->format_amount(\%myconfig, $form->{"mt_amount_$item"}, LedgerSMB::Setting->new(%$form)->get('decimal_places'))
-                        .qq|" size="10"/></td>
+                        .qq|" size="10" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_rate_$item"
                          id="mt-rate-$item" value="|
                         .$form->format_amount(\%myconfig, $form->{"mt_rate_$item"})
-                        .qq|" size="4"/></td>
+                        .qq|" size="4" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_basis_$item"
                          id="mt-basis-$item" value="|
                         .$form->format_amount(\%myconfig, $form->{"mt_basis_$item"}, LedgerSMB::Setting->new(%$form)->get('decimal_places'))
-                        .qq|" size="10"/></td>
+                        .qq|" size="10" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_ref_$item"
                          id="mt-ref-$item" value="|
-                        . $form->{"mt_ref_$item"} .qq|" size="10"/></td>
+                        . $form->{"mt_ref_$item"} .qq|" size="10" $readonly /></td>
                 <td><input data-dojo-type="dijit/form/TextBox" type="text" name="mt_memo_$item"
                          id="mt-memo-$item" value="|
-                        .$form->{"mt_memo_$item"} .qq|" size="10"/></td>
+                        .$form->{"mt_memo_$item"} .qq|" size="10" $readonly /></td>
                </tr>|;
             }  else {
            $form->{invtotal} += $form->round_amount($form->{taxes}{$item}, 2);
@@ -927,6 +929,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
     $form->{"selectAR_paid"} =~ /value="(\Q$form->{cash_accno}\E--[^<]*)"/;
     $form->{"AR_paid_$form->{paidaccounts}"} = $1;
     foreach my $i ( 1 .. $form->{paidaccounts} ) {
+        next if $readonly and not $form->{"datepaid_$i"};
 
         $form->hide_form("cleared_$i");
 
@@ -956,7 +959,7 @@ qq|<input type="hidden" name="exchangerate_$i" value="$form->{"exchangerate_$i"}
             }
             else {
                 $exchangerate =
-qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchangerate_$i" size="10" value="$form->{"exchangerate_$i"}">|;
+qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchangerate_$i" size="10" value="$form->{"exchangerate_$i"}" $readonly>|;
             }
         }
 
@@ -965,17 +968,17 @@ qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchang
 |;
 
         $column_data{paid} =
-qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size="11" value="$form->{"paid_$i"}"></td>|;
+qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size="11" value="$form->{"paid_$i"}" $readonly></td>|;
         $column_data{exchangerate} = qq|<td align="center">$exchangerate</td>|;
         $column_data{paidfx} = qq|<td align="center">$form->{"paidfx_$i"}</td>|;
         $column_data{AR_paid} =
-qq|<td align="center"><select data-dojo-type="dijit/form/Select" name="AR_paid_$i" id="AR_paid_$i">$form->{"selectAR_paid_$i"}</select></td>|;
+qq|<td align="center"><select data-dojo-type="dijit/form/Select" name="AR_paid_$i" id="AR_paid_$i" $readonly>$form->{"selectAR_paid_$i"}</select></td>|;
         $column_data{datepaid} =
-qq|<td align="center"><input class="date" data-dojo-type="lsmb/DateTextBox" name="datepaid_$i" id="datepaid_$i" size="11" title="$myconfig{dateformat}" value="$form->{"datepaid_$i"}"></td>|;
+qq|<td align="center"><input class="date" data-dojo-type="lsmb/DateTextBox" name="datepaid_$i" id="datepaid_$i" size="11" title="$myconfig{dateformat}" value="$form->{"datepaid_$i"}" $readonly></td>|;
         $column_data{source} =
-qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="source_$i" id="source_$i" size="11" value="$form->{"source_$i"}"></td>|;
+qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="source_$i" id="source_$i" size="11" value="$form->{"source_$i"}" $readonly></td>|;
         $column_data{memo} =
-qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id="memo_$i" size="11" value="$form->{"memo_$i"}"></td>|;
+qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id="memo_$i" size="11" value="$form->{"memo_$i"}" $readonly></td>|;
 
         for (@column_index) { print qq|$column_data{$_}\n| }
         print "


### PR DESCRIPTION
This commit renders all invoice and transaction inputs except the 'Save Info'-saveable fields as read-only in order to remove the impression that the transaction could be editable.

To further remove that impression, it also prevents rendering of the empty 'new input' line on the invoice and payments sections.

