### PR TITLE
Section break formatting improvements in B/S and P&L

### DIFF
--- a/UI/css/ledgersmb-common.css
+++ b/UI/css/ledgersmb-common.css
@@ -542,6 +542,39 @@ span.indicator {
     text-decoration: none;
 }
 
+
+.financial-statement .heading3.H {
+  padding-bottom: 1em;
+}
+
+.financial-statement .heading2.H {
+  padding-bottom: 1.5em;
+}
+
+.financial-statement .heading4.H {
+  padding-bottom: 0.75em;
+}
+
+.financial-statement .section1 {
+  font-size: 140%;
+}
+
+.financial-statement .section2 {
+  font-size: 120%;
+}
+
+.financial-statement .section3 {
+  font-size: 110%;
+}
+
+.financial-statement .H {
+  font-style: italic;
+}
+
+.financial-statement .section4 {
+  font-size: 105%;
+}
+
 #plDebug .plDebugPanelContent {
     left: 207px;
     right: 207px;

--- a/templates/demo/PNL.html
+++ b/templates/demo/PNL.html
@@ -234,6 +234,34 @@ h2 {
     color: black;
     text-decoration: none;
 }
+
+.heading3.H {
+  padding-bottom: 1em;
+}
+.heading2.H {
+  padding-bottom: 1.5em;
+}
+.heading4.H {
+  padding-bottom: 0.75em;
+}
+.section1 {
+  font-size: 140%;
+}
+.section2 {
+  font-size: 120%;
+}
+.section3 {
+  font-size: 110%;
+}
+.H {
+  font-style: italic;
+}
+.section4 {
+  font-size: 105%;
+}
+th {
+    font-weight: normal;
+}
   </style>
 </head><?lsmb
 account_data = report.account_data;
@@ -312,11 +340,11 @@ END ;
              <th class="indent">&nbsp;</th>
              <?lsmb- END -?>
            <?lsmb- END -?>
-          <th colspan="<?lsmb path_suffix_len ?>">
+          <th colspan="<?lsmb path_suffix_len ?>" <?lsmb class ?>>
           <?lsmb IF report.rheads.ids.$row.props.section_for ;
           head_id = report.rheads.ids.$row.props.section_for;
           report.rheads.ids.$head_id.props.account_description; ?></th>
-          <th colspan="<?lsmb report.cheads.ids.keys.size ?>">
+          <th colspan="<?lsmb report.cheads.ids.keys.size ?>" <?lsmb class ?>>
           <?lsmb ELSE -?><?lsmb IF report.rheads.ids.$row.props.account_number && report.incl_accnos; -?><?lsmb report.rheads.ids.$row.props.account_number ?>&nbsp;-&nbsp;<?lsmb END; -?>
           <?lsmb report.rheads.ids.$row.props.account_description ?></th><?lsmb FOREACH col IN report.sorted_col_ids -?>
           <td class="amount <?lsmb clazz ?>">

--- a/templates/demo/balance_sheet.html
+++ b/templates/demo/balance_sheet.html
@@ -234,6 +234,34 @@ h2 {
     color: black;
     text-decoration: none;
 }
+
+.heading3.H {
+  padding-bottom: 1em;
+}
+.heading2.H {
+  padding-bottom: 1.5em;
+}
+.heading4.H {
+  padding-bottom: 0.75em;
+}
+.section1 {
+  font-size: 140%;
+}
+.section2 {
+  font-size: 120%;
+}
+.section3 {
+  font-size: 110%;
+}
+.H {
+  font-style: italic;
+}
+.section4 {
+  font-size: 105%;
+}
+th {
+    font-weight: normal;
+}
   </style>
 </head><?lsmb
 
@@ -312,11 +340,11 @@ END ;
             <th class="indent">&nbsp;</th>
             <?lsmb- END -?>
           <?lsmb END ?>
-          <th colspan="<?lsmb path_suffix_len ?>">
+          <th colspan="<?lsmb path_suffix_len ?>" <?lsmb class ?>>
           <?lsmb IF report.rheads.ids.$row.props.section_for ;
           head_id = report.rheads.ids.$row.props.section_for;
           report.rheads.ids.$head_id.props.account_description; ?></th>
-          <th colspan="<?lsmb report.cheads.ids.keys.size ?>">
+          <th colspan="<?lsmb report.cheads.ids.keys.size ?>" <?lsmb class ?>>
           <?lsmb ELSE -?><?lsmb IF report.rheads.ids.$row.props.account_number && report.incl_accnos; -?><?lsmb report.rheads.ids.$row.props.account_number ?>&nbsp;-&nbsp;<?lsmb END; -?>
           <?lsmb report.rheads.ids.$row.props.account_description ?></th><?lsmb FOREACH col IN report.sorted_col_ids -?>
           <td class="amount <?lsmb clazz ?>">


### PR DESCRIPTION
By adding whitespace and formatting to section totals, section boundaries stand out more clearly.
