### PR TITLE
Populate reconciliation after upload processing

### DIFF
--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -235,8 +235,8 @@ sub _display_report {
     $recon->{decimal_places} = $request->setting->get('decimal_places');
     _set_sort_options($recon, $request);
 
-    $recon->get;
     _process_upload($recon, $request) unless $recon->{submitted};
+    $recon->get;
     $recon->build_totals;
 
     if ($recon->{account_info}->{category} eq 'A') {


### PR DESCRIPTION
By populating the reconciliation from the database after processing the uploaded data, the uploaded data is taken into account on the resulting page. Without this change, the uploaded data isn't presented; even worse: if the user decides to save the reconciliation report, the uploaded data gets completely discarded.

Fixes #6183.
