### PR TITLE
Fix AR/AP transactions being posted instead of saved

### DIFF
--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -346,7 +346,7 @@ sub post_transaction {
     $form->{datepaid} = $form->{transdate} unless $form->{datepaid};
     my $datepaid = ($paid) ? qq|'$form->{datepaid}'| : undef;
     my $approved = 1;
-    $approved = 0 if $form->{separate_duties};
+    $approved = 0 if $form->get_setting('separate_duties');
 
     my @queryargs = (
         $form->{invnumber},        $form->{description},


### PR DESCRIPTION
For some reason, 'separate_duties' isn't set in $form for AR and AP transactions. Instead of depending on it being defined, actively query the setting.
