### PR TITLE
Restore focussing behaviour on AR/AP and Orders/Quotes

### DIFF
--- a/UI/journal/journal_entry.html
+++ b/UI/journal/journal_entry.html
@@ -6,7 +6,10 @@
 <body class="lsmb [% dojo_theme %]">
 <div id="journal-entry">
 
-<form data-dojo-type="lsmb/Form" method="post" action="[% form.script %]">
+  <form data-dojo-type="lsmb/Form"
+        data-lsmb-focus="[% form.focus %]"
+        method="post"
+        action="[% form.script %]">
 <table width="100%">
 <tr>
     <th class="listtop" >[% form.title %]</th>
@@ -24,7 +27,7 @@
                         type = "text",
                         size = "20",
                         class = 'reference'
-                        id = "ref_1"
+                        id = "reference"
                 };
              IF form.sequences;
                  PROCESS select element_data = {

--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -87,6 +87,7 @@ export default {
                                 }
                                 topic.publish("lsmb/page-fresh-content");
                                 maindiv.setAttribute("data-lsmb-done", "true");
+                                this._setFormFocus();
                             },
                             (e) => {
                                 this._report_error(e);
@@ -102,6 +103,18 @@ export default {
                     dismiss();
                 }
             }
+        },
+        _setFormFocus() {
+            [ ...document.forms ].forEach(
+                (form) => {
+                    if (form.hasAttribute('data-lsmb-focus')) {
+                        let focus = form.getAttribute('data-lsmb-focus');
+                        let elm = document.getElementById(focus);
+                        if (elm) {
+                            elm.select();
+                        }
+                    }
+                });
         },
         _recursively_resize(widget) {
             widget.getChildren().forEach((child) => {

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -534,7 +534,10 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=
  print qq|
 <body> | .
 $form->open_status_div($status_div_id) . qq|
-<form method="post" data-dojo-type="lsmb/Form" action=$form->{script}>
+<form method="post"
+      data-dojo-type="lsmb/Form"
+      data-lsmb-focus="${focus}"
+      action=$form->{script}>
 <input type=hidden name=type value="$form->{formname}">
 <input type=hidden name=title value="$title">
 
@@ -760,7 +763,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
     $taxformcheck=qq|<td><input type="checkbox" data-dojo-type="dijit/form/CheckBox" name="taxformcheck_$i" value="1" $taxchecked $readonly></td>|;
         print qq|
     <tr valign=top class="transaction-line $form->{ARAP}" id="line-$i">
-     <td><input data-dojo-type="dijit/form/TextBox" name="amount_$i" size=10 value="$form->{"amount_$i"}" $readonly></td>
+     <td><input data-dojo-type="dijit/form/TextBox" id="amount_$i" name="amount_$i" size=10 value="$form->{"amount_$i"}" $readonly></td>
      <td>| . (($form->{currency} ne $form->{defaultcurrency})
               ? $form->format_amount(\%myconfig, $form->parse_amount( \%myconfig, $form->{"amount_$i"} )
                                                   * $form->{exchangerate}, $form->{_setting_decimal_places})

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -357,11 +357,12 @@ sub form_header {
     $form->header;
 
     print qq|
-<body class="lsmb $form->{dojo_theme}" onLoad="document.forms[0].${focus}.focus()" />
+<body>
 | . $form->open_status_div($status_div_id) . qq|
 <form method="post"
       id="invoice"
       data-dojo-type="lsmb/Invoice"
+      data-lsmb-focus="${focus}"
       action="$form->{script}" >
 |;
     if ($form->{notice}){

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -374,6 +374,7 @@ sub form_header {
 | if $form->{selectemployee};
 
     $i     = ($form->{rowcount} // 0) + 1;
+    $focus = "partnumber_$i";
 
     $form->header;
 
@@ -383,6 +384,7 @@ sub form_header {
 <form method="post"
       id="invoice"
       data-dojo-type="lsmb/Invoice"
+      data-lsmb-focus="${focus}"
       action="$form->{script}" >
 |;
 

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -562,11 +562,12 @@ sub form_header {
     $form->header;
 
     print qq|
-<body class="lsmb $form->{dojo_theme}" onLoad="document.forms[0].${focus}.focus()" />
+<body>
 | . $form->open_status_div($status_div_id) . qq|
 <form method="post"
       id="invoice"
       data-dojo-type="lsmb/Invoice"
+      data-lsmb-focus="${focus}"
       action="$form->{script}" >
 |;
 


### PR DESCRIPTION
When we switched to being a Single Page Application (SPA) on the client in version 1.5, we lost how the next data entry row was selected on page refresh. This comit restores that for invoices, orders, quotes and AR/AP transactions (but not GL transactions).

Re #1584
