### PR TITLE
HTML correctness: no hidden inputs between cells and rows

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -559,12 +559,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" id="notes_$i" name="notes_$i" 
     }
 
     print qq|
-      </table>
-    </td>
-  </tr>
-|;
-
-    $form->hide_form(qw(audittrail));
+      </table>|;
 
     print qq|
 
@@ -575,8 +570,12 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" id="notes_$i" name="notes_$i" 
 <input type=hidden name=selectprojectnumber value="|
       . ($form->escape( $form->{selectprojectnumber}, 1 )//'') . qq|">
 
+
+    </td>
+  </tr>
 |;
 
+    $form->hide_form(qw(audittrail));
 }
 
 sub new_item {
@@ -1676,8 +1675,8 @@ sub ship_to {
                                 print qq|
                            <tr>
 
-                              <td><input type=radio data-dojo-type="dijit/form/RadioButton" name=shiptoradio id="shiptoradio_$i" value="$i"  $checked ></td>
-                              <input name="shiptolocationid_$i" id="shiptolocationid_$i" type="hidden" value="$form->{"shiptolocationid_$i"}" readonly>
+                              <td><input type=radio data-dojo-type="dijit/form/RadioButton" name=shiptoradio id="shiptoradio_$i" value="$i"  $checked >
+                              <input name="shiptolocationid_$i" id="shiptolocationid_$i" type="hidden" value="$form->{"shiptolocationid_$i"}" readonly></td>
                               <td><input data-dojo-type="dijit/form/TextBox" name=shiptoaddress1_$i size=12 maxlength=64 id="ad1_$i" value="$form->{"shiptoaddress1_$i"}" readonly></td>
                               <td><input data-dojo-type="dijit/form/TextBox" name=shiptoaddress2_$i size=12 maxlength=64 id="ad2_$i" value="$form->{"shiptoaddress2_$i"}" readonly></td>
                               <td><input data-dojo-type="dijit/form/TextBox" name=shiptoaddress3_$i size=12 maxlength=64 id="ad3_$i" value="$form->{"shiptoaddress3_$i"}" readonly></td>

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -311,21 +311,21 @@ sub form_header {
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
                 <th align=right nowrap>| . $locale->text('Currency') . qq|</th>
-        <td><select data-dojo-type="dijit/form/Select" id=currency name=currency $readonly>$form->{selectcurrency}</select></td> |
+        <td><select data-dojo-type="dijit/form/Select" id=currency name=currency $readonly>$form->{selectcurrency}</select> |
       if $form->{defaultcurrency};
 
     if (   $form->{defaultcurrency}
         && $form->{currency} ne $form->{defaultcurrency} )
     {
         $exchangerate .= qq|
-                <th align=right nowrap>|
+                </td><th align=right nowrap>|
               . $locale->text('Exchange Rate')
               . qq|</th>
-                <td><input data-dojo-type="dijit/form/TextBox" name=exchangerate size=10 value=$form->{exchangerate} $readonly></td>
+                <td><input data-dojo-type="dijit/form/TextBox" name=exchangerate size=10 value=$form->{exchangerate} $readonly>
 |;
     }
     $exchangerate .= qq|
-<input type=hidden name=forex value=$form->{forex}>
+<input type=hidden name=forex value=$form->{forex}></td>
 </tr>
 |;
 
@@ -391,11 +391,11 @@ sub form_header {
         <table>
           <tr>
         <th align=right nowrap><label for="vendor">| . $locale->text('Vendor') . qq|</label></th>
-        <td colspan=3>$vendor</td>
+        <td colspan=3>$vendor
 
         <input type=hidden name=vendor_id value=$form->{vendor_id}>
         <input type=hidden name=oldvendor value="$form->{oldvendor}">
-
+</td>
           </tr>
           <tr>
             <td></td>
@@ -467,8 +467,8 @@ sub form_header {
           </tr>
           <tr>
         <th align=right nowrap><label for="ordnumber">| . $locale->text('Order Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" id=ordnumber name=ordnumber size=20 value="$form->{ordnumber}" $readonly></td>
-<input type=hidden name=quonumber value="$form->{quonumber}">
+        <td><input data-dojo-type="dijit/form/TextBox" id=ordnumber name=ordnumber size=20 value="$form->{ordnumber}" $readonly>
+<input type=hidden name=quonumber value="$form->{quonumber}"></td>
           </tr>
               <tr>
                 <th align=right nowrap><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -312,19 +312,19 @@ sub form_header {
     $exchangerate = qq|<tr>|;
     $exchangerate .= qq|
         <th align=right nowrap>| . $locale->text('Currency') . qq|</th>
-        <td><select data-dojo-type="dijit/form/Select" id="currency" name="currency" $readonly>$form->{selectcurrency}</select></td>
+        <td><select data-dojo-type="dijit/form/Select" id="currency" name="currency" $readonly>$form->{selectcurrency}</select>
 | if $form->{defaultcurrency};
 
     if (   $form->{defaultcurrency}
         && $form->{currency} ne $form->{defaultcurrency} )
     {
         $exchangerate .=
-                qq|<th align=right>|
+                qq|</td><th align=right>|
               . $locale->text('Exchange Rate')
-              . qq|</th><td><input data-dojo-type="dijit/form/TextBox" name="exchangerate" size="10" value="$form->{exchangerate}" $readonly></td>|;
+              . qq|</th><td><input data-dojo-type="dijit/form/TextBox" name="exchangerate" size="10" value="$form->{exchangerate}" $readonly>|;
     }
     $exchangerate .= qq|
-<input type=hidden name="forex" value="$form->{forex}">
+<input type=hidden name="forex" value="$form->{forex}"></td>
 </tr>
 |;
 
@@ -430,9 +430,10 @@ sub form_header {
         <table>
           <tr>
         <th align=right nowrap><label for="customer">| . $locale->text('Customer') . qq|</label></th>
-        <td colspan=3>$customer</td>
+        <td colspan=3>$customer
         <input type=hidden name="customer_id" value="$form->{customer_id}">
         <input type=hidden name="oldcustomer" value="$form->{oldcustomer}">
+</td>
           </tr>
           <tr>
         <td></td>
@@ -523,8 +524,8 @@ sub form_header {
           </tr>
           <tr>
         <th align=right nowrap><label for="ordnumber">| . $locale->text('Order Number') . qq|</label></th>
-        <td><input data-dojo-type="dijit/form/TextBox" name="ordnumber" id="ordnumber" size="20" value="$form->{ordnumber}" $readonly></td>
-<input type=hidden name="quonumber" value="$form->{quonumber}">
+        <td><input data-dojo-type="dijit/form/TextBox" name="ordnumber" id="ordnumber" size="20" value="$form->{ordnumber}" $readonly>
+<input type=hidden name="quonumber" value="$form->{quonumber}"></td>
           </tr>
           <tr class="crdate-row">
         <th align=right><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -351,8 +351,8 @@ sub form_header {
             $exchangerate .=
                 qq|<th align=right>|
               . $locale->text('Exchange Rate')
-              . qq|</th><td>$form->{exchangerate}</td>
-      <input type=hidden name=exchangerate value=$form->{exchangerate}>
+              . qq|</th><td>$form->{exchangerate}
+      <input type=hidden name=exchangerate value=$form->{exchangerate}></td>
 |;
         }
         else {
@@ -399,8 +399,8 @@ sub form_header {
           <tr class="ordnumber-row">
         <th width=70% align=right nowrap>| . $locale->text('Order Number') . qq|</th>
                 <td><input data-dojo-type="dijit/form/TextBox" id=ordnumber name=ordnumber size=20 value="$form->{ordnumber}">
-                     $sequences</td>
-        <input type=hidden name=quonumber value="$form->{quonumber}">
+                     $sequences
+        <input type=hidden name=quonumber value="$form->{quonumber}"></td>
           </tr>
           <tr class="transdate-row">
         <th align=right nowrap>| . $locale->text('Order Date') . qq|</th>
@@ -474,8 +474,8 @@ sub form_header {
               . $locale->text('Quotation Number')
               . qq|</th>
         <td><input data-dojo-type="dijit/form/TextBox" id=quonumber name=quonumber size=20 value="$form->{quonumber}">
-                    $sequences</td>
-        <input type=hidden name=ordnumber value="$form->{ordnumber}">
+                    $sequences
+        <input type=hidden name=ordnumber value="$form->{ordnumber}"></td>
           </tr>
 |;
         }
@@ -484,8 +484,8 @@ sub form_header {
           <tr class="rfqnumber-row">
         <th width=70% align=right nowrap>| . $locale->text('RFQ Number') . qq|</th>
         <td><input data-dojo-type="dijit/form/TextBox" id=quonumber name=quonumber size=20 value="$form->{quonumber}">
-                    $sequences</td>
-        <input type=hidden name=ordnumber value="$form->{ordnumber}">
+                    $sequences
+        <input type=hidden name=ordnumber value="$form->{ordnumber}"></td>
           </tr>
 |;
 
@@ -594,9 +594,9 @@ sub form_header {
         <table width=100%>
           <tr>
         <th align=right>$vclabel</th>
-        <td colspan=3>$vc</td>
+        <td colspan=3>$vc
         <input type=hidden name=$form->{vc}_id value=$form->{"$form->{vc}_id"}>
-        <input type=hidden name="old$form->{vc}" value="$form->{"old$form->{vc}"}">
+        <input type=hidden name="old$form->{vc}" value="$form->{"old$form->{vc}"}"></td>
           </tr>
           $creditremaining
           $business
@@ -856,10 +856,10 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
       </td>
     </tr>
       </table>
-    </td>
-  </tr>
 <input type=hidden name=oldinvtotal value=$form->{oldinvtotal}>
 <input type=hidden name=oldtotalpaid value=$totalpaid>
+    </td>
+  </tr>
   <tr>
     <td>
       <table width=100%>
@@ -1888,9 +1888,9 @@ sub display_ship_receive {
         <table width=100%>
           <tr>
         <th align=right>$vclabel</th>
-        <td colspan=3>$form->{$form->{vc}}</td>
+        <td colspan=3>$form->{$form->{vc}}
         <input type=hidden name=$form->{vc} value="$form->{$form->{vc}}">
-        <input type=hidden name="$form->{vc}_id" value=$form->{"$form->{vc}_id"}>
+        <input type=hidden name="$form->{vc}_id" value=$form->{"$form->{vc}_id"}></td>
           </tr>
           $department
           <tr>
@@ -1911,19 +1911,19 @@ sub display_ship_receive {
           $employee
           <tr>
         <th align=right nowrap>| . $locale->text('Order Number') . qq|</th>
-        <td>$form->{ordnumber}</td>
-        <input type=hidden name=ordnumber value="$form->{ordnumber}">
+        <td>$form->{ordnumber}
+        <input type=hidden name=ordnumber value="$form->{ordnumber}"></td>
           </tr>
           <tr>
         <th align=right nowrap>| . $locale->text('Order Date') . qq|</th>
-        <td>$form->{transdate}</td>
-        <input type=hidden name=transdate value=$form->{transdate}>
+        <td>$form->{transdate}
+        <input type=hidden name=transdate value=$form->{transdate}></td>
           </tr>
           <tr>
         <th align=right nowrap>| . ($form->{type} =~ /purchase_/ ?
             $locale->text('SO Number') : $locale->text('PO Number')) . qq|</th>
-        <td>$form->{ponumber}</td>
-        <input type=hidden name=ponumber value="$form->{ponumber}">
+        <td>$form->{ponumber}
+        <input type=hidden name=ponumber value="$form->{ponumber}"></td>
           </tr>
           <tr>
         <th align=right nowrap>$shipped</th>


### PR DESCRIPTION
Tables allow content only between TH and TD tags. Make sure INPUT tags -- even if TYPE=HIDDEN -- are not between cells or rows.

This commit *could* speed up rendering on Blink (Chrome/Opera/Edge) as was shown to be the case with dynatable.html.
