### PR TITLE
Fix various buttons in payment and customer screens

### DIFF
--- a/UI/js-src/lsmb/JumpScreenButton.js
+++ b/UI/js-src/lsmb/JumpScreenButton.js
@@ -1,14 +1,13 @@
 /** @format */
 
-define(["dojo/_base/declare", "dijit/registry", "dijit/form/Button"], function (
+define(["dojo/_base/declare", "dijit/form/Button"], function (
     declare,
-    registry,
     button
 ) {
     return declare("lsmb/payments/JumpScreenButton", [button], {
         url: null,
         onClick: function () {
-            registry.byId("maindiv").load_link(this.url);
+            window.__lsmbLoadLink(this.url);
         }
     });
 });

--- a/UI/js-src/lsmb/payments/PostPrintButton.js
+++ b/UI/js-src/lsmb/payments/PostPrintButton.js
@@ -35,14 +35,12 @@ define([
                         // revoking the ObjectURL
                         window.URL.revokeObjectURL(_data);
                     }, 100);
-                    registry
-                        .byId("maindiv")
-                        .load_link(
-                            "payment.pl?action=payment&account_class=" +
-                                _data.account_class +
-                                "&type=" +
-                                _data.type
-                        );
+                    window.__lsmbLoadLink(
+                        "payment.pl?action=payment&account_class=" +
+                            _data.account_class +
+                            "&type=" +
+                            _data.type
+                    );
                 },
                 function (err) {
                     registry.byId("maindiv").report_request_error(err);


### PR DESCRIPTION
The 'load_link' function no longer exists. It has been removed when we moved to Vue.
