### PR TITLE
Fix error reporting for old DBObject code

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Asset.pm
+++ b/old/lib/LedgerSMB/DBObject/Asset.pm
@@ -91,6 +91,8 @@ use base qw(LedgerSMB::PGOld);
 use strict;
 use warnings;
 
+use Carp;
+
 =item save
 
 Uses standard properties
@@ -252,7 +254,7 @@ sub get_invoice_id {
     my ($self) = @_;
     my ($ref) = $self->call_dbmethod(funcname => 'get_vendor_invoice_id');
     if (!$ref) {
-        return $self->error($self->{_locale}->text('Invoice not found'));
+        Carp::croak $self->{_locale}->text('Invoice not found');
     } else {
         return $self->{invoice_id} = $ref->{get_vendor_invoice_id};
     }

--- a/old/lib/LedgerSMB/DBObject/Draft.pm
+++ b/old/lib/LedgerSMB/DBObject/Draft.pm
@@ -23,6 +23,8 @@ use warnings;
 
 use base qw/LedgerSMB::PGOld/;
 
+use Carp;
+
 =item search()
 
 returns a list of results for the search criteria.  This list is also stored
@@ -56,7 +58,7 @@ approved, the draft shows up in financial reports.
 sub approve {
    my ($self) = @_;
    if (!$self->{id}){
-       $self->error($self->{_locale}->text('No ID Set'));
+       Carp::croak $self->{_locale}->text('No ID Set');
    }
    ($self->{approved}) = $self->call_dbmethod(funcname => 'draft_approve');
    return $self->{approved};
@@ -74,7 +76,7 @@ books, a draft may not be deleted.
 sub delete {
    my ($self) = @_;
    if (!$self->{id}){
-       $self->error($self->{_locale}->text('No ID Set'));
+       Carp::croak $self->{_locale}->text('No ID Set');
    }
    ($self->{deleted}) = $self->call_dbmethod(funcname => 'draft_delete');
    return $self->{deleted};

--- a/old/lib/LedgerSMB/DBObject/TransTemplate.pm
+++ b/old/lib/LedgerSMB/DBObject/TransTemplate.pm
@@ -2,6 +2,8 @@ package LedgerSMB::DBObject::TransTemplate;
 use base qw(LedgerSMB::PGOld);
 use strict;
 use warnings;
+
+use Carp;
 use Log::Any;
 
 use LedgerSMB::Magic qw(JRNL_GJ JRNL_AR JRNL_AP EC_CUSTOMER EC_VENDOR);
@@ -64,7 +66,7 @@ sub save {
        $l->{account_id} = $ref->{id};
        $logger->debug( "$l->{accno}\n" );
        if (!$ref->{id}){
-           $self->error($self->{_locale}->text('No Account id for [_1]', $l->{accno}));
+           Carp::croak $self->{_locale}->text('No Account id for [_1]', $l->{accno});
        }
        $l->call_dbmethod(funcname=> 'journal__add_line');
    }

--- a/old/lib/LedgerSMB/DBObject/User.pm
+++ b/old/lib/LedgerSMB/DBObject/User.pm
@@ -14,6 +14,7 @@ use base qw(LedgerSMB::PGOld);
 
 use Locale::CLDR;
 
+use Carp;
 use Log::Any;
 
 =head2 NOTES
@@ -57,7 +58,7 @@ sub change_my_password {
     # Before doing any work at all, reject the request when the passwords
     # don't match...
     if ($self->{new_password} ne $self->{confirm_password}){
-        $self->error($self->{_locale}->text('Passwords must match.'));
+        Carp::croak $self->{_locale}->text('Passwords must match.');
         die;
     }
 
@@ -69,7 +70,7 @@ sub change_my_password {
         qq|dbi:Pg:dbname="$dbname"|, $self->{login}, $self->{old_password}
     );
     if (!$verify){
-        $self->error($self->{_locale}->text('Incorrect Password'));
+        Carp::croak $self->{_locale}->text('Incorrect Password');
     }
     $verify->disconnect;
     $self->{password} = $self->{new_password};


### PR DESCRIPTION
There hasn't been an 'error' method or a long time. The method it's trying to call is nothing more than a call to Carp::croak, so instead of all the complexity, call that.

Re #6978
