### PR TITLE
Fix partsgroup selectors all having the same ID

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -512,7 +512,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" id="notes_$i" name="notes_$i" 
                 <td colspan=6 nowrap><b>$serialnumber</b> <input data-dojo-type="dijit/form/TextBox" id="serialnumber_$i" name="serialnumber_$i" value="$form->{"serialnumber_$i"}"></td>|
           if $form->{type} !~ /_quotation/;
 
-        if ( $i == $numrows ) {
+        if ( $i >= $numrows ) {
             $partsgroup = "";
             if ( $form->{selectpartsgroup} ) {
                 $partsgroup = qq|


### PR DESCRIPTION
All partsgroup selectors on invoices, orders and quotes have the same 'id' attribute value. This scenario is triggered by setting 'Min empty lines' > 1.

Fixes #6911

