### PR TITLE
Add stringification to PGDate instead of the one inherited

### DIFF
--- a/lib/LedgerSMB/PGDate.pm
+++ b/lib/LedgerSMB/PGDate.pm
@@ -252,6 +252,11 @@ sub _formatter {
 # table (being GL>Search-ed without restrictions)
 memoize('_formatter');
 
+# Provide a stringification routine instead of the one inherited
+use overload (
+    q{""}    => 'to_output',
+);
+
 sub to_output {
     my ($self) = @_;
     return '' if not $self->is_date();

--- a/lib/LedgerSMB/PGDate.pm
+++ b/lib/LedgerSMB/PGDate.pm
@@ -254,6 +254,7 @@ memoize('_formatter');
 
 # Provide a stringification routine instead of the one inherited
 use overload (
+    fallback => 1,
     q{""}    => 'to_output',
 );
 


### PR DESCRIPTION
Make sure that PGDate handles the output to handle undefined, date or time only and uses user desired format.