### PR TITLE
Fix Contact > Addresses mismatch

### DIFF
--- a/UI/Contact/divs/address.html
+++ b/UI/Contact/divs/address.html
@@ -91,9 +91,9 @@
                 value= DISPLAY.id
         };
 %]
-<div class="two-column-grid" style="width:fit-content">
-  [% IF credit_act.id;
-                    IF DISPLAY.is_for_credit;
+  [% IF credit_act.id; %]
+        <div class="two-column-grid" style="width:fit-content">
+                    [% IF DISPLAY.is_for_credit;
                        attach_to = 3;
                     ELSE;
                        attach_to = 1;
@@ -104,10 +104,12 @@
                           default_values  = [attach_to]
                           options         = attach_level_options
                           label = text('Attach To') #'
-                       };
-                     ELSE %]
-  <label>[% text('Attach to Entity'); %]</label>
+                       }; %]
+        </div>
+                    [% ELSE %]
+        <label>[% text('Attach to Entity'); %]</label>
                    [% END; %]
+        <div class="two-column-grid" style="width:fit-content">
                 [% INCLUDE select element_data = {
                        name           = "location_class"
                        default_values = [DISPLAY.location_class]
@@ -115,30 +117,31 @@
                        text_attr      = "class"
                        value_attr     = "id"
                        label = text('Type')
-  } %]
-  <label style="grid-row: span 3">[% text('Address') %]</label>
+                } %]
+        </div>
+        <div class="four-column-grid" style="width:fit-content">
                 [% INCLUDE input element_data = {
                         name = "line_one"
-                        title = text('Address'),
+                        label = text('Address'),
                         value = DISPLAY.line_one,
                         type = "text",
                         size = "20",
-  required = 'true',
+                        required = 'true',
                 } %]
                 [% PROCESS input element_data = {
                         name = "line_two"
-                        class = "addl-address"
                         value = DISPLAY.line_two
                         type = "text"
                         size = "20"
                 } %]
                 [% PROCESS input element_data = {
                         name = "line_three"
-                        class = "addl-address"
                         value = DISPLAY.line_three
                         type = "text"
                         size = "20"
                 } %]
+        </div>
+        <div class="two-column-grid" style="width:fit-content">
                 [% PROCESS input element_data = {
                         label = text('City'),
                         name = "city",
@@ -172,7 +175,7 @@
                         label = text('Country')
                         required = 'true'
                 } %]
-</div>
+        </div>
         <div>
              [%
               IF request.location_class;

--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -700,6 +700,13 @@ h2 {
     grid-template: none / repeat(6, auto);
 }
 
+.two-column-grid,
+.four-column-grid,
+.six-column-grid {
+    gap: 4px;
+    margin: 4px 0;
+}
+
 .two-column-grid lsmb-text,
 .two-column-grid lsmb-password,
 .two-column-grid lsmb-date,

--- a/UI/src/components/ImportCSV-Base.vue
+++ b/UI/src/components/ImportCSV-Base.vue
@@ -9,7 +9,7 @@
             <div v-if="multi"
                  class="listheading">Batch Information</div>
             <div :class="transaction_fields ? 'two-column-grid' : 'non-grid'"
-                 style="width:fit-content;grid-gap:4px">
+                 style="width:fit-content">
                 <template v-if="transaction_fields">
                     <lsmb-text class="reference"
                                name="reference"


### PR DESCRIPTION
- Fix Contact > Addresses doesn't render correctly after moving from TableContainer to Grid system
- Add gap and margin to the grid system to render more elegantly
- Remove inline grid-gap style from importCSV-Base for two reasons:
  1. gap property is defined in CSS, no inline style need
  2. grid-gap is obsolete and replaced by 'gap' property