### PR TITLE
Fix rounding crash in reports

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -544,7 +544,17 @@ sub _render {
         }
     }
     my @col_ids = map { $_->{col_id} } @columns;
-    push @col_ids, 'row_id';
+
+    # values expected by dynatable:
+    push @col_ids, (
+        map {
+            ($_ . '_href_suffix',
+             $_ . '_NOHREF',
+             $_ . '_ROWSPAN',
+             $_ . '_ROWSPANNED')
+        } @col_ids);
+    push @col_ids, 'row_id', 'NOINPUT', 'html_class';
+
     my @rows = map { +{ $_->%{@col_ids} } } $self->rows->@*;
     $self->rows([]);
 

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -543,6 +543,10 @@ sub _render {
             }
         }
     }
+    my @col_ids = map { $_->{col_id} } @columns;
+    push @col_ids, 'row_id';
+    my @rows = map { +{ $_->%{@col_ids} } } $self->rows->@*;
+    $self->rows([]);
 
     # needed to get aroud escaping of header line names
     # i.e. ignore_yearends -> ignore\_yearends
@@ -557,6 +561,7 @@ sub _render {
     return $args{renderer}->(
         $template, $self,
         {
+            # 'rows' has been set to an empty array to prevent encoding the same data twice
             report          => $self,
             new_heads       => $replace_hnames,
             name            => $self->name,
@@ -565,7 +570,7 @@ sub _render {
             order_url       => $self->order_url,
             buttons         => $self->buttons,
             options         => $self->options,
-            rows            => $self->rows,
+            rows            => \@rows,
         });
 }
 


### PR DESCRIPTION
This fix solves the rounding crash, caused by "money" data in the row hashes that isn't formatted by the report, because the columns aren't included in the report.

Next to that, it eliminates double traversal of the row data while encoding the data for HTML: once via the 'report' variable and once via the 'rows' variable. The latter traversal meant full double encoding of the data (because the data is copied during traversal).

Reported by @aungzwin10 on the Matrix chat channel.
