### PR TITLE
Asset sale should take cash into account

### DIFF
--- a/UI/asset/begin_approval.html
+++ b/UI/asset/begin_approval.html
@@ -55,6 +55,16 @@
      label = text('Loss Account') #'
 } %]
 </div>
+<div class="inputgroup" id="cashgroup">
+[% PROCESS select element_data = {
+     name = "cash_acct"
+     class = "account"
+     options = asset_report.cash_accounts
+     value_attr = "id"
+     default_blank = 1
+     label = text('Cash Account') #'
+} %]
+</div>
 [% END %]
 </div>
 <div class="inputrow" id="buttonrow">

--- a/lib/LedgerSMB/Scripts/asset.pm
+++ b/lib/LedgerSMB/Scripts/asset.pm
@@ -445,7 +445,7 @@ sub report_results {
              $base_href .= '&depreciation=1';
     } else {
              $base_href .= "&gain_acct=$ar->{gain_acct}&loss_acct=".
-                            "$ar->{loss_acct}";
+                            "$ar->{loss_acct}&cash_acct=$ar->{cash_acct}";
     }
     $base_href .= '&id=';
     my $cols = [
@@ -497,6 +497,7 @@ sub report_results {
     my $hiddens = {
         gain_acct => $request->{gain_acct},
         loss_acct => $request->{loss_acct},
+        cash_acct => $request->{cash_acct},
     };
     my $count = 0;
     for my $r (@results){
@@ -758,6 +759,7 @@ sub partial_disposal_details {
             id        => $report->{id},
             gain_acct => $report->{gain_acct},
             loss_acct => $report->{loss_acct},
+            cash_acct => $report->{cash_acct},
         },
         FORM_ID => $request->{form_id},
         name    => $title,
@@ -865,6 +867,7 @@ sub disposal_details {
             id        => $report->{id},
             gain_acct => $report->{gain_acct},
             loss_acct => $report->{loss_acct},
+            cash_acct => $report->{cash_acct},
         },
         FORM_ID => $request->{form_id},
         name    => $title,
@@ -892,7 +895,7 @@ Approves disposal details.  id must be set,
 For disposal reports, gain_acct and loss_acct must be set to appropriate
 account id's.
 
-For depreciation reports, expense_acct must be set to an appropriate accont id.
+For depreciation reports, expense_acct must be set to an appropriate account id.
 
 =cut
 
@@ -907,7 +910,7 @@ sub report_details_approve {
 
 Loops through the input and approves all selected reports.
 
-For disposal reports, gain_acct and loss_acct must be set to appropriate
+For disposal reports, gain_acct, loss_acct and cash_acct must be set to appropriate
 account id's.
 
 For depreciation reports, expense_acct must be set to an appropriate accont id.

--- a/old/lib/LedgerSMB/DBObject/Asset_Report.pm
+++ b/old/lib/LedgerSMB/DBObject/Asset_Report.pm
@@ -236,7 +236,10 @@ sub get_metadata {
     @{$self->{loss_accounts}} = $self->call_dbmethod(
                    funcname => 'asset_report__get_loss_accts'
     );
-    for my $atype (qw(exp_accounts gain_accounts loss_accounts)){
+    @{$self->{cash_accounts}} = $self->call_dbmethod(
+                   funcname => 'asset_report__get_cash_accts'
+    );
+    for my $atype (qw(exp_accounts gain_accounts loss_accounts cash_accounts)){
         for my $acct (@{$self->{$atype}}){
             $acct->{text} = $acct->{accno}. '--'. $acct->{description};
         }

--- a/sql/modules/Assets.sql
+++ b/sql/modules/Assets.sql
@@ -1,6 +1,31 @@
 
 set client_min_messages = 'warning';
 
+/*
+
+
+  asset_report__generate_gl   - creates GL transaction upon approval of depreciation report
+  asset_report__disposal_gl   - creates GL transaction upon approval of a disposal (sale/abandonment)
+  asset_disposal__approve     - creates GL transaction upon approval of *partial* disposal (sale/abandonment)
+  asset__import_from_disposal - creates new assets from partially disposed assets, upon approval
+  asset_report__get_disposal  - returns a line per disposed asset in a disposal report with disposal details
+
+
+  call tree:
+
+    asset_report__approve
+      report_class of
+        '1': (depreciation)
+          asset_report__generate_gl
+        '2': (full disposal)
+          asset_report__disposal_gl
+            asset_report__get_disposal
+        '4': (partial disposal)
+          asset_disposal__approve
+            asset__import_from_disposal
+
+*/
+
 
 BEGIN;
 
@@ -743,8 +768,10 @@ $$ LANGUAGE SQL;
 COMMENT ON FUNCTION asset_report_partial_disposal_details(in_id int) IS
 $$ Returns the partial disposal details for a partial disposal report.$$;
 
+DROP FUNCTION IF EXISTS asset_report__approve(int, int, int, int);
+
 CREATE OR REPLACE FUNCTION asset_report__approve
-(in_id int, in_expense_acct int, in_gain_acct int, in_loss_acct int)
+(in_id int, in_expense_acct int, in_gain_acct int, in_loss_acct int, in_cash_acct int)
 RETURNS asset_report AS
 $$
 DECLARE ret_val asset_report;
@@ -759,7 +786,7 @@ BEGIN
                     PERFORM asset_report__generate_gl(in_id, in_expense_acct);
                 ELSIF ret_val.report_class = 2 THEN
                     PERFORM asset_report__disposal_gl(
-                                 in_id, in_gain_acct, in_loss_acct);
+                                 in_id, in_gain_acct, in_loss_acct, in_cash_acct);
                 ELSIF ret_val.report_class = 4 THEN
                     PERFORM asset_disposal__approve(in_id, in_gain_acct, in_loss_acct, (select asset_account_id from asset_class
                                                                                          where id = ret_val.asset_class)
@@ -771,25 +798,25 @@ BEGIN
         RETURN ret_val;
 end;
 $$ language plpgsql;
-revoke execute on function asset_report__approve(int, int, int, int) from public;
+revoke execute on function asset_report__approve(int, int, int, int, int) from public;
 
-COMMENT ON function asset_report__approve(int, int, int, int) is
+COMMENT ON function asset_report__approve(int, int, int, int, int) is
 $$ This function approves an asset report (whether depreciation or disposal).
 Also generates relevant GL drafts for review and posting.$$;
 
+DROP FUNCTION IF EXISTS asset_report__disposal_gl(int, int, int);
+
 CREATE OR REPLACE FUNCTION asset_report__disposal_gl
-(in_id int, in_gain_acct int, in_loss_acct int)
+(in_id int, in_gain_acct int, in_loss_acct int, in_cash_acct int)
 RETURNS bool AS
 $$
   INSERT INTO gl (reference, description, transdate, approved, trans_type_code)
   SELECT setting_increment('glnumber'), 'Asset Report ' || asset_report.id,
                 report_date, false, 'fd'
     FROM asset_report
-    JOIN asset_report_line ON (asset_report.id = asset_report_line.report_id)
-    JOIN asset_item        ON (asset_report_line.asset_id = asset_item.id)
-   WHERE asset_report.id = in_id
-GROUP BY asset_report.id, asset_report.report_date;
+  WHERE asset_report.id = in_id;
 
+  -- Clear cumulative depreciation account
   INSERT
     INTO acc_trans (chart_id, trans_id, amount_bc, curr, amount_tc,
                     approved, transdate)
@@ -798,7 +825,20 @@ GROUP BY asset_report.id, asset_report.report_date;
          TRUE, r.disposed_on
     FROM asset_report__get_disposal(in_id) r
     JOIN asset_item a ON (r.id = a.id)
-GROUP BY a.dep_account_id, r.disposed_on;
+   GROUP BY a.dep_account_id, r.disposed_on
+  HAVING sum(r.accum_depreciation) <> 0;
+
+  -- Add cash from sale(=disposal)
+  INSERT
+    INTO acc_trans (chart_id, trans_id, amount_bc, curr, amount_tc,
+                    approved, transdate)
+  SELECT in_cash_acct, currval('id')::int, sum(r.disposal_amt) * -1,
+         defaults_get_defaultcurrency(), sum(r.disposal_amt) * -1,
+         TRUE, r.disposed_on
+    FROM asset_report__get_disposal(in_id) r
+    JOIN asset_item ai ON (r.id = ai.id)
+   GROUP BY r.disposed_on
+  HAVING sum(r.disposal_amt) <> 0;
 
   -- GAIN is negative since it is a debit
   INSERT
@@ -810,8 +850,9 @@ GROUP BY a.dep_account_id, r.disposed_on;
          TRUE, r.disposed_on
     FROM asset_report__get_disposal(in_id) r
     JOIN asset_item ai ON (r.id = ai.id)
-GROUP BY r.disposed_on;
+   GROUP BY r.disposed_on;
 
+  -- Clear asset from asset account
   INSERT
     INTO acc_trans (chart_id, trans_id, amount_bc, curr, amount_tc,
                     approved, transdate)
@@ -820,14 +861,15 @@ GROUP BY r.disposed_on;
          TRUE, r.disposed_on
     FROM asset_report__get_disposal(in_id) r
     JOIN asset_item a ON (r.id = a.id)
-GROUP BY a.asset_account_id, r.disposed_on;
+   GROUP BY a.asset_account_id, r.disposed_on
+  HAVING sum(r.purchase_value) <> 0;
 
 
   SELECT TRUE;
 $$ language sql;
 
 COMMENT ON  FUNCTION asset_report__disposal_gl
-(in_id int, in_gain_acct int, in_loss_acct int) IS
+(in_id int, in_gain_acct int, in_loss_acct int, in_cash_acct int) IS
 $$ Generates GL transactions for ful disposal reports.$$;
 
 
@@ -865,6 +907,12 @@ CREATE OR REPLACE FUNCTION asset_report__get_loss_accts()
 RETURNS SETOF account
 AS $$
     SELECT * FROM account__get_by_link_desc('asset_loss');
+$$ language sql;
+
+CREATE OR REPLACE FUNCTION asset_report__get_cash_accts()
+RETURNS SETOF account
+AS $$
+  SELECT * FROM account;
 $$ language sql;
 
 COMMENT ON FUNCTION asset_report__get_loss_accts() IS
@@ -1114,7 +1162,7 @@ $$ language plpgsql;
 
 COMMENT ON FUNCTION asset_report__begin_disposal
 (in_asset_class int, in_report_date date, in_report_class int) IS
-$$ Creates the asset report recofd for the asset disposal report.$$;
+$$ Creates the asset report record for the asset disposal report.$$;
 
 create or replace function asset_report__record_approve(in_id int)
 returns asset_report

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -73,6 +73,7 @@ asset_report__dispose
 asset_report__generate
 asset_report__generate_gl
 asset_report__get
+asset_report__get_cash_accts
 asset_report__get_disposal
 asset_report__get_disposal_methods
 asset_report__get_expense_accts

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1291,7 +1291,7 @@ SELECT lsmb__grant_perms('assets_approve', obj, 'SELECT')
   FROM unnest(array['asset_report'::text, 'asset_report_line', 'asset_item',
                     'asset_class']) obj;
 
-SELECT lsmb__grant_exec('assets_approve', 'asset_report__approve(int, int, int, int)');
+SELECT lsmb__grant_exec('assets_approve', 'asset_report__approve(int, int, int, int, int)');
 SELECT lsmb__grant_menu('assets_approve', id, 'allow')
   FROM unnest(array[239,240]) id;
 

--- a/xt/42-assets.pg
+++ b/xt/42-assets.pg
@@ -5,7 +5,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(39);
+    SELECT plan(40);
 
     -- Add data
 
@@ -46,12 +46,13 @@ BEGIN;
     SELECT has_function('asset_report__get_disposal',array['integer']);
     SELECT has_function('asset_nbv_report','{}'::text[]);
     SELECT has_function('asset_report_partial_disposal_details',array['integer']);
-    SELECT has_function('asset_report__approve',array['integer', 'integer', 'integer', 'integer']);
-    SELECT has_function('asset_report__disposal_gl',array['integer', 'integer', 'integer']);
+    SELECT has_function('asset_report__approve',array['integer', 'integer', 'integer', 'integer', 'integer']);
+    SELECT has_function('asset_report__disposal_gl',array['integer', 'integer', 'integer', 'integer']);
     SELECT has_function('asset_item__add_note',array['integer', 'text', 'text']);
     SELECT has_function('asset_report__get_expense_accts','{}'::text[]);
     SELECT has_function('asset_report__get_gain_accts','{}'::text[]);
     SELECT has_function('asset_report__get_loss_accts','{}'::text[]);
+    SELECT has_function('asset_report__get_cash_accts','{}'::text[]);
     SELECT has_function('asset_report__get',array['integer']);
     SELECT has_function('asset_report__get_lines',array['integer']);
     SELECT has_function('asset_report__search',array['date', 'date', 'integer', 'boolean', 'integer']);
@@ -95,7 +96,7 @@ BEGIN;
     select asset_report__save(null, '2010-11-01'::date, :asset_report_type_depreciation,
                               (:'new_class'::asset_class).id, true) as new_report
     \gset
-    select asset_report__approve((:'new_report'::asset_report).id, :exp_acc_id, null, null) as approved_report
+    select asset_report__approve((:'new_report'::asset_report).id, :exp_acc_id, null, null, null) as approved_report
     \gset
 
 
@@ -107,7 +108,7 @@ BEGIN;
     select asset_report__dispose((:'disposal_report'::asset_report).id, (:'new_asset'::asset_item).id,
                                  0.00, (select id from asset_disposal_method where short_label = 'A'), 50);
     select asset_report__approve((:'disposal_report'::asset_report).id, :exp_acc_id,
-                                 :gain_acc_id, :loss_acc_id) as approved_report
+                                 :gain_acc_id, :loss_acc_id, null) as approved_report
     \gset
 
 
@@ -119,7 +120,7 @@ BEGIN;
     select asset_report__dispose((:'full_disposal_report'::asset_report).id, (:'new_asset'::asset_item).id,
                                  0.00, (select id from asset_disposal_method where short_label = 'A'), 100);
     select asset_report__approve((:'disposal_report'::asset_report).id, :exp_acc_id,
-                                 :gain_acc_id, :loss_acc_id) as approved_report
+                                 :gain_acc_id, :loss_acc_id, null) as approved_report
     \gset
 
 


### PR DESCRIPTION
This commit adds a Cash Account to asset disposal reports in order to account for the cash component of the sale. Please do note that if an invoice was created for the sale, there's some additional accounting to be done to move the income out of the PNL, into the "cash" account.

There's a bigger plan for rewriting fixed assets support. This commit is part of the "old world", not the start of development of the new, shiny and highly desired code base.

Fixes #5180.
