### PR TITLE
Fix searching on quote number

### DIFF
--- a/UI/Reports/filters/orders.html
+++ b/UI/Reports/filters/orders.html
@@ -35,6 +35,7 @@
                     value = meta_number
                     } %]</td>
       </tr>
+[% IF oe_class_id == 1 OR oe_class_id == 2 %]
       <tr>
         <th>[% text('Order Number') %]</th>
         <td>[%  PROCESS input element_data = {
@@ -45,6 +46,18 @@
                     value = ordnumber
                     } %]</td>
       </tr>
+[% ELSE %]
+      <tr>
+        <th>[% text('Quote Number') %]</th>
+        <td>[%  PROCESS input element_data = {
+                    name = 'ordnumber'
+                    size = 16
+                    class = 'control-code'
+                    type = 'text'
+                    value = ordnumber
+                    } %]</td>
+      </tr>
+[% END %]
       <tr>
         <th>[% text('PO Number') %]</th>
         <td>[%  PROCESS input element_data = {

--- a/sql/modules/OrderEntry.sql
+++ b/sql/modules/OrderEntry.sql
@@ -63,8 +63,9 @@ LANGUAGE SQL AS $$
              AND (in_legal_name IS NULL OR
                      c.name @@ plainto_tsquery(in_legal_name))
              AND (in_ponumber IS NULL OR o.ponumber ILIKE in_ponumber || '%')
-            AND (in_ordnumber IS NULL
-                     OR o.ordnumber ILIKE in_ordnumber || '%')
+             AND (in_ordnumber IS NULL
+                  OR (oe_class_id IN (1, 2) AND o.ordnumber ILIKE in_ordnumber || '%')
+                  OR oe_class_id IN (3, 4) AND o.quonumber ILIKE in_ordnumber || '%')
              AND ((in_open is true and o.closed is false)
                  OR (in_closed is true and o.closed is true))
              AND (in_shipvia IS NULL


### PR DESCRIPTION
Although the stored procedure outputs the order or quote number based on the order class input, it always searches on the order number. Which makes it impossible to find quotes.
