### PR TITLE
Fix alignment issues on Contact screen

### DIFF
--- a/UI/Contact/divs/address.html
+++ b/UI/Contact/divs/address.html
@@ -103,8 +103,7 @@
                           id              = 'attach_address_to'
                           default_values  = [attach_to]
                           options         = attach_level_options
-                          title = text('Attach To') #'
-                          label = "_none_"
+                          label = text('Attach To') #'
                        };
                      ELSE %]
   <label>[% text('Attach to Entity'); %]</label>
@@ -115,8 +114,7 @@
                        options        = location_class_list
                        text_attr      = "class"
                        value_attr     = "id"
-                       title = text('Type')
-                       label = "_none_"
+                       label = text('Type')
   } %]
   <label style="grid-row: span 3">[% text('Address') %]</label>
                 [% INCLUDE input element_data = {

--- a/UI/Contact/divs/contact_info.html
+++ b/UI/Contact/divs/contact_info.html
@@ -82,8 +82,7 @@ PROCESS dynatable
                           id              = 'attach-contact-to'
                           default_values  = [attach_to]
                           options         = attach_level_options
-                          title = text('Attach To') #'
-                          label = "_none_"
+                          label = text('Attach To') #'
                        };
                      ELSE %]
              <label>[% text('Attach to Entity'); %]</label><div>&nbsp;</div>

--- a/UI/Contact/divs/notes.html
+++ b/UI/Contact/divs/notes.html
@@ -25,14 +25,14 @@
                 name="credit_id"
                 value=credit_act.id
         } %]
-<div class="two-column-grid">
+<div class="two-column-grid" style="width: fit-content">
 [%
 IF credit_act.id;
     PROCESS select element_data = {
                         name = "note_class"
                         default_values = [note_class]
                         options = attach_level_options
-                        title = text("Note Class")
+                        label = text("Attach To")
                         value_attr = "value"
         };
 ELSE; %]


### PR DESCRIPTION
Missing labels on address and contact info screens as well as labels on wrong row and too wide screen on notes.
