### PR TITLE
Improve old-UI integration with Vue

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -62,7 +62,16 @@ export default {
                 });
 
                 if (r.ok && !domReject(r)) {
-                    this.content = await r.text();
+                    let newContent = await r.text();
+                    this.notify({
+                        title: options.done || this.$t("Loaded")
+                    });
+                    if (newContent === this.content) {
+                        // when there is no difference in returned content,
+                        // Vue won't re-render... so don't rerun the parser!
+                        return;
+                    }
+                    this.content = newContent;
                     this.$nextTick(() => {
                         let maindiv = document.getElementById("maindiv");
                         parser.parse(maindiv).then(
@@ -76,30 +85,22 @@ export default {
                                 if (dismiss) {
                                     dismiss();
                                 }
-                                this.notify({
-                                    title: options.done || this.$t("Loaded")
-                                });
                                 topic.publish("lsmb/page-fresh-content");
                                 maindiv.setAttribute("data-lsmb-done", "true");
                             },
                             (e) => {
-                                if (dismiss) {
-                                    dismiss();
-                                }
                                 this._report_error(e);
                             });
                     });
                 } else {
-                    if (dismiss) {
-                        dismiss();
-                    }
                     this._report_error(r);
                 }
             } catch (e) {
+                this._report_error(e);
+            } finally {
                 if (dismiss) {
                     dismiss();
                 }
-                this._report_error(e);
             }
         },
         _recursively_resize(widget) {


### PR DESCRIPTION
Based on a better understanding of the Vue lifecycle hooks, this commit improves integration between "old UI"-updates and the Vue component marshalling the changes to Vue.

This commit prevents widgets from being cleared (discarded) until Vue actually intends to remove them from the UI. In the past, widgets could visually remain in scope, but be discarded by Dojo, resulting in
a UI which is "dead in the water": not responding to any events anymore.
