### PR TITLE
Fix user password change

### DIFF
--- a/old/lib/LedgerSMB/DBObject/User.pm
+++ b/old/lib/LedgerSMB/DBObject/User.pm
@@ -65,9 +65,11 @@ sub change_my_password {
 
     my $dbname = $self->{company};
 
-    my $verify = DBI->connect(
-        qq|dbi:Pg:dbname="$dbname"|, $self->{login}, $self->{old_password}
-    );
+    my $verify = $self->{_wire}->get('db')->instance(
+        dbname   => $self->{company},
+        user     => $self->{login},
+        password => $self->{old_password}
+        )->connect();
     if (!$verify){
         $self->error($self->{_locale}->text('Incorrect Password'));
     }


### PR DESCRIPTION
Instead of implicitly depending on the environment to hold the database connection data in PG* environment variables, use the explicitly declared data from the dependency injection system.

Fixes #6978
