### PR TITLE
Add a payments subtotal and remaining balance on invoices

### DIFF
--- a/locale/LedgerSMB.pot
+++ b/locale/LedgerSMB.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.11.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -177,7 +177,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -185,9 +185,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -195,7 +195,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -306,7 +306,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -451,11 +451,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -475,11 +475,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -517,7 +517,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr ""
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -529,15 +529,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -565,8 +565,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -598,7 +598,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -675,9 +675,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -780,8 +780,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -819,20 +819,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr ""
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -905,16 +905,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -945,31 +945,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1118,8 +1118,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1131,7 +1131,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1198,14 +1198,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1376,19 +1376,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1397,15 +1397,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1425,7 +1425,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1486,7 +1487,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1602,7 +1603,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1635,7 +1636,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1687,7 +1688,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1695,7 +1696,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1738,8 +1739,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1750,7 +1751,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1799,7 +1800,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1811,19 +1812,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1843,8 +1844,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1908,7 +1909,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1929,7 +1930,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1953,7 +1954,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1962,7 +1963,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -1999,7 +2000,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2029,7 +2030,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2042,7 +2043,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2058,7 +2059,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2082,7 +2083,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2131,7 +2132,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2146,11 +2147,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2188,7 +2189,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2212,7 +2213,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2258,7 +2259,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2371,9 +2372,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2423,16 +2424,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2440,11 +2441,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2466,7 +2467,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2518,13 +2519,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2541,7 +2542,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2612,16 +2613,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2629,7 +2630,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2637,7 +2638,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2653,7 +2654,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2673,7 +2674,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2715,14 +2716,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2734,8 +2735,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3037,11 +3038,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3057,7 +3058,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3079,7 +3080,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3103,7 +3104,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3111,20 +3112,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3132,7 +3133,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3177,8 +3178,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3256,7 +3257,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3270,17 +3271,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3317,7 +3318,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3377,7 +3378,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3409,7 +3410,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3458,7 +3459,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3466,7 +3467,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3495,11 +3496,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3544,8 +3545,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3787,8 +3788,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3846,11 +3847,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3858,8 +3859,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3877,22 +3878,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3908,8 +3909,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3918,7 +3919,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3976,7 +3977,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4004,7 +4005,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4045,7 +4046,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4109,7 +4110,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4330,11 +4331,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4411,7 +4412,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4442,9 +4443,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4791,15 +4792,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4813,15 +4814,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4846,7 +4847,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4865,7 +4866,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4903,7 +4904,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4918,7 +4919,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4973,7 +4974,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -4991,12 +4992,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5008,8 +5009,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5017,15 +5018,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5112,8 +5113,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5129,7 +5130,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5137,11 +5138,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5165,7 +5166,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5185,8 +5186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5207,7 +5208,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5237,7 +5238,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5306,7 +5307,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5318,7 +5319,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5327,7 +5328,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5335,11 +5336,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5374,7 +5375,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5505,8 +5506,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5523,7 +5524,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5618,9 +5619,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5629,11 +5630,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5685,15 +5686,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5715,7 +5716,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5758,8 +5759,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5798,7 +5799,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5828,8 +5829,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5845,7 +5846,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5853,11 +5854,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5872,7 +5873,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5898,7 +5899,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5939,7 +5940,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5968,7 +5969,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -5996,7 +5997,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6022,11 +6023,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6063,8 +6064,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6093,7 +6098,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6141,11 +6146,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6266,11 +6271,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6299,7 +6304,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6308,8 +6313,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6374,7 +6379,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6419,7 +6424,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6427,7 +6432,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6444,7 +6449,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6453,7 +6458,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6491,7 +6496,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6504,12 +6509,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6650,11 +6655,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6674,12 +6679,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6770,7 +6775,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6788,11 +6793,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6836,13 +6841,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6872,12 +6877,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6894,23 +6899,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6986,12 +6991,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7072,11 +7077,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7160,7 +7165,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7223,8 +7228,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7246,7 +7251,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7256,7 +7261,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7280,7 +7285,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7288,7 +7293,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7387,7 +7392,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7607,7 +7612,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7642,7 +7647,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7688,7 +7693,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7709,7 +7714,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7721,6 +7726,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7729,7 +7738,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7762,20 +7771,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7862,7 +7871,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7923,7 +7932,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7939,7 +7948,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7957,7 +7966,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8009,20 +8018,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8084,7 +8093,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8170,8 +8179,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8190,7 +8199,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8206,7 +8215,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8229,7 +8238,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8266,7 +8275,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8343,7 +8352,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8417,7 +8426,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8436,11 +8445,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8507,7 +8516,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8551,7 +8560,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/ar_EG.po
+++ b/locale/po/ar_EG.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Arabic (Egypt) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/ar_EG/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "الوصول ممنوع"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "اضافة موظف"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -459,11 +459,11 @@ msgstr "اضافة جزء"
 msgid "Add Pricegroup"
 msgstr "إضافة مجموعة سعرية"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "اضافة طلب شراء"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "اضافة عرض سعر "
 
@@ -471,7 +471,7 @@ msgstr "اضافة عرض سعر "
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "اضافة عرض سعر مورد"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "اضافة كود صناعى قياسى"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "اضافة فاتورة بيع"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "اضافة طلب بيع"
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr "إضافة بطاقة زمنية"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "إضافة إلى القائمة"
 
@@ -525,7 +525,7 @@ msgstr "اضافة مستخدم"
 msgid "Add Vendor"
 msgstr "اضافة مورد"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "اضافة فاتورة المورد"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "اضافة مخزن"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr "حالة القبول"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "موافقة"
@@ -827,20 +827,20 @@ msgstr "ابريل"
 msgid "April"
 msgstr "ابريل"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "هل انت متأكد انك تريد الغاء رقم الطلب"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -913,16 +913,16 @@ msgstr ""
 msgid "Assets"
 msgstr "الأصول"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "إرفاق"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr "تم الإرفاق بواسطة"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "تم الإرفاق إلى"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "تم الإرفاق بواسطة"
@@ -1010,7 +1010,7 @@ msgstr "اغسطس"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "أوتوماتيكي"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "رصيد"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "الميزانية"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr "مليار"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "احتساب الضرائب"
 
@@ -1321,12 +1321,12 @@ msgstr "احتساب الضرائب"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "لا يمكن الغاء الوحدة"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "لا يمكن الغاء الطلب"
 
@@ -1384,19 +1384,19 @@ msgstr "لا يمكن الغاء الطلب"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "لا يمكن تسجيل المدفوعات لفترة مغلقة"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "لا يمكن تسجيل الحركة لفترة مغلقة"
 
@@ -1405,15 +1405,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "لا يمكن تسجيل الحركة"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "لا يمكن تخزين الطلب"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1433,7 +1433,8 @@ msgstr "معرّف البطاقة"
 msgid "Cash"
 msgstr "النقدية"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1494,7 +1495,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1610,7 +1611,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "شركة"
 
@@ -1643,7 +1644,7 @@ msgstr "تلفون الشركة"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1695,7 +1696,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr "تأكيد العملية"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "تاكيد"
 
@@ -1703,7 +1704,7 @@ msgstr "تاكيد"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "تعارض مع بيانات موجودة، ربما أدخلت هذا من قبل؟"
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1746,8 +1747,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1758,7 +1759,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1807,7 +1808,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "تكلفة"
 
@@ -1819,19 +1820,19 @@ msgstr "تكلفة البضائع المباعة"
 msgid "Could Not Load Template from DB"
 msgstr "لم نتمكن من تحميل القالب من قاعدة البيانات"
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "لم نتمكن من الحفظ!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1851,8 +1852,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1916,7 +1917,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "دائن"
 
@@ -1937,7 +1938,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1961,7 +1962,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "عملة"
 
@@ -1970,7 +1971,7 @@ msgstr "عملة"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2007,7 +2008,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2037,7 +2038,7 @@ msgstr "اسم العميل"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2050,7 +2051,7 @@ msgstr "رقم العميل"
 msgid "Customer Search"
 msgstr "البحث عن عميل"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "عميل غير موجود"
 
@@ -2066,7 +2067,7 @@ msgstr " عميل غير موجود في الملف"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2139,7 +2140,7 @@ msgstr "قاعدة البيانات غير موجودة"
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2154,11 +2155,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2196,7 +2197,7 @@ msgstr "تاريخ الدفع"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2220,7 +2221,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2266,7 +2267,7 @@ msgstr "أيام"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "مدين"
 
@@ -2379,9 +2380,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2431,16 +2432,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "تاريخ الوصول"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2448,11 +2449,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2474,7 +2475,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2526,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2549,7 +2550,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2620,16 +2621,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2637,7 +2638,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2645,7 +2646,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2661,7 +2662,7 @@ msgstr "نوع المستند"
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "نفذ"
 
@@ -2681,7 +2682,7 @@ msgstr ""
 msgid "Dr."
 msgstr "د."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2723,14 +2724,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "تاريخ الاستحقاق"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "تاريخ الاستحقاق غير موجود"
 
@@ -2742,8 +2743,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "بريد الكتروني"
 
@@ -3045,11 +3046,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3065,7 +3066,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3087,7 +3088,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3111,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3119,20 +3120,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "سعر  الصرف"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "سعر الصرف"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "سعر الصرف للمدفوعات غير موجود"
 
@@ -3140,7 +3141,7 @@ msgstr "سعر الصرف للمدفوعات غير موجود"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "سعر الصرف غير موجود"
 
@@ -3185,8 +3186,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3264,7 +3265,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3278,17 +3279,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3325,7 +3326,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3385,7 +3386,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3417,7 +3418,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3466,7 +3467,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3474,7 +3475,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3503,11 +3504,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3552,8 +3553,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "مجموعة"
 
@@ -3795,8 +3796,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "ملاحظات داخلية"
 
@@ -3854,11 +3855,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3866,8 +3867,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3885,22 +3886,22 @@ msgstr "فاتورة"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "تاريخ الفاتورة"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "تاريخ الفاتورة غير موجود"
 
@@ -3916,8 +3917,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3926,7 +3927,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "رقم الفاتورة"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "رقم الفاتورة غير موجود"
 
@@ -3984,7 +3985,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "الغيت الوحدة"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "الوحدة غير موجودة في الملف"
 
@@ -4012,7 +4013,7 @@ msgstr "يناير"
 msgid "January"
 msgstr "يناير"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4053,7 +4054,7 @@ msgstr "يونية"
 msgid "June"
 msgstr "يونية"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4117,7 +4118,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4338,11 +4339,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "دخول"
 
@@ -4419,7 +4420,7 @@ msgstr "مدير"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4450,9 +4451,9 @@ msgid "May"
 msgstr "مايو"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "ملاحظات"
@@ -4799,15 +4800,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4821,15 +4822,15 @@ msgstr "ملاحظات"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "لم يتم الاختيار"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4854,7 +4855,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4873,7 +4874,7 @@ msgstr "الرقم"
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4911,7 +4912,7 @@ msgstr "اكتوبر"
 msgid "October"
 msgstr "اكتوبر"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4926,7 +4927,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "بالمخزن"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4981,7 +4982,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "امر"
 
@@ -4999,12 +5000,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "تاريخ الامر"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "تاريخ الامر غير موجود"
 
@@ -5016,8 +5017,8 @@ msgstr "ادخال الامر"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5025,15 +5026,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "رقم الامر"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "رقم الامر غير موجود"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "الغي الامر"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5120,8 +5121,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5137,7 +5138,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5145,11 +5146,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "قائمة تعبئة"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "تاريخ بوليصة الشحن غير موجود"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "رقم بوليصة الشحن غير موجود"
 
@@ -5173,7 +5174,7 @@ msgstr "المدفوع"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "جزء"
 
@@ -5193,8 +5194,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5215,7 +5216,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5245,7 +5246,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "كلمة السر"
 
@@ -5314,7 +5315,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "تاريخ الدفع غير موجود"
 
@@ -5326,7 +5327,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5335,7 +5336,7 @@ msgstr ""
 msgid "Payments"
 msgstr "المدفوعات"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5343,11 +5344,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5382,7 +5383,7 @@ msgstr "تليفون"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5513,8 +5514,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "تسجيل"
@@ -5531,7 +5532,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "سجل كجديد"
 
@@ -5626,9 +5627,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "طباعة"
@@ -5637,11 +5638,11 @@ msgstr "طباعة"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5693,15 +5694,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5723,7 +5724,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5766,8 +5767,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5806,7 +5807,7 @@ msgstr "تم الشراء"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5836,8 +5837,8 @@ msgid "Quarter"
 msgstr "ربع"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5853,7 +5854,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "تاريخ عرض السعر"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "تاريخ عرض السعر غير موجود!"
 
@@ -5861,11 +5862,11 @@ msgstr "تاريخ عرض السعر غير موجود!"
 msgid "Quotation Number"
 msgstr "رقم عرض السعر"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "رقم عرض السعر غير موجود!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "تم حذف عرض السعر!"
 
@@ -5880,7 +5881,7 @@ msgstr "عروض اسعار"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5906,7 +5907,7 @@ msgstr "عروض اسعار موردين"
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5947,7 +5948,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5976,7 +5977,7 @@ msgstr "المقبوضات"
 msgid "Receive"
 msgstr "شحن وارد"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "استلام بضاعة"
 
@@ -6004,7 +6005,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "في السجل"
 
@@ -6030,11 +6031,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "مرجع"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6071,9 +6072,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "متبقى"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6101,7 +6106,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "اسم التقرير"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "نتائج التقرير"
 
@@ -6113,7 +6118,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "نوع التقرير"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,11 +6154,11 @@ msgstr "تقارير"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6274,11 +6279,11 @@ msgstr "الاكواد الصناعية القياسية"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6307,7 +6312,7 @@ msgstr "بيع"
 msgid "Sales"
 msgstr "مبيعات"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "فاتورة المبيعات"
@@ -6316,8 +6321,8 @@ msgstr "فاتورة المبيعات"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6382,7 +6387,7 @@ msgstr "السبت"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6427,7 +6432,7 @@ msgstr "حفظ مسودة"
 msgid "Save Groups"
 msgstr "حفظ المجموعات"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6435,7 +6440,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6452,7 +6457,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "خزن كجديد"
@@ -6461,7 +6466,7 @@ msgstr "خزن كجديد"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6499,7 +6504,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6512,12 +6517,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6658,11 +6663,11 @@ msgstr "اختر العميل"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "اختر المورد"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "اختر طابعة"
 
@@ -6682,12 +6687,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6778,7 +6783,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "رقم تسلسلي"
 
@@ -6796,11 +6801,11 @@ msgstr "رقم  مسلسل"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "خدمة"
 
@@ -6844,13 +6849,13 @@ msgstr "سبعة عشر"
 msgid "Seventy"
 msgstr "سبعون"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "شحن صادر"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "شحن بضاعة للخارج"
 
@@ -6880,12 +6885,12 @@ msgstr "شحن إلى:"
 msgid "Ship Via"
 msgstr "شحن بواسطة"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "شحن الى"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6902,23 +6907,23 @@ msgstr "شحن من خلال"
 msgid "Shipping"
 msgstr "شحن"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "تاريخ الشحن"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "تاريخ الشحن غير موجود!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6994,12 +6999,12 @@ msgstr "بعض"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7080,11 +7085,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "الولاية"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7168,7 +7173,7 @@ msgstr "تسليم"
 msgid "Submitted"
 msgstr "تم التسليم"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7231,8 +7236,8 @@ msgstr "الإجمالي"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7254,7 +7259,7 @@ msgstr "ضريبة"
 msgid "Tax Account"
 msgstr "حساب الضريبة"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "كود الضريبة"
 
@@ -7264,7 +7269,7 @@ msgstr "كود الضريبة"
 msgid "Tax Form"
 msgstr "ضريبة من"
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7288,7 +7293,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7296,7 +7301,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "الضريبة المضافة"
@@ -7395,7 +7400,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7615,7 +7620,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7650,7 +7655,7 @@ msgstr "حتى تاريخ"
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7696,7 +7701,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7717,7 +7722,7 @@ msgstr ""
 msgid "Total"
 msgstr "مجموع"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7729,6 +7734,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr "إجمالي المدفوعات"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7737,7 +7746,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "حركة"
 
@@ -7770,20 +7779,20 @@ msgstr "نوع الحركة"
 msgid "Transactions"
 msgstr "حركات"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "تحويل"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "تحويل من"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "تحويل إلى"
 
@@ -7870,7 +7879,7 @@ msgstr "اثنان"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7931,7 +7940,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7947,7 +7956,7 @@ msgstr "سعر الوحدة"
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7965,7 +7974,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8017,20 +8026,20 @@ msgstr "غير مستخدم"
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "تعديل"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "معدل"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8092,7 +8101,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8178,8 +8187,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8198,7 +8207,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "بيانات تاريخية عن مورد"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "فاتورة المورد "
@@ -8214,7 +8223,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8237,7 +8246,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr "البحث عن مورد"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "مورد غير موجود"
 
@@ -8274,7 +8283,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8351,7 +8360,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "ما نوع هذة الوحدة؟"
 
@@ -8367,7 +8376,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8425,7 +8434,7 @@ msgstr ""
 msgid "Years"
 msgstr "سنوات"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "نعم"
@@ -8444,11 +8453,11 @@ msgstr ""
 msgid "Zero"
 msgstr "صفر"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8515,7 +8524,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "مدينة"
 
@@ -8559,7 +8568,7 @@ msgstr "نفذ"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "قطعة"
 

--- a/locale/po/bg.po
+++ b/locale/po/bg.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Bulgarian (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/bg/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr "Натрупване"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Добави сътрудник"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Добави валутен курс"
 
@@ -458,11 +458,11 @@ msgstr "Добави позиция"
 msgid "Add Pricegroup"
 msgstr "Добави ценова група"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Добави платежно нареждане"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Добави заявка"
 
@@ -470,7 +470,7 @@ msgstr "Добави заявка"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Добави запитване за заявка"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Добави SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Добави фактура продажби"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Добави поръчка продажби"
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Добави потребител"
 msgid "Add Vendor"
 msgstr "Добави доставчик"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Добави фактура за доставка"
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Добави склад"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "Апр"
 msgid "April"
 msgstr "Април"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Сигурен ли сте, че ще изтриете номера на поръчката"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Сигурен ли сте, че ще изтриете номера на заданието"
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "Август"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "Баланс"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Баланс"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Пакет"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Не е възможно изтриване на стоката!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Не е възможно изтриване на поръчка!"
 
@@ -1383,19 +1383,19 @@ msgstr "Не е възможно изтриване на поръчка!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Не е възможно изтриване на задание!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Не е възможно запазване на фактура в приключен период!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Не мога да извърша плащане за закрит период!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Не мога да извърша превод за закрит период!"
 
@@ -1406,15 +1406,15 @@ msgstr ""
 "Не е възможно запазването на превода едновременно в дебита и кредита на "
 "сметката!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Не мога да извърша плащане!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Не е възможно запазване на поръчката!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Не в възможно запазване на заданието!"
 
@@ -1434,7 +1434,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Каса"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1495,7 +1496,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1611,7 +1612,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Фирма"
 
@@ -1644,7 +1645,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1696,7 +1697,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Съгласие!"
 
@@ -1704,7 +1705,7 @@ msgstr "Съгласие!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1747,8 +1748,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1759,7 +1760,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1808,7 +1809,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Цена"
 
@@ -1820,19 +1821,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Невъзможно е да се запази!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Невъзможно е да се премести инвентара!"
 
@@ -1852,8 +1853,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1917,7 +1918,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Кредит"
 
@@ -1938,7 +1939,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Кредитно известие към фактура"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1962,7 +1963,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Валута"
 
@@ -1971,7 +1972,7 @@ msgstr "Валута"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2008,7 +2009,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2038,7 +2039,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2051,7 +2052,7 @@ msgstr "Клиент номер"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Пропуснат клиент!"
 
@@ -2067,7 +2068,7 @@ msgstr "Липсва клиента в базите!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2140,7 +2141,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2155,11 +2156,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2197,7 +2198,7 @@ msgstr "Падеж"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Дата за получаване"
 
@@ -2221,7 +2222,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Липсва дата на получаване!"
 
@@ -2267,7 +2268,7 @@ msgstr "Дни"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Дебит"
 
@@ -2380,9 +2381,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2432,16 +2433,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Дата на доставка"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2449,11 +2450,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2475,7 +2476,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2527,13 +2528,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2550,7 +2551,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2621,16 +2622,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2638,7 +2639,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2646,7 +2647,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2662,7 +2663,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Готов"
 
@@ -2682,7 +2683,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2724,14 +2725,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Платете до"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Пропусната дата за плащане"
 
@@ -2743,8 +2744,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Ел.адрес"
 
@@ -3046,11 +3047,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3088,7 +3089,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3112,7 +3113,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3120,20 +3121,20 @@ msgstr ""
 msgid "Every"
 msgstr "Винаги"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Курс"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Валутен курс"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Валутен курс за пропуснато плащане"
 
@@ -3141,7 +3142,7 @@ msgstr "Валутен курс за пропуснато плащане"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Пропуснат валутен курс"
 
@@ -3186,8 +3187,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3265,7 +3266,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3279,17 +3280,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3326,7 +3327,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3386,7 +3387,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3418,7 +3419,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "От склад"
 
@@ -3467,7 +3468,7 @@ msgstr "Номер на главната книга"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3475,7 +3476,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3504,11 +3505,11 @@ msgstr "Създай"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Създай поръчка"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Създай поръчка за доставка"
 
@@ -3553,8 +3554,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Група"
 
@@ -3796,8 +3797,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Вътрешни бележки"
 
@@ -3856,11 +3857,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Ивентара е запазен!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Инвентара е преместен!"
 
@@ -3868,8 +3869,8 @@ msgstr "Инвентара е преместен!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3887,22 +3888,22 @@ msgstr "Фактура"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Фактура дата"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Попусната дата на фактурата"
 
@@ -3918,8 +3919,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3928,7 +3929,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Фактура номер"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Липсва номер на фактура!"
 
@@ -3986,7 +3987,7 @@ msgstr "Стока"
 msgid "Item deleted!"
 msgstr "Стоката е изтрита!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Стоката липсва в базата!"
 
@@ -4014,7 +4015,7 @@ msgstr "Яну"
 msgid "January"
 msgstr "Януари"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4055,7 +4056,7 @@ msgstr "Юни"
 msgid "June"
 msgstr "Юни"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4119,7 +4120,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Тежест"
 
@@ -4340,11 +4341,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Влизане"
 
@@ -4421,7 +4422,7 @@ msgstr "Ръководител"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4452,9 +4453,9 @@ msgid "May"
 msgstr "Май"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Бележка"
@@ -4801,15 +4802,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4823,15 +4824,15 @@ msgstr "Забележка"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Нищо не е въведено!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Не сте избрали нищо!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Нищо не е преведено!"
 
@@ -4856,7 +4857,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4875,7 +4876,7 @@ msgstr "Номер"
 msgid "Number Format"
 msgstr "Формат-число"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4913,7 +4914,7 @@ msgstr "Окт"
 msgid "October"
 msgstr "Октомври"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4928,7 +4929,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "На ръка"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4983,7 +4984,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Поръчка"
 
@@ -5001,12 +5002,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Дата на поръчка"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Липсва дата на поръчката!"
 
@@ -5018,8 +5019,8 @@ msgstr "Поръчки"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5027,15 +5028,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Поръчка номер"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Липсва номер на поръчката!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Поръчката е изтрита!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Създаването на поръчка е провалено!"
 
@@ -5122,8 +5123,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5139,7 +5140,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5147,11 +5148,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Опъковачен лист"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Липсва дата на опаковъчния лист!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Липсва номер на опаковъчния лист!"
 
@@ -5175,7 +5176,7 @@ msgstr "Платено"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Позиция"
 
@@ -5195,8 +5196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5217,7 +5218,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5247,7 +5248,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Парола"
 
@@ -5316,7 +5317,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Пропусната дата на плащане!"
 
@@ -5328,7 +5329,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5337,7 +5338,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Плащания"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5345,11 +5346,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5384,7 +5385,7 @@ msgstr "Телефон"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5515,8 +5516,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Запази"
@@ -5533,7 +5534,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Запази като нов"
 
@@ -5628,9 +5629,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Печат"
@@ -5639,11 +5640,11 @@ msgstr "Печат"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Разпечатай и запази"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Разпечатай и запази като нов"
 
@@ -5695,15 +5696,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5726,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5768,8 +5769,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5808,7 +5809,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5838,8 +5839,8 @@ msgid "Quarter"
 msgstr "Четиримесечие"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5855,7 +5856,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Дата на заданието"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Липсва дата на заданието!"
 
@@ -5863,11 +5864,11 @@ msgstr "Липсва дата на заданието!"
 msgid "Quotation Number"
 msgstr "Номер на задание"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Липсва номер на заданието!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Заданието е изтрито!"
 
@@ -5882,7 +5883,7 @@ msgstr "Запазени форми"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5908,7 +5909,7 @@ msgstr "Резервации"
 msgid "ROP"
 msgstr "ROP"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5949,7 +5950,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Запис"
 
@@ -5978,7 +5979,7 @@ msgstr "Подлежащи на получване"
 msgid "Receive"
 msgstr "Получи"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Получаване на стока"
 
@@ -6006,7 +6007,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Запази в"
 
@@ -6032,11 +6033,11 @@ msgstr "Повтарящи се преводи"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Референция"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6073,9 +6074,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Напомняне"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6103,7 +6108,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6115,7 +6120,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6151,11 +6156,11 @@ msgstr "Справки"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Req"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6276,11 +6281,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6309,7 +6314,7 @@ msgstr "Продажби"
 msgid "Sales"
 msgstr "Продажби"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Фактура продажба"
@@ -6318,8 +6323,8 @@ msgstr "Фактура продажба"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Фактура продажби/Номер на превод от клиент"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6384,7 +6389,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6429,7 +6434,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6437,7 +6442,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6454,7 +6459,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Запази като нов"
@@ -6463,7 +6468,7 @@ msgstr "Запази като нов"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6501,7 +6506,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6514,12 +6519,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Разписание"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Зададено разписание"
 
@@ -6660,11 +6665,11 @@ msgstr "Избери клиент"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Избери доставчик"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Избери принтер!"
 
@@ -6684,12 +6689,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Избери postscript или PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Избери txt, postscrip или PDF!"
 
@@ -6780,7 +6785,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Сериен номер"
 
@@ -6798,11 +6803,11 @@ msgstr "Сериен номер"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Услуга"
 
@@ -6846,13 +6851,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Доставка"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Доставка на стока"
 
@@ -6882,12 +6887,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Доставка до"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6904,23 +6909,23 @@ msgstr "Доставка със"
 msgid "Shipping"
 msgstr "Доставки"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Дата на доставка"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Липсва дата на доставка!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6996,12 +7001,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7082,11 +7087,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Окръг"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7170,7 +7175,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7233,8 +7238,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7256,7 +7261,7 @@ msgstr "Данък"
 msgid "Tax Account"
 msgstr "Сметка за данъци"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7266,7 +7271,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7290,7 +7295,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7298,7 +7303,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Включен данък"
@@ -7397,7 +7402,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7617,7 +7622,7 @@ msgstr "Пъти"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7652,7 +7657,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "За склад"
 
@@ -7698,7 +7703,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7719,7 +7724,7 @@ msgstr ""
 msgid "Total"
 msgstr "Всичко"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,6 +7736,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Стока с проследяване"
@@ -7739,7 +7748,7 @@ msgstr "Стока с проследяване"
 msgid "Trade Discount"
 msgstr "Търговска остъпка"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Превод"
 
@@ -7772,20 +7781,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Преводи"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Прехвърляне"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Прехвърляне на инвентар"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Преместване от"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Преместване в"
 
@@ -7872,7 +7881,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7933,7 +7942,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7949,7 +7958,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7967,7 +7976,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8019,20 +8028,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Обнови"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Обновен"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8094,7 +8103,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8180,8 +8189,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8200,7 +8209,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "История на доставчика"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Фактура за доставка"
@@ -8216,7 +8225,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8239,7 +8248,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Липсва доставчик"
 
@@ -8276,7 +8285,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8353,7 +8362,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Какъв тип е тази номенклатура на стоките?"
 
@@ -8369,7 +8378,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8427,7 +8436,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Да"
@@ -8446,11 +8455,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8517,7 +8526,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8561,7 +8570,7 @@ msgstr "Готов"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "бр."
 

--- a/locale/po/ca.po
+++ b/locale/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Catalan (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "ca/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -458,11 +458,11 @@ msgstr "Afegir Article"
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Afegir Ordre Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Afegir Pressupost"
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Afegir Usuari"
 msgid "Add Vendor"
 msgstr "Afegir Proveïdor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Segur que voleu esborrar l'Ordre"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "Agost"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Fulla de Balanç"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Bin"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1383,19 +1383,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "No es pot registrar una transacció per un període tancat"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Empresa"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar!"
 
@@ -1702,7 +1703,7 @@ msgstr "Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crèdit"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "Data Pagament"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Dèbit"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Data Venciment"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta la Data Venciment!"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Email"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Canvi"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Taxa de Canvi"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3854,11 +3855,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3866,8 +3867,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3885,22 +3886,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Data Fra."
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Falta Data Fra.!"
 
@@ -3916,8 +3917,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3926,7 +3927,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Núm Fra."
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Falta Núm Fra.!"
 
@@ -3984,7 +3985,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "No es troba cap arxiu amb aquest element!"
 
@@ -4012,7 +4013,7 @@ msgstr "Gen"
 msgid "January"
 msgstr "Gener"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4053,7 +4054,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Juny"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4117,7 +4118,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4338,11 +4339,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrar"
 
@@ -4419,7 +4420,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4450,9 +4451,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4799,15 +4800,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4821,15 +4822,15 @@ msgstr "Notes"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4854,7 +4855,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4873,7 +4874,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Format Número"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4911,7 +4912,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4926,7 +4927,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4981,7 +4982,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Ordre"
 
@@ -4999,12 +5000,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data Ordre"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Falta Data Ordre!"
 
@@ -5016,8 +5017,8 @@ msgstr "Pressupostos i Comandes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5025,15 +5026,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número Ordre"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Falta Número Ordre!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5120,8 +5121,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5137,7 +5138,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5145,11 +5146,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Albarà"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Falta Data Albarà!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Falta Número Albarà!"
 
@@ -5173,7 +5174,7 @@ msgstr "Pagat"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Article"
 
@@ -5193,8 +5194,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5215,7 +5216,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5245,7 +5246,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contrasenya"
 
@@ -5314,7 +5315,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Falta Data Pagament!"
 
@@ -5326,7 +5327,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5335,7 +5336,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagaments"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5343,11 +5344,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5382,7 +5383,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5513,8 +5514,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5531,7 +5532,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5626,9 +5627,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5637,11 +5638,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5693,15 +5694,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5723,7 +5724,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5766,8 +5767,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5806,7 +5807,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5836,8 +5837,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5853,7 +5854,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5861,11 +5862,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5880,7 +5881,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5906,7 +5907,7 @@ msgstr ""
 msgid "ROP"
 msgstr "ROP"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5947,7 +5948,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5976,7 +5977,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6004,7 +6005,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registar en"
 
@@ -6030,11 +6031,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6071,9 +6072,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Remanent"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6101,7 +6106,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6113,7 +6118,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,11 +6154,11 @@ msgstr "Informes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6274,11 +6279,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6307,7 +6312,7 @@ msgstr ""
 msgid "Sales"
 msgstr "Vendes"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6316,8 +6321,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6382,7 +6387,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6427,7 +6432,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6435,7 +6440,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6452,7 +6457,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6461,7 +6466,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6499,7 +6504,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6512,12 +6517,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6658,11 +6663,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6682,12 +6687,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6778,7 +6783,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6796,11 +6801,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servei"
 
@@ -6844,13 +6849,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6880,12 +6885,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6902,23 +6907,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6994,12 +6999,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7080,11 +7085,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7168,7 +7173,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7231,8 +7236,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7254,7 +7259,7 @@ msgstr "Impost"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7264,7 +7269,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7288,7 +7293,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7296,7 +7301,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impostos Inclosos"
@@ -7395,7 +7400,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7615,7 +7620,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7650,7 +7655,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7696,7 +7701,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7717,7 +7722,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7729,6 +7734,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7737,7 +7746,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7770,20 +7779,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7870,7 +7879,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7931,7 +7940,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7947,7 +7956,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7965,7 +7974,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8017,20 +8026,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8092,7 +8101,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8178,8 +8187,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8198,7 +8207,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8214,7 +8223,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8237,7 +8246,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8274,7 +8283,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8351,7 +8360,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Quin tipus d'element és?"
 
@@ -8367,7 +8376,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8425,7 +8434,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sí"
@@ -8444,11 +8453,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8515,7 +8524,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8559,7 +8568,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "unit."
 

--- a/locale/po/cmn.po
+++ b/locale/po/cmn.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese (Mandarin) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/cmn/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "新增職員"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "新增外汇率"
 
@@ -458,11 +458,11 @@ msgstr "新增原料"
 msgid "Add Pricegroup"
 msgstr "新增价格组"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "新增采购单"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "新增报价单"
 
@@ -470,7 +470,7 @@ msgstr "新增报价单"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "新增報價單要求"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "新增標準工業分類代碼"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "新增销售发票"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "新增销货单"
 
@@ -502,7 +502,7 @@ msgstr "新增報稅單"
 msgid "Add Timecard"
 msgstr "新增工時卡"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "新增到清單"
 
@@ -524,7 +524,7 @@ msgstr "新增使用者"
 msgid "Add Vendor"
 msgstr "新增供應商"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "新增供應商發票"
 
@@ -536,15 +536,15 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr "以調整"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "核准"
@@ -826,20 +826,20 @@ msgstr "四月"
 msgid "April"
 msgstr "四月"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "您是否确定要删除订单编号"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "您是否确定要删除报价单编号"
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "八月"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "餘額"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "资产负债表"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "箱"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "不能刪除項目！"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "不能删除定单"
 
@@ -1383,19 +1383,19 @@ msgstr "不能删除定单"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "不能删除报价单"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "不能在已關閉的時段內加入發票！"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "不能在已关闭的时段内加入款项"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "不能在已關閉的時段內加入交易！"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "在交易同一帳戶不能又出現在借方又出現在貸方！"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "不能加入交易！"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "不能储存定单"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "不能儲存報價單！"
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr "現金"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "公司"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "入帳成功！"
 
@@ -1702,7 +1703,7 @@ msgstr "入帳成功！"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "成本"
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "不能儲存！"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "存貨清單不能轉移！"
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "貸方"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "目前"
 
@@ -1969,7 +1970,7 @@ msgstr "目前"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr "客戶編號"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "未指明客户"
 
@@ -2065,7 +2066,7 @@ msgstr "沒有此客戶的記錄！"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "付款日期"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "收款日期"
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "未指明收款日期"
 
@@ -2265,7 +2266,7 @@ msgstr "日"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "借方"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "巳完成"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "到期日"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "未指明到期日！"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "電子郵件"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr "每"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "汇率"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "汇率"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "未指明付款的汇率"
 
@@ -3139,7 +3140,7 @@ msgstr "未指明付款的汇率"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "未指明匯率！"
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "外幣兌換"
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "從貨倉"
 
@@ -3465,7 +3466,7 @@ msgstr "總帳索引編號"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr "生成"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "产生订单"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "生成採購單"
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "组"
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "內部備忘錄"
 
@@ -3853,11 +3854,11 @@ msgstr "在停用此项组合品之前, 存货数量必需为零!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "已儲存存貨！"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "轉移的存貨！"
 
@@ -3865,8 +3866,8 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "发票"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "发票日期"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "未指明发票日期!"
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "发票编号"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "未指明發票編號！"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "已刪除項目！"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "查无此项目"
 
@@ -4011,7 +4012,7 @@ msgstr "一月"
 msgid "January"
 msgstr "一月"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "六月"
 msgid "June"
 msgstr "六月"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "交付時間"
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "登入"
 
@@ -4418,7 +4419,7 @@ msgstr "經理"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "五月"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "備忘錄"
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "備註"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "没有巳输入"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "没有巳选择"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "沒有可轉移的項目！"
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "編號"
 msgid "Number Format"
 msgstr "數字格式"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "十月"
 msgid "October"
 msgstr "十月"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "已有存量"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "订单"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "未指明下單日期！"
 
@@ -5015,8 +5016,8 @@ msgstr "下单项目"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "订单编号"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "未指明訂單編號！"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "已刪除訂單！"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "生成訂單失敗！"
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "出货单"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "未指明出貨單日期！"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "未指明包装清单编号!"
 
@@ -5172,7 +5173,7 @@ msgstr "已付"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "零件"
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "密碼"
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "未指明付款日期!"
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr "付款"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr "电话号码"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "加入"
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "當新的加入"
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "列印"
@@ -5636,11 +5637,11 @@ msgstr "列印"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "列印並儲存"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "列印並儲存作為新的"
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr "季度"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "報價單日期"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "未指明報價單日期！"
 
@@ -5860,11 +5861,11 @@ msgstr "未指明報價單日期！"
 msgid "Quotation Number"
 msgstr "报价单号码"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "未指明报价单号码"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "巳删除报价单"
 
@@ -5879,7 +5880,7 @@ msgstr "報價單"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr "报价请求"
 msgid "ROP"
 msgstr "再订点"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "已收到"
 
@@ -5975,7 +5976,7 @@ msgstr "应收帐户"
 msgid "Receive"
 msgstr "收到"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "收到貨物"
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "記錄於"
 
@@ -6029,11 +6030,11 @@ msgstr "多次记录"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "参考资料"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,9 +6071,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "尚【◎Fix:◎余;◎馀】"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr "報表"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "需要"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr "標準工業分類代碼"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "被指定的数量"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr "销售"
 msgid "Sales"
 msgstr "销售"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "銷售發票"
@@ -6315,8 +6320,8 @@ msgstr "銷售發票"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "銷售發票/應收帳交易編號"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "當新的儲存"
@@ -6460,7 +6465,7 @@ msgstr "當新的儲存"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "時間表"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "編排了時間"
 
@@ -6657,11 +6662,11 @@ msgstr "選擇客戶"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "选厂商"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "選擇印表機！"
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "選擇postscript或PDF！"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "選擇文字、postscript或PDF！"
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "序號"
 
@@ -6795,11 +6800,11 @@ msgstr "序號"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "服務"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "付運"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "海运货物"
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "海运至"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr "由海运"
 msgid "Shipping"
 msgstr "付運"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "付運日期"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "未指明海运日期"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "州"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "税金"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "巳含税金"
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr "次"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "到倉庫"
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr "总计"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "需要追蹤的項目"
@@ -7736,7 +7745,7 @@ msgstr "需要追蹤的項目"
 msgid "Trade Discount"
 msgstr "贸易折扣"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "交易"
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "交易"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "转移"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "转移存货"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "由這裡取貨"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "存貨至"
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "更新"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "巳更新"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "供应商历史"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "供应商发票"
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "未指明供应商"
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "此项目的型态?"
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "是"
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr "完成"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "個"
 

--- a/locale/po/cs.po
+++ b/locale/po/cs.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Czech (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "cs/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -459,11 +459,11 @@ msgstr "Příjem zboží"
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Nová objednávka (nákup)"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Nová objednávka (příjem)"
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Nový uživatel"
 msgid "Add Vendor"
 msgstr "Nový dodavatel"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr "Dub"
 msgid "April"
 msgstr "Duben"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Opravdu chcete vymazat objednávku číslo"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -913,16 +913,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr "Srpen"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Rozvaha"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Paleta"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1384,19 +1384,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Do uzavřeného období nelze účtovat!"
 
@@ -1405,15 +1405,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1433,7 +1433,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1494,7 +1495,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1610,7 +1611,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firma"
 
@@ -1643,7 +1644,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1695,7 +1696,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Podtvrďte!"
 
@@ -1703,7 +1704,7 @@ msgstr "Podtvrďte!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1746,8 +1747,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1758,7 +1759,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1807,7 +1808,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1819,19 +1820,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1851,8 +1852,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1916,7 +1917,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Dal"
 
@@ -1937,7 +1938,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1961,7 +1962,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Měna"
 
@@ -1970,7 +1971,7 @@ msgstr "Měna"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2007,7 +2008,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2037,7 +2038,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2050,7 +2051,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2066,7 +2067,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2139,7 +2140,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2154,11 +2155,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2196,7 +2197,7 @@ msgstr "Zaplaceno"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2220,7 +2221,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2266,7 +2267,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Má dáti"
 
@@ -2379,9 +2380,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2431,16 +2432,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2448,11 +2449,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2474,7 +2475,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2526,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2549,7 +2550,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2620,16 +2621,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2637,7 +2638,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2645,7 +2646,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2661,7 +2662,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2681,7 +2682,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2723,14 +2724,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Datum splatnosti"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Chybí datum splatnosti!"
 
@@ -2742,8 +2743,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3045,11 +3046,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3065,7 +3066,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3087,7 +3088,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3111,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3119,20 +3120,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Kurz"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Měnový kurz"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3140,7 +3141,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3185,8 +3186,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3264,7 +3265,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3278,17 +3279,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3325,7 +3326,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3385,7 +3386,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3417,7 +3418,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3466,7 +3467,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3474,7 +3475,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3503,11 +3504,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3552,8 +3553,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3795,8 +3796,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3854,11 +3855,11 @@ msgstr "Před vyřazením výrobu, musí být stav na skladě nulový!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3866,8 +3867,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3885,22 +3886,22 @@ msgstr "Faktura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Datum vystavení"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Chybí datum vystavení!"
 
@@ -3916,8 +3917,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3926,7 +3927,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Číslo faktury"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Chybí číslo faktury!"
 
@@ -3984,7 +3985,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Tato položka není v databázi!"
 
@@ -4012,7 +4013,7 @@ msgstr "Led"
 msgid "January"
 msgstr "Leden"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4053,7 +4054,7 @@ msgstr "Čer"
 msgid "June"
 msgstr "Červen"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4117,7 +4118,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4338,11 +4339,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Uživatelské jméno"
 
@@ -4419,7 +4420,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4450,9 +4451,9 @@ msgid "May"
 msgstr "Květen"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4799,15 +4800,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4821,15 +4822,15 @@ msgstr "Poznámky"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4854,7 +4855,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4873,7 +4874,7 @@ msgstr "Číslo"
 msgid "Number Format"
 msgstr "Číselný formát"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4911,7 +4912,7 @@ msgstr "Říj"
 msgid "October"
 msgstr "Říjen"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4926,7 +4927,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "K dispozici"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4981,7 +4982,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Objednávka"
 
@@ -4999,12 +5000,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Datum objednávky"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Chybí datum objednávky!"
 
@@ -5016,8 +5017,8 @@ msgstr "Zadání objednávky"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5025,15 +5026,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Objednávka číslo"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Chybí číslo objednávky!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5120,8 +5121,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5137,7 +5138,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5145,11 +5146,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Dodací list"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Chybí číslo dodacího listu"
 
@@ -5173,7 +5174,7 @@ msgstr "Zaplaceno"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Zboží"
 
@@ -5193,8 +5194,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5215,7 +5216,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5245,7 +5246,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Heslo"
 
@@ -5314,7 +5315,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Chybí datum platby!"
 
@@ -5326,7 +5327,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5335,7 +5336,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Platby"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5343,11 +5344,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5382,7 +5383,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5513,8 +5514,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5531,7 +5532,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5626,9 +5627,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5637,11 +5638,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5693,15 +5694,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5723,7 +5724,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5766,8 +5767,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5806,7 +5807,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5836,8 +5837,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5853,7 +5854,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5861,11 +5862,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5880,7 +5881,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5906,7 +5907,7 @@ msgstr ""
 msgid "ROP"
 msgstr "ROP"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5947,7 +5948,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5976,7 +5977,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6004,7 +6005,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Zaúčtovat do"
 
@@ -6030,11 +6031,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6071,9 +6072,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Zbývá"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6101,7 +6106,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6113,7 +6118,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,11 +6154,11 @@ msgstr "Sestavy"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6274,11 +6279,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6307,7 +6312,7 @@ msgstr ""
 msgid "Sales"
 msgstr "Příjmy z prodeje"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6316,8 +6321,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6382,7 +6387,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6427,7 +6432,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6435,7 +6440,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6452,7 +6457,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6461,7 +6466,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6499,7 +6504,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6512,12 +6517,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6658,11 +6663,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6682,12 +6687,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6778,7 +6783,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6796,11 +6801,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Služba"
 
@@ -6844,13 +6849,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6880,12 +6885,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6902,23 +6907,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6994,12 +6999,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7080,11 +7085,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7168,7 +7173,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7231,8 +7236,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7254,7 +7259,7 @@ msgstr "Daň"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7264,7 +7269,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7288,7 +7293,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7296,7 +7301,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Cena včetně daně"
@@ -7395,7 +7400,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7615,7 +7620,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7650,7 +7655,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7696,7 +7701,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7717,7 +7722,7 @@ msgstr ""
 msgid "Total"
 msgstr "Celkem"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7729,6 +7734,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7737,7 +7746,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7770,20 +7779,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7870,7 +7879,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7931,7 +7940,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7947,7 +7956,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7965,7 +7974,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8017,20 +8026,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8092,7 +8101,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8178,8 +8187,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8198,7 +8207,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8214,7 +8223,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8237,7 +8246,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8274,7 +8283,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8351,7 +8360,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "O jaký typ položky se jedná?"
 
@@ -8367,7 +8376,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8425,7 +8434,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ano"
@@ -8444,11 +8453,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8515,7 +8524,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8559,7 +8568,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "m.j."
 

--- a/locale/po/da.po
+++ b/locale/po/da.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Mikkel Høgh <mikkel@hoegh.org>, 2016\n"
 "Language-Team: Danish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -190,7 +190,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Ingen adgang"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -198,9 +198,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -208,7 +208,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -319,7 +319,7 @@ msgstr "Periodisering"
 msgid "Accrual Basis:"
 msgstr "Periosdisering Basis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -428,7 +428,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Ny medarbejder"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Ny vekselkurs"
 
@@ -464,11 +464,11 @@ msgstr "Ny vare"
 msgid "Add Pricegroup"
 msgstr "Ny prisgruppe"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Ny indkøbsordre"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Nyt tilbud"
 
@@ -476,7 +476,7 @@ msgstr "Nyt tilbud"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Nyt tilbudsønske"
 
@@ -488,11 +488,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Ny SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Ny salgsfaktura"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Ny salgsordre"
 
@@ -508,7 +508,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr "Ny bruger"
 msgid "Add Vendor"
 msgstr "Ny leverandør"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Ny leverandørfaktura"
 
@@ -542,15 +542,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Nyt lager"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -578,8 +578,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -611,7 +611,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -688,9 +688,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -793,8 +793,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -832,20 +832,20 @@ msgstr "apr"
 msgid "April"
 msgstr "april"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Er du sikker på at du vil fjerne ordrenummer"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Er du sikker på at du vil slette tilbudsnummer"
 
@@ -918,16 +918,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -958,31 +958,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1015,7 +1015,7 @@ msgstr "august"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgid "Balance"
 msgstr "Balance"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Status"
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1211,14 +1211,14 @@ msgstr "Milliard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Varelager"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1381,7 +1381,7 @@ msgstr "Kan ikke oprette serviceydelse; indtægtskontoen findes ikke!"
 msgid "Cannot delete item!"
 msgstr "Kan ikke slette varenummer!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Kan ikke slette ordre!"
 
@@ -1389,19 +1389,19 @@ msgstr "Kan ikke slette ordre!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Kan ikke slette tilbud"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Kan ikke bogføre faktura for en afsluttet periode!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Kan ikke bogføre betaling for en afsluttet periode"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Kan ikke bogføre postering for en afsluttet periode!"
 
@@ -1410,15 +1410,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "Kan ikke bogføre med kredit og debit på samme konto!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Kan ikke bogføre postering!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Kan ikke gemme ordre!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Kan ikke gemme tilbud"
 
@@ -1438,7 +1438,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Kontanter"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1499,7 +1500,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1615,7 +1616,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firma"
 
@@ -1648,7 +1649,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1700,7 +1701,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Bekræft!"
 
@@ -1708,7 +1709,7 @@ msgstr "Bekræft!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1751,8 +1752,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1763,7 +1764,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1812,7 +1813,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Udgifter"
 
@@ -1824,19 +1825,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Kunne ikke gemme!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Kunne ikke overføre lagerbeholdning!"
 
@@ -1856,8 +1857,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1921,7 +1922,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredit"
 
@@ -1942,7 +1943,7 @@ msgstr "Kreditkonti"
 msgid "Credit Invoice"
 msgstr "Kreditorfaktura"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1966,7 +1967,7 @@ msgstr "Kredit"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Val"
 
@@ -1975,7 +1976,7 @@ msgstr "Val"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2012,7 +2013,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2042,7 +2043,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2055,7 +2056,7 @@ msgstr "Kundenummer"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Kunde mangler!"
 
@@ -2071,7 +2072,7 @@ msgstr "Kunde ikke i databasen!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2095,7 +2096,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2144,7 +2145,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2159,11 +2160,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2201,7 +2202,7 @@ msgstr "Betalingsdato"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Modtagelsesdato"
 
@@ -2225,7 +2226,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Modtagelsesdato mangler!"
 
@@ -2271,7 +2272,7 @@ msgstr "Dage"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debet"
 
@@ -2384,9 +2385,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2436,16 +2437,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Leveringsdato"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2453,11 +2454,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2479,7 +2480,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2531,13 +2532,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2554,7 +2555,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2625,16 +2626,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2642,7 +2643,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2650,7 +2651,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2666,7 +2667,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Færdig"
 
@@ -2686,7 +2687,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2728,14 +2729,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Forfaldsdato"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Forfaldsdato mangler!"
 
@@ -2747,8 +2748,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-post"
 
@@ -3050,11 +3051,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3070,7 +3071,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3092,7 +3093,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3116,7 +3117,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3124,20 +3125,20 @@ msgstr ""
 msgid "Every"
 msgstr "Hver"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Vxl"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Vekselkurs"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Valutakurs for betaling mangler!"
 
@@ -3145,7 +3146,7 @@ msgstr "Valutakurs for betaling mangler!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Vekselkurs mangler!"
 
@@ -3190,8 +3191,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3269,7 +3270,7 @@ msgstr "Halvtreds"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3283,17 +3284,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3330,7 +3331,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3390,7 +3391,7 @@ msgstr "Fjorten"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3422,7 +3423,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Fra lager"
 
@@ -3471,7 +3472,7 @@ msgstr "Hovedbog referencenummer"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3479,7 +3480,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3508,11 +3509,11 @@ msgstr "Generer"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Generer ordrer"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generer indkøbsordrer"
 
@@ -3557,8 +3558,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Gruppe"
 
@@ -3800,8 +3801,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Interne noter"
 
@@ -3859,11 +3860,11 @@ msgstr "Lagerbeholdning skal være nul for at du kan lade dette produkt udgå!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Lagerbeholdning gemt!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Lagerbeholdning overført!"
 
@@ -3871,8 +3872,8 @@ msgstr "Lagerbeholdning overført!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3890,22 +3891,22 @@ msgstr "Faktura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fakturadato"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Fakturadato mangler!"
 
@@ -3921,8 +3922,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3931,7 +3932,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Fakturanummer"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Fakturanummer mangler!"
 
@@ -3989,7 +3990,7 @@ msgstr "Varenummer"
 msgid "Item deleted!"
 msgstr "Varenummer slettet!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Varenummer er ikke i databasen!"
 
@@ -4017,7 +4018,7 @@ msgstr "jan"
 msgid "January"
 msgstr "januar"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4058,7 +4059,7 @@ msgstr "jun"
 msgid "June"
 msgstr "juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4122,7 +4123,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Lev.tid"
 
@@ -4343,11 +4344,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Log på"
 
@@ -4424,7 +4425,7 @@ msgstr "Leder"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4455,9 +4456,9 @@ msgid "May"
 msgstr "maj"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Note"
@@ -4804,15 +4805,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4826,15 +4827,15 @@ msgstr "Bemærkninger"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Ingenting indtastet!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Ingenting valgt!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Intet at overføre!"
 
@@ -4859,7 +4860,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4878,7 +4879,7 @@ msgstr "Nummer"
 msgid "Number Format"
 msgstr "Numerisk format"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4916,7 +4917,7 @@ msgstr "okt"
 msgid "October"
 msgstr "oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4931,7 +4932,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "På lager"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4986,7 +4987,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Ordre"
 
@@ -5004,12 +5005,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ordredato"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Ordredato mangler"
 
@@ -5021,8 +5022,8 @@ msgstr "Ordreindgang"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5030,15 +5031,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Ordrenummer"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Ordrenummer mangler"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Ordre slettet"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Ordregenerering fejlet!"
 
@@ -5125,8 +5126,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5142,7 +5143,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5150,11 +5151,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Følgeseddel"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Dato for pakkeliste mangler!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Nummer for pakkeliste mangler!"
 
@@ -5178,7 +5179,7 @@ msgstr "Betalt"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Vare"
 
@@ -5198,8 +5199,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5220,7 +5221,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5250,7 +5251,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Adgangskode"
 
@@ -5319,7 +5320,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Betalingsdato mangler!"
 
@@ -5331,7 +5332,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5340,7 +5341,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Betalinger"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5348,11 +5349,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5387,7 +5388,7 @@ msgstr "Tel."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5518,8 +5519,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Bogfør"
@@ -5536,7 +5537,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Bogfør som ny"
 
@@ -5631,9 +5632,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Udskriv"
@@ -5642,11 +5643,11 @@ msgstr "Udskriv"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Udskriv og gem"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Udskriv og gem som ny"
 
@@ -5698,15 +5699,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5728,7 +5729,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5771,8 +5772,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5811,7 +5812,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5841,8 +5842,8 @@ msgid "Quarter"
 msgstr "Kvartal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5858,7 +5859,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Tilbudsdato"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Tilbudsdato mangler!"
 
@@ -5866,11 +5867,11 @@ msgstr "Tilbudsdato mangler!"
 msgid "Quotation Number"
 msgstr "Tilbudsnummer"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Tilbudsnummer mangler!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Tilbud slettet!"
 
@@ -5885,7 +5886,7 @@ msgstr "Tilbud"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5911,7 +5912,7 @@ msgstr "Tilbudsønsker"
 msgid "ROP"
 msgstr "Genbestil ved"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5952,7 +5953,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Modt"
 
@@ -5981,7 +5982,7 @@ msgstr "Indbetalinger"
 msgid "Receive"
 msgstr "Modtagelse"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Modtag varer"
 
@@ -6009,7 +6010,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Bogfør på"
 
@@ -6035,11 +6036,11 @@ msgstr "Gentagne transaktioner"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Reference"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6076,9 +6077,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resterer"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6106,7 +6111,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Rapportnavn"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6118,7 +6123,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6154,11 +6159,11 @@ msgstr "Rapporter"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Krævet"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6279,11 +6284,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "Varenummer"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6312,7 +6317,7 @@ msgstr "Salg"
 msgid "Sales"
 msgstr "Salg"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Salgsfaktura"
@@ -6321,8 +6326,8 @@ msgstr "Salgsfaktura"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Salgsfaktura/debitorposteringnummer"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6387,7 +6392,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6432,7 +6437,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6440,7 +6445,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6457,7 +6462,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Gem som ny"
@@ -6466,7 +6471,7 @@ msgstr "Gem som ny"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6504,7 +6509,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6517,12 +6522,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Planlæg"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Planlagt"
 
@@ -6663,11 +6668,11 @@ msgstr "Vælg kunde"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Vælg leverandør"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Vælg en printer!"
 
@@ -6687,12 +6692,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Vælg postscript eller PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Vælg txt, postscript eller PDF"
 
@@ -6783,7 +6788,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serienummer"
 
@@ -6801,11 +6806,11 @@ msgstr "Serienummer"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Serviceydelse"
 
@@ -6849,13 +6854,13 @@ msgstr "Sytten"
 msgid "Seventy"
 msgstr "Halvfjerds"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Afsend"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Afsend varer"
 
@@ -6885,12 +6890,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Send til"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6907,23 +6912,23 @@ msgstr "Send via"
 msgid "Shipping"
 msgstr "Afsendelse"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Afsendelsesdato"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Afsendelsesdato mangler!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6999,12 +7004,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7085,11 +7090,11 @@ msgstr "Startdato"
 msgid "Starting Date:"
 msgstr "Startdato"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Stat"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7173,7 +7178,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7236,8 +7241,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7259,7 +7264,7 @@ msgstr "Moms/afgift"
 msgid "Tax Account"
 msgstr "Moms/afgiftkonti"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7269,7 +7274,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7293,7 +7298,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7301,7 +7306,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Inkl. moms og afgifter"
@@ -7400,7 +7405,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7620,7 +7625,7 @@ msgstr "Gange"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7655,7 +7660,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Til lager"
 
@@ -7701,7 +7706,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7722,7 +7727,7 @@ msgstr ""
 msgid "Total"
 msgstr "I alt"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7734,6 +7739,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7742,7 +7751,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr "Handelsrabat"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Postering"
 
@@ -7775,20 +7784,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Posteringer"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Overførsel"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Overfør lagerbeholdning"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Overfør fra"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Overfør til"
 
@@ -7875,7 +7884,7 @@ msgstr "To"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7936,7 +7945,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7952,7 +7961,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7970,7 +7979,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8022,20 +8031,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Opdatér"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Opdateret"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8097,7 +8106,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8183,8 +8192,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8203,7 +8212,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Leverandørhistorik"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Leverandørfaktura"
@@ -8219,7 +8228,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8242,7 +8251,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Leverandør mangler!"
 
@@ -8279,7 +8288,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8356,7 +8365,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Hvilken type varenummer er dette?"
 
@@ -8372,7 +8381,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8430,7 +8439,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
@@ -8449,11 +8458,11 @@ msgstr ""
 msgid "Zero"
 msgstr "Nul"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8520,7 +8529,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8564,7 +8573,7 @@ msgstr "færdig"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "stk"
 

--- a/locale/po/de.po
+++ b/locale/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: d34703e27442b8aae408ee1a019d49fd_1d2c70b, 2022\n"
 "Language-Team: German (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -190,7 +190,7 @@ msgstr "Verzicht"
 msgid "Access Denied"
 msgstr "Zugriff verweigert"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr "Zugriff verweigert: Falscher Benutzername oder Passwort"
 
@@ -198,9 +198,9 @@ msgstr "Zugriff verweigert: Falscher Benutzername oder Passwort"
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -208,7 +208,7 @@ msgstr "Zugriff verweigert: Falscher Benutzername oder Passwort"
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -319,7 +319,7 @@ msgstr "Rückstellung"
 msgid "Accrual Basis:"
 msgstr "Periodenabgrenzung:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Summierte Abschreibungen"
 
@@ -428,7 +428,7 @@ msgstr "Lastschrift hinzufügen"
 msgid "Add Employee"
 msgstr "Mitarbeiter hinzufÃ¼gen"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Wechselkurs hinzufÃ¼gen"
 
@@ -464,11 +464,11 @@ msgstr "Teil hinzufÃ¼gen"
 msgid "Add Pricegroup"
 msgstr "Preisgruppe hinzufÃ¼gen"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Einkaufsbestellung hinzufÃ¼gen"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Angebot hinzufÃ¼gen"
 
@@ -476,7 +476,7 @@ msgstr "Angebot hinzufÃ¼gen"
 msgid "Add Reporting Unit"
 msgstr "Berichtseinheit hinzufügen"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Angebotsanfrage hinzufÃ¼gen"
 
@@ -488,11 +488,11 @@ msgstr "Rücknahme hinzufügen"
 msgid "Add SIC"
 msgstr "SIC hinzufÃ¼gen"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Ausgangsrechnung anlegen"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Verkaufsbeleg anlegen"
 
@@ -508,7 +508,7 @@ msgstr "Steuererklärung hinzufügen"
 msgid "Add Timecard"
 msgstr "Zeitkarte hinzufügen"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Zur Liste hinzufügen"
 
@@ -530,7 +530,7 @@ msgstr "Benutzer hinzufügen"
 msgid "Add Vendor"
 msgstr "Lieferanten hinzufÃ¼gen"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Kreditorenrechnung hinzufÃ¼gen"
 
@@ -542,15 +542,15 @@ msgstr "Lieferantenrückgabe hinzufügen"
 msgid "Add Warehouse"
 msgstr "Warenlager hinzufÃ¼gen"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Zeile 1 hinzufÃ¼gen"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Zeile 2 hinzufÃ¼gen"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Zeile 3 hinzufÃ¼gen "
 
@@ -578,8 +578,8 @@ msgstr "id [_1] hinzugefügt"
 msgid "Adding"
 msgstr "Hinzufügen"
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -611,7 +611,7 @@ msgstr "Anp"
 msgid "Adjusted"
 msgstr "Justiert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Angepasste Basis"
 
@@ -688,9 +688,9 @@ msgstr "Erlaubte Eingabe"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -801,8 +801,8 @@ msgstr "Freigabestatus"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Genehmigen"
@@ -840,20 +840,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Kaufwert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Verbleibender Kaufwert"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Sind Sie sicher dass Sie die Bestellnummer lÃ¶schen wollen"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Sind Sie sicher dass Sie die Angebotsnummer lÃ¶schen wollen"
 
@@ -926,16 +926,16 @@ msgstr "Anlagenkennzeichnung"
 msgid "Assets"
 msgstr "Aktiven"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Anlage zu Eigenkapital"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr "Anlage zu Verbindlichkeiten"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "AnhÃ¤ngen"
@@ -966,31 +966,31 @@ msgstr "Angefügt an"
 msgid "Attached By"
 msgstr "Angefügt bei"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "AngehÃ¤ngt an"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "AngehÃ¤ngt an Typ"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "AngehÃ¤ngte und Verlinkte Dateien"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "AngehÃ¤ngt an"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "AngehÃ¤ngt von"
@@ -1023,7 +1023,7 @@ msgstr "August"
 msgid "Author: [_1]"
 msgstr "Autor: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatisch"
 
@@ -1092,7 +1092,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilanz"
@@ -1139,8 +1139,8 @@ msgstr "Basiswährung"
 msgid "Base system"
 msgstr "Basissystem"
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basis"
 
@@ -1152,7 +1152,7 @@ msgstr "Posten"
 msgid "Batch Class"
 msgstr "Postenklasse"
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr "Posten Kontroll Nummer"
 
@@ -1172,7 +1172,7 @@ msgstr "Posten Nr"
 msgid "Batch ID Missing"
 msgstr "Posten Nr. fehlt"
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr "Postenname"
 
@@ -1219,14 +1219,14 @@ msgstr "Billion"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Stellage"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1326,7 +1326,7 @@ msgstr "Umsatzkostenreport"
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Steuern berechnen"
 
@@ -1334,12 +1334,12 @@ msgstr "Steuern berechnen"
 msgid "Can't post credits and debits on one line."
 msgstr "Guthaben und Lastschriften können nicht in einer Zeile gebucht werden."
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Eine stornierte Rechnung kann nicht storniert werden!"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1394,7 +1394,7 @@ msgstr "Dienstleistung kann nicht angelegt werden; Konto existiert nicht!"
 msgid "Cannot delete item!"
 msgstr "Artikel kann nicht gelÃ¶scht werden!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Bestellung konnte nicht gelÃ¶scht werden!"
 
@@ -1402,19 +1402,19 @@ msgstr "Bestellung konnte nicht gelÃ¶scht werden!"
 msgid "Cannot delete posted transaction"
 msgstr "Transaktion konnte nicht gelöscht werden"
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Angebot konnte nicht gelÃ¶scht werden!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Rechnung kann in abgeschlossener Periode nicht gebucht werden!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Zahlung kann im abgeschlossenen Zeitraum nicht gebucht werden!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Transaktion kann in geschlossener Periode nicht gebucht werden!"
 
@@ -1425,15 +1425,15 @@ msgstr ""
 "Transaktion kann nicht gebucht werden mit Soll und Haben Eintrag im gleichen "
 "Konto!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Transaktion konnte nicht gebucht werden!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Bestellung konnte nicht gespeichert werden!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Angebot konnte nicht gespeichert werden!"
 
@@ -1453,7 +1453,8 @@ msgstr "Perso"
 msgid "Cash"
 msgstr "Bar"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Portokassenkonto"
 
@@ -1514,7 +1515,7 @@ msgid "Chord"
 msgstr "Akkord"
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1633,7 +1634,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firma"
 
@@ -1666,7 +1667,7 @@ msgstr "Firmentelefon"
 msgid "Company Sales Tax ID"
 msgstr "Firmensteuernummer"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr "Firma existiert nicht"
 
@@ -1718,7 +1719,7 @@ msgstr "Lagerhäuser konfigurieren"
 msgid "Confirm Operation"
 msgstr "Vorgang bestätigen"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "BestÃ¤tigen!"
 
@@ -1728,7 +1729,7 @@ msgstr ""
 "Konflikt mit bestehenden Daten.  MÃ¶glicherweise haben Sie diese Angabe "
 "bereits gemacht?"
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1771,8 +1772,8 @@ msgstr "Inhalt"
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1783,7 +1784,7 @@ msgstr "Inhalt"
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1836,7 +1837,7 @@ msgid "Copy to New Name"
 msgstr "Zu einem neuen Namen kopieren"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Kosten"
 
@@ -1848,19 +1849,19 @@ msgstr "Kosten der verkauften GÃ¼ter"
 msgid "Could Not Load Template from DB"
 msgstr "Die Template von der Datenbank konnte nicht geladen werden"
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr "Die Verbindung zum Server konnte nicht hergestellt werden"
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Daten konnten nicht gespeichert werden.  Bitte versuchen Sie es erneut"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Konnte nicht gespeichert werden!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Inventar konnte nicht Ã¼bertragen werden!"
 
@@ -1880,8 +1881,8 @@ msgstr "Kontrahentcode"
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1945,7 +1946,7 @@ msgstr "Erstellt am"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Haben"
 
@@ -1966,7 +1967,7 @@ msgstr "Kundenkreditkonto"
 msgid "Credit Invoice"
 msgstr "Gutschrift"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1990,7 +1991,7 @@ msgstr "Haben"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "WÃ¤hrung"
 
@@ -1999,7 +2000,7 @@ msgstr "WÃ¤hrung"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2036,7 +2037,7 @@ msgstr "Benutzerdefinierte Markierungen"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2066,7 +2067,7 @@ msgstr "Kundenname"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2079,7 +2080,7 @@ msgstr "Kundennummer"
 msgid "Customer Search"
 msgstr "Kunden suchen"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Kunde fehlt!"
 
@@ -2095,7 +2096,7 @@ msgstr "Kunde nicht in der Datei!"
 msgid "Customer/Vendor Accounts"
 msgstr "Kunden/Lieferant Konto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr "D M"
 
@@ -2119,7 +2120,7 @@ msgstr "Daten aus Ihrem Kontoauszug."
 msgid "Data from your ledger"
 msgstr "Daten aus dem Hauptbuch"
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Daten nicht gespeichert.  Bitte erneut versuchen."
 
@@ -2168,7 +2169,7 @@ msgstr "Datenbank existiert nicht."
 msgid "Database exists."
 msgstr "Datenbank existiert."
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr "Datenbankversion stimmt nicht überein"
 
@@ -2183,11 +2184,11 @@ msgstr "Datenbankversion stimmt nicht überein"
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2225,7 +2226,7 @@ msgstr "Zahlungseingang"
 msgid "Date Range"
 msgstr "Datumsbereich"
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Empfangsdatum"
 
@@ -2249,7 +2250,7 @@ msgstr "Datum von"
 msgid "Date of Birth"
 msgstr "Geburtsdatum"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Eingangsdatum fehlt!"
 
@@ -2295,7 +2296,7 @@ msgstr "Tage"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Soll"
 
@@ -2408,9 +2409,9 @@ msgstr "Definierte Wechselkurstypen"
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2460,16 +2461,16 @@ msgstr "Lieferung"
 msgid "Delivery Date"
 msgstr "Lieferdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Abschreibungsbasis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Abschreibungsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Abschreibungsbeginn"
 
@@ -2477,11 +2478,11 @@ msgstr "Abschreibungsbeginn"
 msgid "Dep. Through"
 msgstr "Abschreiben bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Abschreibungen YTD"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Abschreibungen in dieser Periode"
 
@@ -2503,7 +2504,7 @@ msgstr "Abschreibung"
 msgid "Depreciate Through"
 msgstr "Abschreiben bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Abschreibung"
@@ -2555,13 +2556,13 @@ msgstr "Abschreibungsbeginn"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2578,7 +2579,7 @@ msgstr "Abschreibungsbeginn"
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2649,16 +2650,16 @@ msgstr "Rabatt (%)"
 msgid "Discount:"
 msgstr "Rabatt:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Durch AbgÃ¤nge erzielte Werte"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Abgabe"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Zeitpunkt der VerÃ¤usserung"
 
@@ -2666,7 +2667,7 @@ msgstr "Zeitpunkt der VerÃ¤usserung"
 msgid "Disposal Method"
 msgstr "VerÃ¤usserungsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 
@@ -2674,7 +2675,7 @@ msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 msgid "Division by 0 error"
 msgstr "Division durch 0 Fehler"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr "Feld nicht leer lassen [_1]"
 
@@ -2690,7 +2691,7 @@ msgstr "Dokumententyp"
 msgid "Don't know what to do with backup"
 msgstr "Unklar was mit Sicherungskopie geschehen soll"
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Erledigt"
 
@@ -2710,7 +2711,7 @@ msgstr "Herunterladen:"
 msgid "Dr."
 msgstr "Dr."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Entwurf gebucht"
 
@@ -2752,14 +2753,14 @@ msgstr "FÃ¤llig"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "FÃ¤lligkeitsdatum"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Verfallsdatum fehlt!"
 
@@ -2771,8 +2772,8 @@ msgstr "Doppelter Benutzer gefunden: Benutzer wird importiert"
 msgid "Duplicate employee numbers"
 msgstr "Doppelte Mitarbeiternummer"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3076,11 +3077,11 @@ msgstr "EntitÃ¤t"
 msgid "Entity Class"
 msgstr "Entitätsklasse"
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "EntitÃ¤t Kode"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "EntitÃ¤t Kontroll Nummer"
 
@@ -3096,7 +3097,7 @@ msgstr "Entitätsname"
 msgid "Entry ID"
 msgstr "Eintragungs ID"
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "Umschlag"
@@ -3118,7 +3119,7 @@ msgstr "Eigenkapital und Verbindlichkeiten"
 msgid "Equity (Temporary)"
 msgstr "Eigenkapital (temporär)"
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr "Eigenkapital zu Verbindlichkeiten"
 
@@ -3143,7 +3144,7 @@ msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 "Fehler: Saldenzusammenfassung konnte nicht ins AufklappmenÃ¼ eingefÃ¼gt werden"
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "GeschÃ¤tzte Lebensdauer"
 
@@ -3151,20 +3152,20 @@ msgstr "GeschÃ¤tzte Lebensdauer"
 msgid "Every"
 msgstr "Jede"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Wechselkurs"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Wechselkurs"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Wechselkurs fÃ¼r Zahlung fehlt!"
 
@@ -3172,7 +3173,7 @@ msgstr "Wechselkurs fÃ¼r Zahlung fehlt!"
 msgid "Exchange rate hasn't been defined!"
 msgstr "Wechselkurs wurde nicht definiert!"
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Wechselkurs fehlt!"
 
@@ -3217,8 +3218,8 @@ msgstr "Extra gebraucht"
 msgid "FAQ"
 msgstr "FAQ"
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3296,7 +3297,7 @@ msgstr "fünfzig"
 msgid "File"
 msgstr "Datei"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Datei importiert"
 
@@ -3310,17 +3311,17 @@ msgstr "Dateiname"
 msgid "File Type"
 msgstr "Dateityp"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Dateiname"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Dateityp"
@@ -3357,7 +3358,7 @@ msgstr "Erst"
 msgid "First Name"
 msgstr "Vorname"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr "Erste Spalte nur"
 
@@ -3417,7 +3418,7 @@ msgstr "vierzehn"
 msgid "Fri"
 msgstr "Fre"
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3449,7 +3450,7 @@ msgstr "Datum vom"
 msgid "From File"
 msgstr "Aus Datei"
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Aus Warenlager"
 
@@ -3498,7 +3499,7 @@ msgstr "Grundbuch Referenznummer"
 msgid "Gain"
 msgstr "Gewinn"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Gewinn (Verlust)"
 
@@ -3506,7 +3507,7 @@ msgstr "Gewinn (Verlust)"
 msgid "Gain Account"
 msgstr "Gewinnkonto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr "Gewinn/Verlust"
 
@@ -3535,11 +3536,11 @@ msgstr "Generieren"
 msgid "Generate Control Code"
 msgstr "Kontrolnummer erstellen"
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Bestellungen erstellen"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Einkaufsauftrag erstellen"
 
@@ -3584,8 +3585,8 @@ msgid "Grand Total"
 msgstr "Gesamtsumme"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Gruppe"
 
@@ -3831,8 +3832,8 @@ msgstr "Interner Datenbankenfehler"
 msgid "Internal Files"
 msgstr "Interne Dateien"
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Interne Notizen"
 
@@ -3895,11 +3896,11 @@ msgstr ""
 "Bevor dieses Erzeugnis als ungültig markiert werden kann muß das Teil auf "
 "Null sein!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventar gespeichert!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventar Ã¼bertragen!"
 
@@ -3907,8 +3908,8 @@ msgstr "Inventar Ã¼bertragen!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3926,22 +3927,22 @@ msgstr "Rechnung"
 msgid "Invoice #"
 msgstr "Rechnung #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Rechnung erstellt"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Rechnungserstellt"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Rechnungsdatum"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Rechnungsdatum fehlt!"
 
@@ -3957,8 +3958,8 @@ msgstr "Rechnungsnr."
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3967,7 +3968,7 @@ msgstr "Rechnungsnr."
 msgid "Invoice Number"
 msgstr "Rechnungsnummer"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Rechnungsnummer fehlt!"
 
@@ -4025,7 +4026,7 @@ msgstr "Artikel"
 msgid "Item deleted!"
 msgstr "Artikel gelÃ¶scht!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Artikel nicht in der Datei!"
 
@@ -4059,7 +4060,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Januar"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr "JavaScript-Fehler:"
 
@@ -4100,7 +4101,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr "Verhältnisse"
 
@@ -4164,7 +4165,7 @@ msgstr "Letzte Aktualisierung"
 msgid "Last name"
 msgstr "Nachname"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Bestellzeit"
 
@@ -4393,11 +4394,11 @@ msgstr "Gesperrt von [_1]"
 msgid "Logged out due to inactivity"
 msgstr "Wegen Inaktivität abgemeldet"
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr "Anmelden... Bitte warten Sie."
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Anmelden"
 
@@ -4476,7 +4477,7 @@ msgstr "Manager"
 msgid "Manager:"
 msgstr "Manager:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Manuell"
 
@@ -4507,9 +4508,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Vermerk"
@@ -4862,15 +4863,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4884,15 +4885,15 @@ msgstr "Notizen"
 msgid "Notes:<br />"
 msgstr "Notes:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Nichts eingegeben!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nichts ausgewÃ¤hlt!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nichts zu Ã¼bertragen!"
 
@@ -4917,7 +4918,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4936,7 +4937,7 @@ msgstr "Nummer"
 msgid "Number Format"
 msgstr "Zahlenformat"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr "Nummer fehlt in Reihe [_1]"
 
@@ -4974,7 +4975,7 @@ msgstr "Okt"
 msgid "October"
 msgstr "Oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr "Warten"
 
@@ -4989,7 +4990,7 @@ msgstr "Altes Passwort"
 msgid "On Hand"
 msgstr "Am Lager"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "In Warteschleife"
@@ -5044,7 +5045,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Bestellung"
 
@@ -5062,12 +5063,12 @@ msgstr "Bestellnummer #"
 msgid "Order By"
 msgstr "Sortieren nach"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Bestelldatum"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Bestelldatum fehlt!"
 
@@ -5079,8 +5080,8 @@ msgstr "Bestellungen"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5088,15 +5089,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Bestellnummer"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Bestellnummer fehlt!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Bestellung gelÃ¶scht!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Erstellen der Bestellung fehlgeschlagen!"
 
@@ -5183,8 +5184,8 @@ msgstr "Best. #"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5200,7 +5201,7 @@ msgstr "BUCHEN"
 msgid "POST AND PRINT"
 msgstr "BUCHEN UND DRUCKEN"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5208,11 +5209,11 @@ msgstr "BUCHEN UND DRUCKEN"
 msgid "Packing List"
 msgstr "Packliste"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Datum für Verpackungsliste fehlt!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Verpackungslistennummer fehlt!"
 
@@ -5236,7 +5237,7 @@ msgstr "Bezahlt"
 msgid "Parent"
 msgstr "VorgÃ¤nger"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Teil"
 
@@ -5256,8 +5257,8 @@ msgstr "Teilegruppe"
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5278,7 +5279,7 @@ msgstr "Teildetails"
 msgid "Partial"
 msgstr "Teilweise"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 
@@ -5308,7 +5309,7 @@ msgstr "Teilegruppen"
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Passwort"
 
@@ -5377,7 +5378,7 @@ msgstr "Zahlungsart"
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Datum der Einzahlung fehlt!"
 
@@ -5389,7 +5390,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5398,7 +5399,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Zahlungen"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 "Zahlungen aus stornierten Rechnungen mÃ¼ssen mÃ¶glicherweise rÃ¼ckÃ¼berwiesen "
@@ -5408,11 +5409,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Prozent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "VerÃ¤usserungen in Prozent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Prozent verbleibend"
 
@@ -5447,7 +5448,7 @@ msgstr "Tel."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5578,8 +5579,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Buchen"
@@ -5596,7 +5597,7 @@ msgstr "Datum einfÃ¼gen"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Als Neu buchen"
 
@@ -5691,9 +5692,9 @@ msgid "Primary Phone"
 msgstr "Primäres Telefon"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Drucken"
@@ -5702,11 +5703,11 @@ msgstr "Drucken"
 msgid "Print Batch"
 msgstr "Stapel drucken"
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Drucken und Speichern"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Drucken und als Neu speichern"
 
@@ -5758,15 +5759,15 @@ msgstr "Drucken von Transaktion [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Drucken von Arbeitsauftrags [_1]"
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "GetÃ¤tigte Abschreibungen"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "ErtrÃ¤ge"
 
@@ -5788,7 +5789,7 @@ msgstr "Produktbeleg"
 msgid "Profit and Loss"
 msgstr "Gewinn und Verlust"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Gewinn/Verlust"
 
@@ -5831,8 +5832,8 @@ msgstr "Kaufdatum:"
 msgid "Purchase History"
 msgstr "Kaufhistorie"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5871,7 +5872,7 @@ msgstr "Gekauft"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5901,8 +5902,8 @@ msgid "Quarter"
 msgstr "Quartal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5918,7 +5919,7 @@ msgstr "Kostenvoranschlag #"
 msgid "Quotation Date"
 msgstr "Angebotsdatum"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Angebotsdatum fehlt!"
 
@@ -5926,11 +5927,11 @@ msgstr "Angebotsdatum fehlt!"
 msgid "Quotation Number"
 msgstr "Angebotsnummer"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Angebotsnummer fehlt!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Angebot gelÃ¶scht!"
 
@@ -5945,7 +5946,7 @@ msgstr "Angebote"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5971,7 +5972,7 @@ msgstr "Angebotsanfragen"
 msgid "ROP"
 msgstr "Nachbestellungspunkt"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -6012,7 +6013,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Dokumentieren"
 
@@ -6041,7 +6042,7 @@ msgstr "Forderungen"
 msgid "Receive"
 msgstr "Empfangen"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Waren empfangen"
 
@@ -6069,7 +6070,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr "Kontenabgleichsberichte"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Aufzeichnen in"
 
@@ -6095,11 +6096,11 @@ msgstr "Wiederkehrende Transaktionen"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referenz"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr "Referenznummer fehlt"
 
@@ -6136,9 +6137,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Restnutzdauer"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Restlich"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6166,7 +6171,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Berichtsname"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Berichtsergebnisse"
 
@@ -6178,7 +6183,7 @@ msgstr "Bericht eingereicht"
 msgid "Report Type"
 msgstr "Berichtstyp"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr "Bericht [_1] am [_2]"
 
@@ -6214,11 +6219,11 @@ msgstr "Berichte"
 msgid "Reposting Not Allowed"
 msgstr "Umbuchen nicht erlaubt"
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "BenÃ¶tigt"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6339,11 +6344,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr "Kundenauftragsnummer"
 
@@ -6372,7 +6377,7 @@ msgstr "Verkauf"
 msgid "Sales"
 msgstr "Verkauf"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Verkaufsrechnung"
@@ -6381,8 +6386,8 @@ msgstr "Verkaufsrechnung"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Ausgangsrechnung/Transaktionsnummer ausstehende Rechnung"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6447,7 +6452,7 @@ msgstr "Sat"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6492,7 +6497,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr "Gruppe speichern"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Standort speichern"
 
@@ -6500,7 +6505,7 @@ msgstr "Standort speichern"
 msgid "Save New"
 msgstr "Neu sichern"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6517,7 +6522,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Als Neu speichern"
@@ -6526,7 +6531,7 @@ msgstr "Als Neu speichern"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6564,7 +6569,7 @@ msgstr "Speichern [_1] [_2]"
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6577,12 +6582,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Planen"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Geplant"
 
@@ -6723,11 +6728,11 @@ msgstr "Kunde wÃ¤hlen"
 msgid "Select Templates to Load"
 msgstr "Wähle Vorlage aus"
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Lieferanten wÃ¤hlen"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Drucker wÃ¤hlen!"
 
@@ -6747,12 +6752,12 @@ msgstr "Wähle Rechnung aus"
 msgid "Select or Enter User"
 msgstr "Wähle aus oder gebe Benutzer an"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "WÃ¤hle Postscript oder PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "WÃ¤hle TXT, Postscript oder PDF!"
 
@@ -6843,7 +6848,7 @@ msgstr "Sequenz"
 msgid "Serial #"
 msgstr "Serien #"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serien Nr."
 
@@ -6861,11 +6866,11 @@ msgstr "Seriennummer"
 msgid "Serialnumber"
 msgstr "Seriennummer"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Dienstleistung"
 
@@ -6909,13 +6914,13 @@ msgstr "siebzehn"
 msgid "Seventy"
 msgstr "siebzig"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Versenden"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Waren verschicken"
 
@@ -6945,12 +6950,12 @@ msgstr "Lieferadresse:"
 msgid "Ship Via"
 msgstr "Versand durch"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Liefern an"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6967,23 +6972,23 @@ msgstr "Versenden mit"
 msgid "Shipping"
 msgstr "Versand"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Versanddatum"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Versanddatum fehlt!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr "Versandaufkleber"
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7059,12 +7064,12 @@ msgstr "Einige"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7145,11 +7150,11 @@ msgstr "Anfangsdatum"
 msgid "Starting Date:"
 msgstr "Anfangsdatum:"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Bundesland"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7233,7 +7238,7 @@ msgstr "Eingereichen"
 msgid "Submitted"
 msgstr "Eingereicht"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7296,8 +7301,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Kennzeichen"
 
@@ -7319,7 +7324,7 @@ msgstr "Steuer"
 msgid "Tax Account"
 msgstr "Steuerkonto"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Steuernummer"
 
@@ -7329,7 +7334,7 @@ msgstr "Steuernummer"
 msgid "Tax Form"
 msgstr "Steuerformular"
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Steuerformular angewandt"
 
@@ -7353,7 +7358,7 @@ msgstr "Steuerformulare"
 msgid "Tax Forms"
 msgstr "Steuerform"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "Steuernummer"
 
@@ -7361,7 +7366,7 @@ msgstr "Steuernummer"
 msgid "Tax ID/SSN"
 msgstr "Steuernummer/Sozialversicherungsnummer"
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Mit Steuer"
@@ -7460,7 +7465,7 @@ msgstr "Vorlage"
 msgid "Template Listing"
 msgstr "Vorlagenauflistung"
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Vorlage gespeichert!"
 
@@ -7682,7 +7687,7 @@ msgstr "Zeiten"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7717,7 +7722,7 @@ msgstr "Bis Datum"
 msgid "To Pay"
 msgstr "Zu bezahlen"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Zu Warenlager"
 
@@ -7763,7 +7768,7 @@ msgstr "Höchststufe"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7784,7 +7789,7 @@ msgstr "Höchststufe"
 msgid "Total"
 msgstr "Gesamtsumme"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Summe Gesamtabschreibungen"
 
@@ -7796,6 +7801,10 @@ msgstr "Total ausstehend"
 msgid "Total Paid"
 msgstr "Gesamtzahlbetrag"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Verfolgen von Artikeln"
@@ -7804,7 +7813,7 @@ msgstr "Verfolgen von Artikeln"
 msgid "Trade Discount"
 msgstr "Handelsrabatt"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Transaktion"
 
@@ -7837,20 +7846,20 @@ msgstr "Transaktionstyp"
 msgid "Transactions"
 msgstr "Transaktion"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Ãœbergabe"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "InventarÃ¼bertrag"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Ãœbergabe von"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Ãœbergabe an"
 
@@ -7937,7 +7946,7 @@ msgstr "zwei"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7998,7 +8007,7 @@ msgstr "Einzigartige nicht veraltete Teilnummer"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -8014,7 +8023,7 @@ msgstr "Einzelpreis"
 msgid "Unknown "
 msgstr "Unbekannt"
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -8032,7 +8041,7 @@ msgstr "Unbekannter Diagrammtyp; sollte H(eader)/A(ccount) sein"
 msgid "Unknown database found."
 msgstr "Unbekannte Datenbank gefunden."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8084,20 +8093,20 @@ msgstr "unbenutzt"
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Aktualisiert"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8159,7 +8168,7 @@ msgstr "Benutze Forderungen Überzahlung"
 msgid "Use Overpayment"
 msgstr "Überzahlung nutzen"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr "Verwenden Sie die Lieferadresse"
 
@@ -8245,8 +8254,8 @@ msgstr "Unterschied:"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8265,7 +8274,7 @@ msgstr "Lieferantenkonto"
 msgid "Vendor History"
 msgstr "Alle Belege für Lieferant"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Lieferantenrechnung"
@@ -8281,7 +8290,7 @@ msgstr "Lieferantenname"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8304,7 +8313,7 @@ msgstr "Lieferantenreferenznummer"
 msgid "Vendor Search"
 msgstr "Lieferantensuche"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Lieferant fehlt!"
 
@@ -8341,7 +8350,7 @@ msgstr "Löhne und Abzüge"
 msgid "Wages/Deductions"
 msgstr "LÃ¶hne/Absetzungen"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8418,7 +8427,7 @@ msgstr "Willkommen bei LedgerSMB"
 msgid "What is LedgerSMB"
 msgstr "Was ist LedgerSMB"
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Welche Artikelart ist es?"
 
@@ -8434,7 +8443,7 @@ msgstr "Ganzer Monat geradlinig"
 msgid "Widgit Themes"
 msgstr "Widgit Themen"
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8492,7 +8501,7 @@ msgstr "Jahresabschluss beendet"
 msgid "Years"
 msgstr "Jahre"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
@@ -8513,11 +8522,11 @@ msgstr "Postleitzahl"
 msgid "Zero"
 msgstr "Null"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Postleitzahl"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Postleitzahl"
 
@@ -8586,7 +8595,7 @@ msgstr "Bankkontenabgleich"
 msgid "bug"
 msgstr "Fehler"
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "Stadt"
 
@@ -8630,7 +8639,7 @@ msgstr "Erledigt"
 msgid "e"
 msgstr "e"
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "ea"
 

--- a/locale/po/de_CH.po
+++ b/locale/po/de_CH.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: German (Switzerland) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/de_CH/)\n"
@@ -187,7 +187,7 @@ msgstr "Verzicht"
 msgid "Access Denied"
 msgstr "Zugriff verweigert"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr "Zugriff verweigert: Falscher Benutzername oder Passwort"
 
@@ -195,9 +195,9 @@ msgstr "Zugriff verweigert: Falscher Benutzername oder Passwort"
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -205,7 +205,7 @@ msgstr "Zugriff verweigert: Falscher Benutzername oder Passwort"
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -316,7 +316,7 @@ msgstr "Rückstellung"
 msgid "Accrual Basis:"
 msgstr "Periodenabgrenzung:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Summierte Abschreibungen"
 
@@ -425,7 +425,7 @@ msgstr "Lastschrift hinzufügen"
 msgid "Add Employee"
 msgstr "Arbeitnehmer erfassen"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Wechselkurs erfassen"
 
@@ -461,11 +461,11 @@ msgstr "Ware erfassen"
 msgid "Add Pricegroup"
 msgstr "Preisgruppe erfassen"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Einkaufsbeleg erfassen"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Offerte erstellen"
 
@@ -473,7 +473,7 @@ msgstr "Offerte erstellen"
 msgid "Add Reporting Unit"
 msgstr "Berichtseinheit hinzufügen"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Offertanfrage"
 
@@ -485,11 +485,11 @@ msgstr "Rücknahme hinzufügen"
 msgid "Add SIC"
 msgstr "Euro-SIC erfassen"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Ausgangsrechnung erfassen"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Auftragsbestätigung"
 
@@ -505,7 +505,7 @@ msgstr "Steuererklärung hinzufügen"
 msgid "Add Timecard"
 msgstr "Zeitkarte hinzufügen"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Zur Liste hinzufügen"
 
@@ -527,7 +527,7 @@ msgstr "Benutzer erfassen"
 msgid "Add Vendor"
 msgstr "Lieferant erfassen"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Einkaufsrechnung erfassen"
 
@@ -539,15 +539,15 @@ msgstr "Lieferantenrückgabe hinzufügen"
 msgid "Add Warehouse"
 msgstr "Warenlager erfassen"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Zeile 1 hinzufügen"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Zeile 2 hinzufügen"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Zeile 3 hinzufügen"
 
@@ -575,8 +575,8 @@ msgstr "id [_1] hinzugefügt"
 msgid "Adding"
 msgstr "Hinzufügen"
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -608,7 +608,7 @@ msgstr "Anp"
 msgid "Adjusted"
 msgstr "Justiert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Angepasste Basis"
 
@@ -685,9 +685,9 @@ msgstr "Erlaubte Eingabe"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -798,8 +798,8 @@ msgstr "Freigabestatus"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Genehmigen"
@@ -837,20 +837,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Kaufwert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Verbleibender Kaufwert"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Soll die Bestellung mit folgender Nummer wirklich gelöscht werden:"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Soll die Offerte mit folgender Nummer wirklich gelöscht werden:"
 
@@ -923,16 +923,16 @@ msgstr "Anlagenkennzeichnung"
 msgid "Assets"
 msgstr "Aktiven"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Anlage zu Eigenkapital"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr "Anlage zu Verbindlichkeiten"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Anhängen"
@@ -963,31 +963,31 @@ msgstr "Angehängt bei"
 msgid "Attached By"
 msgstr "Angehängt von"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Angehängt an"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Angehängt an Typ"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Angehängte und verknüpfte Dateien"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Angehängt an"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Angehängt von"
@@ -1020,7 +1020,7 @@ msgstr "August"
 msgid "Author: [_1]"
 msgstr "Autor: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatisch"
 
@@ -1089,7 +1089,7 @@ msgid "Balance"
 msgstr "Bilanz"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilanz"
@@ -1136,8 +1136,8 @@ msgstr "Basiswährung"
 msgid "Base system"
 msgstr "Basissystem"
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basis"
 
@@ -1149,7 +1149,7 @@ msgstr "Posten"
 msgid "Batch Class"
 msgstr "Postenklasse"
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr "Posten Kontroll Nummer"
 
@@ -1169,7 +1169,7 @@ msgstr "Posten Nr"
 msgid "Batch ID Missing"
 msgstr "Posten Nr. fehlt"
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr "Stapelname"
 
@@ -1216,14 +1216,14 @@ msgstr "Billion"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Lagerort"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1323,7 +1323,7 @@ msgstr "Umsatzkosten Lots Bericht"
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Steuern berechnen"
 
@@ -1331,12 +1331,12 @@ msgstr "Steuern berechnen"
 msgid "Can't post credits and debits on one line."
 msgstr "Guthaben und Lastschriften können nicht in einer Zeile gebucht werden."
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Eine stornierte Rechnung kann nicht storniert werden!"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1391,7 +1391,7 @@ msgstr "Dienstleistung kann nicht angelegt werden; Konto existiert nicht!"
 msgid "Cannot delete item!"
 msgstr "Artikel kann nicht gelöscht werden!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Bestellung kann nicht gelöscht werden!"
 
@@ -1399,22 +1399,22 @@ msgstr "Bestellung kann nicht gelöscht werden!"
 msgid "Cannot delete posted transaction"
 msgstr "Buchung konnte nicht gelöscht werden"
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Offerte kann nicht gelöscht werden!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 "Rechnung kann nicht gebucht werden, weil die Periode bereits abgeschlossen "
 "inst!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 "Zahlung kann nicht gebucht werden, weil die Periode bereits abgeschlossen ist!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 "Buchung kann nicht erfasst werden, weil die Periode bereits abgeschlossen ist!"
@@ -1426,15 +1426,15 @@ msgstr ""
 "Sie können eine Buchung mit Aktiva und Passiva nicht auf das selbe Konto "
 "buchen!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Rechnung kann nicht gebucht werden!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Bestellung kann nicht gespeichert werden!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Offerte kann nicht gespeichert werden!"
 
@@ -1454,7 +1454,8 @@ msgstr "ID Karte"
 msgid "Cash"
 msgstr "vereinnahmt"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Kassenkonto"
 
@@ -1515,7 +1516,7 @@ msgid "Chord"
 msgstr "Akkord"
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1634,7 +1635,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firmenname"
 
@@ -1667,7 +1668,7 @@ msgstr "Firmentelefon"
 msgid "Company Sales Tax ID"
 msgstr "Firmensteuernummer"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr "Firma existiert nicht"
 
@@ -1719,7 +1720,7 @@ msgstr "Lagerhäuser konfigurieren"
 msgid "Confirm Operation"
 msgstr "Vorgang bestätigen"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Bestätigen Sie!"
 
@@ -1729,7 +1730,7 @@ msgstr ""
 "Konflikt mit bestehenden Daten.  Möglicherweise haben Sie diese Angabe "
 "bereits gemacht?"
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1772,8 +1773,8 @@ msgstr "Inhalt"
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1784,7 +1785,7 @@ msgstr "Inhalt"
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1837,7 +1838,7 @@ msgid "Copy to New Name"
 msgstr "Zu einem neuen Namen kopieren"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Kosten"
 
@@ -1849,19 +1850,19 @@ msgstr "Kosten der verkauften GÃ¼ter"
 msgid "Could Not Load Template from DB"
 msgstr "Die Template von der Datenbank konnte nicht geladen werden"
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr "Die Verbindung zum Server konnte nicht hergestellt werden"
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Daten konnten nicht gespeichert werden.  Bitte versuchen Sie es erneut"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Konnte nicht gespeichert werden!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Inventar wurde nicht übertragen!"
 
@@ -1881,8 +1882,8 @@ msgstr "Kontrahentcode"
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1946,7 +1947,7 @@ msgstr "Erstellt am"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Haben"
 
@@ -1967,7 +1968,7 @@ msgstr "Kundenkreditkonto"
 msgid "Credit Invoice"
 msgstr "Credit Invoice"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1991,7 +1992,7 @@ msgstr "Haben"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Währung"
 
@@ -2000,7 +2001,7 @@ msgstr "Währung"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2037,7 +2038,7 @@ msgstr "Benutzerdefinierte Markierungen"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2067,7 +2068,7 @@ msgstr "Kundenname"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2080,7 +2081,7 @@ msgstr "Kundennummer"
 msgid "Customer Search"
 msgstr "Kunden suchen"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Kundenname fehlt!"
 
@@ -2096,7 +2097,7 @@ msgstr "Kunde ist nicht in der Datenbank!"
 msgid "Customer/Vendor Accounts"
 msgstr "Kunden/Lieferant Konto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr "T M"
 
@@ -2120,7 +2121,7 @@ msgstr "Daten aus Ihrem Kontoauszug."
 msgid "Data from your ledger"
 msgstr "Daten aus dem Hauptbuch"
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Daten nicht gespeichert.  Bitte erneut versuchen."
 
@@ -2169,7 +2170,7 @@ msgstr "Datenbank existiert nicht."
 msgid "Database exists."
 msgstr "Datenbank existiert."
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr "Datenbankversion stimmt nicht überein"
 
@@ -2184,11 +2185,11 @@ msgstr "Datenbankversion stimmt nicht überein"
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2226,7 +2227,7 @@ msgstr "Zahlungsdatum"
 msgid "Date Range"
 msgstr "Datumsbereich"
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Eingangsdatum"
 
@@ -2250,7 +2251,7 @@ msgstr "Datum von"
 msgid "Date of Birth"
 msgstr "Geburtsdatum"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Eingangsdatum fehlt!"
 
@@ -2296,7 +2297,7 @@ msgstr "Tage"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Soll"
 
@@ -2409,9 +2410,9 @@ msgstr "Definierte Wechselkurstypen"
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2461,16 +2462,16 @@ msgstr "Lieferung"
 msgid "Delivery Date"
 msgstr "Lieferdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Abschreibungsbasis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Abschreibungsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Abschreibungsbeginn"
 
@@ -2478,11 +2479,11 @@ msgstr "Abschreibungsbeginn"
 msgid "Dep. Through"
 msgstr "Abschreiben bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Abschreibungen YTD"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Abschreibungen in dieser Periode"
 
@@ -2504,7 +2505,7 @@ msgstr "Abschreibung"
 msgid "Depreciate Through"
 msgstr "Abschreiben bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Abschreibung"
@@ -2556,13 +2557,13 @@ msgstr "Abschreibungsbeginn"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2579,7 +2580,7 @@ msgstr "Abschreibungsbeginn"
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2650,16 +2651,16 @@ msgstr "Rabatt (%)"
 msgid "Discount:"
 msgstr "Rabatt:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Durch Abgänge erzielte Werte"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Abgabe"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Zeitpunkt der Veräusserung"
 
@@ -2667,7 +2668,7 @@ msgstr "Zeitpunkt der Veräusserung"
 msgid "Disposal Method"
 msgstr "Veräusserungsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten Abgängen [_1] am Datum [_2]"
 
@@ -2675,7 +2676,7 @@ msgstr "Bericht zu geteilten Abgängen [_1] am Datum [_2]"
 msgid "Division by 0 error"
 msgstr "Division durch 0 Fehler"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr "Feld nicht leer lassen [_1]"
 
@@ -2691,7 +2692,7 @@ msgstr "Dokumententyp"
 msgid "Don't know what to do with backup"
 msgstr "Unklar was mit Sicherungskopie geschehen soll"
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Fertig"
 
@@ -2711,7 +2712,7 @@ msgstr "Herunterladen:"
 msgid "Dr."
 msgstr "Dr."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Entwurf gebucht"
 
@@ -2753,14 +2754,14 @@ msgstr "Fällig"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fälligkeitsdatum"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Fälligkeitsdatum fehlt!"
 
@@ -2772,8 +2773,8 @@ msgstr "Doppelter Benutzer gefunden: Benutzer wird importiert"
 msgid "Duplicate employee numbers"
 msgstr "Doppelte Mitarbeiternummer"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-Mail"
 
@@ -3077,11 +3078,11 @@ msgstr "Entität"
 msgid "Entity Class"
 msgstr "Entitätsklasse"
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "Entitätscode"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "Entität Kontrollnummer"
 
@@ -3097,7 +3098,7 @@ msgstr "Entitätsname"
 msgid "Entry ID"
 msgstr "Eintragungs ID"
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "Umschlag"
@@ -3119,7 +3120,7 @@ msgstr "Eigenkapital und Verbindlichkeiten"
 msgid "Equity (Temporary)"
 msgstr "Eigenkapital (temporär)"
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr "Eigenkapital zu Verbindlichkeiten"
 
@@ -3144,7 +3145,7 @@ msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 "Fehler: Saldenzusammenfassung konnte nicht ins Aufklappmenü eingefügt werden"
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Geschätzte Lebensdauer"
 
@@ -3152,20 +3153,20 @@ msgstr "Geschätzte Lebensdauer"
 msgid "Every"
 msgstr "Jeden"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Wkurs."
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Wechselkurs"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Wechselkurs für Bezahlung fehlt!"
 
@@ -3173,7 +3174,7 @@ msgstr "Wechselkurs für Bezahlung fehlt!"
 msgid "Exchange rate hasn't been defined!"
 msgstr "Wechselkurs wurde nicht definiert!"
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Wechselkurs fehlt!"
 
@@ -3218,8 +3219,8 @@ msgstr "Extra gebraucht"
 msgid "FAQ"
 msgstr "FAQ"
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3297,7 +3298,7 @@ msgstr "fünfzig"
 msgid "File"
 msgstr "Datei"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Datei importiert"
 
@@ -3311,17 +3312,17 @@ msgstr "Dateiname"
 msgid "File Type"
 msgstr "Dateityp"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Dateiname"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Dateityp"
@@ -3358,7 +3359,7 @@ msgstr "Erst"
 msgid "First Name"
 msgstr "Vorname"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr "Erste Spalte nur"
 
@@ -3418,7 +3419,7 @@ msgstr "vierzehn"
 msgid "Fri"
 msgstr "Fr."
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3450,7 +3451,7 @@ msgstr "Datum vom"
 msgid "From File"
 msgstr "Aus Datei"
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Vom Lagerhaus"
 
@@ -3499,7 +3500,7 @@ msgstr "Hauptbuchreferenz"
 msgid "Gain"
 msgstr "Gewinn"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Gewinn (Verlust)"
 
@@ -3507,7 +3508,7 @@ msgstr "Gewinn (Verlust)"
 msgid "Gain Account"
 msgstr "Gewinnkonto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr "Gewinn/Verlust"
 
@@ -3536,11 +3537,11 @@ msgstr "Erzeugen"
 msgid "Generate Control Code"
 msgstr "Kontrolnummer erstellen"
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Aufträge erstellen"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Bestellungen erstellen"
 
@@ -3585,8 +3586,8 @@ msgid "Grand Total"
 msgstr "Gesamtsumme"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Warengruppe"
 
@@ -3832,8 +3833,8 @@ msgstr "Interner Datenbankenfehler"
 msgid "Internal Files"
 msgstr "Interne Dateien"
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Interne Notizen"
 
@@ -3896,11 +3897,11 @@ msgstr ""
 "Bevor dieses Erzeugnis als ungültig markiert werden kann muß das Teil auf "
 "Null sein!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventar gespeichert!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventar übertragen"
 
@@ -3908,8 +3909,8 @@ msgstr "Inventar übertragen"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3927,22 +3928,22 @@ msgstr "Rechnung"
 msgid "Invoice #"
 msgstr "Rechnung #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Rechnung erstellt"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Rechnungserstellt"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Rechnungsdatum"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Rechnungsdatum fehlt!"
 
@@ -3958,8 +3959,8 @@ msgstr "Rechnungsnr."
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3968,7 +3969,7 @@ msgstr "Rechnungsnr."
 msgid "Invoice Number"
 msgstr "Rechnungsnummer"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Rechnungsnummer fehlt!"
 
@@ -4026,7 +4027,7 @@ msgstr "Pos"
 msgid "Item deleted!"
 msgstr "Artikel gelöscht!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Dieser Artikel ist nicht in der Datenbank!"
 
@@ -4060,7 +4061,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Januar"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr "JavaScript-Fehler:"
 
@@ -4101,7 +4102,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr "Verhältnisse"
 
@@ -4165,7 +4166,7 @@ msgstr "Letzte Aktualisierung"
 msgid "Last name"
 msgstr "Nachname"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Anlaufzeit"
 
@@ -4394,11 +4395,11 @@ msgstr "Gesperrt von [_1]"
 msgid "Logged out due to inactivity"
 msgstr "Wegen Inaktivität abgemeldet"
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr "Anmelden... Bitte warten Sie."
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Benutzername"
 
@@ -4477,7 +4478,7 @@ msgstr "Geschäftsführer"
 msgid "Manager:"
 msgstr "Manager:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Manuell"
 
@@ -4508,9 +4509,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Notiz"
@@ -4863,15 +4864,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4885,15 +4886,15 @@ msgstr "Bemerkungen"
 msgid "Notes:<br />"
 msgstr "Notizen:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Es wurde nichts eingegeben!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Es wurde nichts ausgewählt!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Es gibt nichts zu übertragen!"
 
@@ -4918,7 +4919,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4937,7 +4938,7 @@ msgstr "Artikelnummer"
 msgid "Number Format"
 msgstr "Zahlenformat"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr "Nummer fehlt in Reihe [_1]"
 
@@ -4975,7 +4976,7 @@ msgstr "Okt"
 msgid "October"
 msgstr "Oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr "Warten"
 
@@ -4990,7 +4991,7 @@ msgstr "Altes Passwort"
 msgid "On Hand"
 msgstr "am Lager"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "In Warteschleife"
@@ -5045,7 +5046,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Bestellung"
 
@@ -5063,12 +5064,12 @@ msgstr "Bestellung #"
 msgid "Order By"
 msgstr "Sortieren nach"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Bestelldatum"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Bestelldatum fehlt!"
 
@@ -5080,8 +5081,8 @@ msgstr "Bestellungen"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5089,15 +5090,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Bestellnummer"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Bestellnummer fehlt!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Bestellung gelöscht!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Auftragserstellung fehlgeschlagen!"
 
@@ -5184,8 +5185,8 @@ msgstr "Best. #"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5201,7 +5202,7 @@ msgstr "BUCHEN"
 msgid "POST AND PRINT"
 msgstr "BUCHEN UND DRUCKEN"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5209,11 +5210,11 @@ msgstr "BUCHEN UND DRUCKEN"
 msgid "Packing List"
 msgstr "Packliste"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Verpackungslisten-Datum fehlt!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Verpackungslistennummer fehlt!"
 
@@ -5237,7 +5238,7 @@ msgstr "Bezahlt"
 msgid "Parent"
 msgstr "VorgÃ¤nger"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artikel"
 
@@ -5257,8 +5258,8 @@ msgstr "Teilegruppe"
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5279,7 +5280,7 @@ msgstr "Teildetails"
 msgid "Partial"
 msgstr "Teilweise"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Bericht zu geteilten AbgÃ¤ngen [_1] am Datum [_2]"
 
@@ -5309,7 +5310,7 @@ msgstr "Teilegruppen"
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Passwort"
 
@@ -5378,7 +5379,7 @@ msgstr "Zahlungsart"
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Zahlungsdatum fehlt!"
 
@@ -5390,7 +5391,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5399,7 +5400,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Zahlungen"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 "Zahlungen aus stornierten Rechnungen mÃ¼ssen mÃ¶glicherweise rÃ¼ckÃ¼berwiesen "
@@ -5409,11 +5410,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Prozent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "VerÃ¤usserungen in Prozent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Prozent verbleibend"
 
@@ -5448,7 +5449,7 @@ msgstr "Tel."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5579,8 +5580,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Buchen"
@@ -5597,7 +5598,7 @@ msgstr "Datum einfÃ¼gen"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Als neu buchen"
 
@@ -5692,9 +5693,9 @@ msgid "Primary Phone"
 msgstr "Primäres Telefon"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Drucken"
@@ -5703,11 +5704,11 @@ msgstr "Drucken"
 msgid "Print Batch"
 msgstr "Stapel drucken"
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Drucken und speichern"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Drucken und als neu speichern"
 
@@ -5759,15 +5760,15 @@ msgstr "Drucken von Transaktion [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Drucken von Arbeitsauftrags [_1]"
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "GetÃ¤tigte Abschreibungen"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Bis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "ErtrÃ¤ge"
 
@@ -5789,7 +5790,7 @@ msgstr "Produktbeleg"
 msgid "Profit and Loss"
 msgstr "Gewinn und Verlust"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Gewinn/Verlust"
 
@@ -5832,8 +5833,8 @@ msgstr "Kaufdatum:"
 msgid "Purchase History"
 msgstr "Kaufhistorie"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5872,7 +5873,7 @@ msgstr "Gekauft"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5902,8 +5903,8 @@ msgid "Quarter"
 msgstr "Quartal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5919,7 +5920,7 @@ msgstr "Kostenvoranschlag #"
 msgid "Quotation Date"
 msgstr "Offertendatum"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Offertendatum fehlt!"
 
@@ -5927,11 +5928,11 @@ msgstr "Offertendatum fehlt!"
 msgid "Quotation Number"
 msgstr "Offertenummer"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Offertenummer fehlt!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Offerte gelöscht!"
 
@@ -5946,7 +5947,7 @@ msgstr "Offerten"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5972,7 +5973,7 @@ msgstr "Offerteanfragen"
 msgid "ROP"
 msgstr "Lagerbestand Untergrenze"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -6013,7 +6014,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Erh"
 
@@ -6042,7 +6043,7 @@ msgstr "Forderungen"
 msgid "Receive"
 msgstr "Einlagern"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Artikeln einlagern"
 
@@ -6070,7 +6071,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr "Kontenabgleichsberichte"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Buchen auf"
 
@@ -6096,11 +6097,11 @@ msgstr "Wiederkehrende Buchungen"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referenz"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr "Referenznummer fehlt"
 
@@ -6137,9 +6138,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Restnutzdauer"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Rest"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6167,7 +6172,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Berichtsname"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Berichtsergebnisse"
 
@@ -6179,7 +6184,7 @@ msgstr "Bericht eingereicht"
 msgid "Report Type"
 msgstr "Berichtstyp"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr "Bericht [_1] am [_2]"
 
@@ -6215,11 +6220,11 @@ msgstr "Berichte"
 msgid "Reposting Not Allowed"
 msgstr "Umbuchen nicht erlaubt"
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ben."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6340,11 +6345,11 @@ msgstr "Euro-SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "Lagerhaltungseinheit"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr "Kundenauftragsnummer"
 
@@ -6373,7 +6378,7 @@ msgstr "Verkauf"
 msgid "Sales"
 msgstr "Warenverkauf"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Ausgangsrechnung"
@@ -6382,8 +6387,8 @@ msgstr "Ausgangsrechnung"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Verkaufsrechnung-/Buchungsnummer"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6448,7 +6453,7 @@ msgstr "Sat"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6493,7 +6498,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr "Gruppen speichern"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Standort speichern"
 
@@ -6501,7 +6506,7 @@ msgstr "Standort speichern"
 msgid "Save New"
 msgstr "Neu speichern"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6518,7 +6523,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "als neu speichern"
@@ -6527,7 +6532,7 @@ msgstr "als neu speichern"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6565,7 +6570,7 @@ msgstr "Speichern [_1] [_2]"
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6578,12 +6583,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Buchungstermine"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "geplant"
 
@@ -6724,11 +6729,11 @@ msgstr "Kunde auswählen"
 msgid "Select Templates to Load"
 msgstr "Wähle Vorlage aus"
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Lieferant auswählen"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Drucker auswählen!"
 
@@ -6748,12 +6753,12 @@ msgstr "Wähle Rechnung aus"
 msgid "Select or Enter User"
 msgstr "Wähle aus oder gebe Benutzer an"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Postscript oder PDF auswählen!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Text, Postscript oder PDF auswählen!"
 
@@ -6844,7 +6849,7 @@ msgstr "Sequenzen"
 msgid "Serial #"
 msgstr "Serien #"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Seriennummer"
 
@@ -6862,11 +6867,11 @@ msgstr "Seriennummer"
 msgid "Serialnumber"
 msgstr "Seriennummer"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Dienstleistung"
 
@@ -6910,13 +6915,13 @@ msgstr "siebzehn"
 msgid "Seventy"
 msgstr "siebzig"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Versenden"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Waren versenden"
 
@@ -6946,12 +6951,12 @@ msgstr "Lieferadresse:"
 msgid "Ship Via"
 msgstr "Versand durch"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Lieferung an"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6968,23 +6973,23 @@ msgstr "Versandart"
 msgid "Shipping"
 msgstr "Versand"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Versanddatum"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Versanddatum fehlt!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr "Versandaufkleber"
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7060,12 +7065,12 @@ msgstr "Einige"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7146,11 +7151,11 @@ msgstr "Anfangsdatum"
 msgid "Starting Date:"
 msgstr "Anfangsdatum:"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Zustand"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7234,7 +7239,7 @@ msgstr "Eingereichen"
 msgid "Submitted"
 msgstr "Eingereicht"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7297,8 +7302,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Kennzeichen"
 
@@ -7320,7 +7325,7 @@ msgstr "MWST"
 msgid "Tax Account"
 msgstr "MWST-Konto"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Steuernummer"
 
@@ -7330,7 +7335,7 @@ msgstr "Steuernummer"
 msgid "Tax Form"
 msgstr "Steuerformular"
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Steuerformular angewandt"
 
@@ -7354,7 +7359,7 @@ msgstr "Steuerformulare"
 msgid "Tax Forms"
 msgstr "Steuerformular"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "Steuernummer"
 
@@ -7362,7 +7367,7 @@ msgstr "Steuernummer"
 msgid "Tax ID/SSN"
 msgstr "Steuernummer/Sozialversicherungsnummer"
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "MWST im Preis enthalten"
@@ -7461,7 +7466,7 @@ msgstr "Vorlage"
 msgid "Template Listing"
 msgstr "Vorlagenauflistung"
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Vorlage gespeichert!"
 
@@ -7683,7 +7688,7 @@ msgstr "mal"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7718,7 +7723,7 @@ msgstr "Bis Datum"
 msgid "To Pay"
 msgstr "Zu bezahlen"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Zum Lager"
 
@@ -7764,7 +7769,7 @@ msgstr "Höchststufe"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7785,7 +7790,7 @@ msgstr "Höchststufe"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Summe Gesamtabschreibungen"
 
@@ -7797,6 +7802,10 @@ msgstr "Total ausstehend"
 msgid "Total Paid"
 msgstr "Gesamtzahlbetrag"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Lagernde Artikel"
@@ -7805,7 +7814,7 @@ msgstr "Lagernde Artikel"
 msgid "Trade Discount"
 msgstr "Handelsrabatt"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Buchung"
 
@@ -7838,20 +7847,20 @@ msgstr "Transaktionstyp"
 msgid "Transactions"
 msgstr "Buchungen"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Übertrag"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Inventarübertrag"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "umlagern von"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Übergabe an"
 
@@ -7938,7 +7947,7 @@ msgstr "zwei"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7999,7 +8008,7 @@ msgstr "Einzigartige nicht veraltete Teilnummer"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -8015,7 +8024,7 @@ msgstr "Preis pro Einheit"
 msgid "Unknown "
 msgstr "Unbekannt"
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -8033,7 +8042,7 @@ msgstr "Unbekannter Diagrammtyp; sollte H(eader)/A(ccount) sein"
 msgid "Unknown database found."
 msgstr "Unbekannte Datenbank gefunden."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8085,20 +8094,20 @@ msgstr "unbenutzt"
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Erneuern"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Erneuert am"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8160,7 +8169,7 @@ msgstr "Nutzen von Forderungen Überzahlung"
 msgid "Use Overpayment"
 msgstr "Überzahlung nutzen"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr "Verwenden Sie die Lieferadresse"
 
@@ -8246,8 +8255,8 @@ msgstr "Unterschied:"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8266,7 +8275,7 @@ msgstr "Lieferantenkonto"
 msgid "Vendor History"
 msgstr "Alle Belege für Lieferant"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Einkaufsrechnung"
@@ -8282,7 +8291,7 @@ msgstr "Lieferantenname"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8305,7 +8314,7 @@ msgstr "Lieferantenreferenznummer"
 msgid "Vendor Search"
 msgstr "Lieferantensuche"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Lieferant fehlt!"
 
@@ -8342,7 +8351,7 @@ msgstr "Löhne und Abzüge"
 msgid "Wages/Deductions"
 msgstr "LÃ¶hne/Absetzungen"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8419,7 +8428,7 @@ msgstr "Willkommen bei LedgerSMB"
 msgid "What is LedgerSMB"
 msgstr "Was ist LedgerSMB"
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Welche Artikelart ist das?"
 
@@ -8435,7 +8444,7 @@ msgstr "Ganzer Monat geradlinig"
 msgid "Widgit Themes"
 msgstr "Widgit Themen"
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8493,7 +8502,7 @@ msgstr "Jahresabschluss beendet"
 msgid "Years"
 msgstr "Jahre"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
@@ -8514,11 +8523,11 @@ msgstr "Postleitzahl"
 msgid "Zero"
 msgstr "Null"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Postleitzahl"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Postleitzahl"
 
@@ -8587,7 +8596,7 @@ msgstr "Bankkontenabgleich"
 msgid "bug"
 msgstr "Fehler"
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "Stadt"
 
@@ -8631,7 +8640,7 @@ msgstr "fertig"
 msgid "e"
 msgstr "e"
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "pro"
 

--- a/locale/po/el.po
+++ b/locale/po/el.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Greek (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "el/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr "Αύξηση"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Προσθήκη υπαλλήλου"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Προσθήκη τιμής συναλάγματος"
 
@@ -458,11 +458,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Προσθήκη προσφοράς"
 
@@ -470,7 +470,7 @@ msgstr "Προσθήκη προσφοράς"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Προσθήκη Τιμολογίου πώλησης"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Προσθήκη Παραγγελίας"
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Προσθήκη χρήστη"
 msgid "Add Vendor"
 msgstr "Προσθήκη Πιστωτή"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Add Creditor Invoice"
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Προσθήκη Αποθήκης"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "Απρ"
 msgid "April"
 msgstr "Απρίλιος"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Είσαι σίγουρος πως θέλεις να διαγράψεις τον αριθμό παραγγελίας"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "Αύγουστος"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "Ισοζύγιο"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Ισοζύγιο"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Δεν μπορεί να διαγραφεί η παραγγελία"
 
@@ -1383,19 +1383,19 @@ msgstr "Δεν μπορεί να διαγραφεί η παραγγελία"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Δεν μπορεί να αποθηκευτεί η παραγγελία"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Ρευστά"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Εταιρία"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Επιβεβαίωση!"
 
@@ -1702,7 +1703,7 @@ msgstr "Επιβεβαίωση!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Κόστος"
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Η αποθήκευση δεν είναι δυνατή"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Πίστωση"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr "Κωδικός Πελάτη"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Ο Πελάτης λείπει!"
 
@@ -2065,7 +2066,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "Ημ. Πληρωμής"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Χρέος"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Εντάξει"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Ημερομηνία λήξης"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Η ημερομηνία λήξης λείπει"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Συναλλ"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Τιμή συναλλάγματος"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Η τιμή συναλλάγματος λείπει"
 
@@ -3139,7 +3140,7 @@ msgstr "Η τιμή συναλλάγματος λείπει"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Ομάδα"
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Η Απογραφή αποθηκεύτηκε"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "Τιμολόγιο"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Ημ. τιμολογίου"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Αρ. τιμολογίου"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Το τιμολόγιο διαγράφηκε"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Το τεμάχιο διαγράφηκε"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Τεμάχιο δεν είναι σε αρχείο"
 
@@ -4011,7 +4012,7 @@ msgstr "Ιάν"
 msgid "January"
 msgstr "Ιανουάριος"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "Ιούν"
 msgid "June"
 msgstr "Ιούνιος"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Εισαγωγή"
 
@@ -4418,7 +4419,7 @@ msgstr "Διευθυντής"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "Μάϊος"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "Σημειώσεις"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Δεν εχει γίνει εισαγωγή"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Δεν έχε επιλεχθεί τίποτα"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "Αριθμός"
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "Οκτ"
 msgid "October"
 msgstr "Οκτώβριος"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Παραγγελία"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ημ. Παραγγελίας"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5015,8 +5016,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Αρ. Παραγγελίας"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Η Παραγγελία διαγράφηκε"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5172,7 +5173,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr "Τηλέφωνο"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Εκτύπωση"
@@ -5636,11 +5637,11 @@ msgstr "Εκτύπωση"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Εκτύπωση και αποθήκευση"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,8 +6071,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr "Πώληση"
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6315,8 +6320,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6460,7 +6465,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Υπηρεσία"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "Φόρος"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Creditor Invoice"
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Creditor missing!"
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/en.po
+++ b/locale/po/en.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2022-01-09T21:20:15.970Z\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -191,9 +191,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -201,7 +201,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -312,7 +312,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -457,11 +457,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -469,7 +469,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -481,11 +481,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -501,7 +501,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -523,7 +523,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr ""
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -535,15 +535,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -571,8 +571,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -681,9 +681,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -786,8 +786,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -825,20 +825,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr ""
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -911,16 +911,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -951,31 +951,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1124,8 +1124,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1204,14 +1204,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1319,12 +1319,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1382,19 +1382,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1403,15 +1403,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1431,7 +1431,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1492,7 +1493,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1608,7 +1609,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1641,7 +1642,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1693,7 +1694,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1701,7 +1702,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1744,8 +1745,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1756,7 +1757,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1805,7 +1806,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1817,19 +1818,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1849,8 +1850,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1914,7 +1915,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1935,7 +1936,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1959,7 +1960,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1968,7 +1969,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2005,7 +2006,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2035,7 +2036,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2048,7 +2049,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2064,7 +2065,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2088,7 +2089,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2137,7 +2138,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2152,11 +2153,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2194,7 +2195,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2218,7 +2219,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2264,7 +2265,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2377,9 +2378,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2429,16 +2430,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2446,11 +2447,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2472,7 +2473,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2524,13 +2525,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2547,7 +2548,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2618,16 +2619,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2643,7 +2644,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2659,7 +2660,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2679,7 +2680,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2721,14 +2722,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2740,8 +2741,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3043,11 +3044,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3063,7 +3064,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3085,7 +3086,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3109,7 +3110,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3117,20 +3118,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3138,7 +3139,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3183,8 +3184,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3262,7 +3263,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3276,17 +3277,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3323,7 +3324,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3383,7 +3384,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3415,7 +3416,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3464,7 +3465,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3472,7 +3473,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3501,11 +3502,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3550,8 +3551,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3793,8 +3794,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3852,11 +3853,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3864,8 +3865,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3883,22 +3884,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3914,8 +3915,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3924,7 +3925,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3982,7 +3983,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4010,7 +4011,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4051,7 +4052,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4115,7 +4116,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4336,11 +4337,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4417,7 +4418,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4448,9 +4449,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4797,15 +4798,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4819,15 +4820,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4852,7 +4853,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4871,7 +4872,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4909,7 +4910,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4924,7 +4925,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4979,7 +4980,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -4997,12 +4998,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5014,8 +5015,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5023,15 +5024,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5118,8 +5119,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5135,7 +5136,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5143,11 +5144,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5171,7 +5172,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5191,8 +5192,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5213,7 +5214,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5243,7 +5244,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5312,7 +5313,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5324,7 +5325,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5333,7 +5334,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5341,11 +5342,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5380,7 +5381,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5511,8 +5512,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5529,7 +5530,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5624,9 +5625,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5635,11 +5636,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5691,15 +5692,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5721,7 +5722,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5764,8 +5765,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5804,7 +5805,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5834,8 +5835,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5851,7 +5852,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5859,11 +5860,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5878,7 +5879,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5904,7 +5905,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5945,7 +5946,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5974,7 +5975,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6002,7 +6003,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6028,11 +6029,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6069,8 +6070,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6099,7 +6104,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6111,7 +6116,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6147,11 +6152,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6272,11 +6277,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6305,7 +6310,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6314,8 +6319,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6380,7 +6385,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6425,7 +6430,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6433,7 +6438,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6450,7 +6455,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6459,7 +6464,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6497,7 +6502,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6510,12 +6515,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6656,11 +6661,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6680,12 +6685,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6776,7 +6781,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6794,11 +6799,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6842,13 +6847,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6878,12 +6883,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6900,23 +6905,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6992,12 +6997,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7078,11 +7083,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7166,7 +7171,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7229,8 +7234,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7252,7 +7257,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7262,7 +7267,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7286,7 +7291,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7294,7 +7299,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7393,7 +7398,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7613,7 +7618,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7648,7 +7653,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7694,7 +7699,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7715,7 +7720,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7727,6 +7732,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7735,7 +7744,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7768,20 +7777,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7868,7 +7877,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7929,7 +7938,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7945,7 +7954,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7963,7 +7972,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8015,20 +8024,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8090,7 +8099,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8176,8 +8185,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8196,7 +8205,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8212,7 +8221,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8235,7 +8244,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8272,7 +8281,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8349,7 +8358,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8365,7 +8374,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8423,7 +8432,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8442,11 +8451,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8513,7 +8522,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8557,7 +8566,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/en_CA.po
+++ b/locale/po/en_CA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: English (Canada) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/en_CA/)\n"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -195,9 +195,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -205,7 +205,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -461,11 +461,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -473,7 +473,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -485,11 +485,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -505,7 +505,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr "Add Creditor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -539,15 +539,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -575,8 +575,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -685,9 +685,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -790,8 +790,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -829,20 +829,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Are you sure you want to delete Order Number?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Are you sure you want to delete Quotation Number?"
 
@@ -915,16 +915,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -955,31 +955,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1081,7 +1081,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1208,14 +1208,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1323,12 +1323,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1386,19 +1386,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1407,15 +1407,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1435,7 +1435,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1496,7 +1497,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1612,7 +1613,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1645,7 +1646,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1705,7 +1706,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1748,8 +1749,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1760,7 +1761,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1809,7 +1810,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1821,19 +1822,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1853,8 +1854,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1918,7 +1919,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1939,7 +1940,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1963,7 +1964,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1972,7 +1973,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2009,7 +2010,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2039,7 +2040,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2052,7 +2053,7 @@ msgstr "Debtor Number"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Debtor missing!"
 
@@ -2068,7 +2069,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2141,7 +2142,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2156,11 +2157,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2198,7 +2199,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2222,7 +2223,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2268,7 +2269,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2381,9 +2382,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2433,16 +2434,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2450,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2476,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2528,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2551,7 +2552,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2622,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2639,7 +2640,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2663,7 +2664,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2683,7 +2684,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2725,14 +2726,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2744,8 +2745,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Email"
 
@@ -3047,11 +3048,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3067,7 +3068,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3089,7 +3090,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3113,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3121,20 +3122,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3142,7 +3143,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3187,8 +3188,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3266,7 +3267,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3280,17 +3281,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3327,7 +3328,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3387,7 +3388,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3419,7 +3420,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3468,7 +3469,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3476,7 +3477,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3505,11 +3506,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3554,8 +3555,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3797,8 +3798,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3856,11 +3857,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3868,8 +3869,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3887,22 +3888,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3918,8 +3919,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3928,7 +3929,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3986,7 +3987,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4014,7 +4015,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4055,7 +4056,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4119,7 +4120,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4340,11 +4341,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4421,7 +4422,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4452,9 +4453,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4801,15 +4802,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4823,15 +4824,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4856,7 +4857,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4875,7 +4876,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4913,7 +4914,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4928,7 +4929,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4983,7 +4984,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -5001,12 +5002,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5018,8 +5019,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5027,15 +5028,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5122,8 +5123,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5139,7 +5140,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5147,11 +5148,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5175,7 +5176,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5195,8 +5196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5217,7 +5218,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5247,7 +5248,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5316,7 +5317,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5328,7 +5329,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5337,7 +5338,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5345,11 +5346,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5384,7 +5385,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5515,8 +5516,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5533,7 +5534,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5628,9 +5629,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5639,11 +5640,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5695,15 +5696,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5726,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5768,8 +5769,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5808,7 +5809,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5838,8 +5839,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5855,7 +5856,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5863,11 +5864,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5882,7 +5883,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5908,7 +5909,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5949,7 +5950,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5978,7 +5979,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6006,7 +6007,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6032,11 +6033,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6073,8 +6074,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6103,7 +6108,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6115,7 +6120,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6151,11 +6156,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6276,11 +6281,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6309,7 +6314,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6318,8 +6323,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6384,7 +6389,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6429,7 +6434,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6437,7 +6442,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6454,7 +6459,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6463,7 +6468,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6501,7 +6506,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6514,12 +6519,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6660,11 +6665,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6684,12 +6689,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6780,7 +6785,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6798,11 +6803,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6846,13 +6851,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6882,12 +6887,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6904,23 +6909,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6996,12 +7001,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7082,11 +7087,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7170,7 +7175,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7233,8 +7238,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7256,7 +7261,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7266,7 +7271,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7290,7 +7295,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7298,7 +7303,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7397,7 +7402,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7617,7 +7622,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7652,7 +7657,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7698,7 +7703,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7719,7 +7724,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,6 +7736,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7739,7 +7748,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7772,20 +7781,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7872,7 +7881,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7933,7 +7942,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7949,7 +7958,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7967,7 +7976,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8019,20 +8028,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8094,7 +8103,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8180,8 +8189,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8200,7 +8209,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Creditor Invoice"
@@ -8216,7 +8225,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8239,7 +8248,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Creditor missing!"
 
@@ -8276,7 +8285,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8353,7 +8362,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8369,7 +8378,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8427,7 +8436,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8446,11 +8455,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8517,7 +8526,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8561,7 +8570,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/en_GB.po
+++ b/locale/po/en_GB.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Nick Prater <nick.github@npbroadcast.com>, 2018\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/ledgersmb/"
@@ -189,7 +189,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -197,9 +197,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -207,7 +207,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -427,7 +427,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -463,11 +463,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr "Add Creditor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -541,15 +541,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -577,8 +577,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -687,9 +687,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -792,8 +792,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -831,20 +831,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Are you sure you want to delete Order Number?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Are you sure you want to delete Quotation Number?"
 
@@ -917,16 +917,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -957,31 +957,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1014,7 +1014,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1083,7 +1083,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1210,14 +1210,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1380,7 +1380,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1388,19 +1388,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1409,15 +1409,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1647,7 +1648,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1707,7 +1708,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1974,7 +1975,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Debtor Number"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Debtor missing!"
 
@@ -2070,7 +2071,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2143,7 +2144,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2270,7 +2271,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2452,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2478,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2641,7 +2642,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Email"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3123,20 +3124,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3144,7 +3145,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3268,7 +3269,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3470,7 +3471,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3478,7 +3479,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3858,11 +3859,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3870,8 +3871,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3889,22 +3890,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3920,8 +3921,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3930,7 +3931,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3988,7 +3989,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4016,7 +4017,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4057,7 +4058,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4121,7 +4122,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4342,11 +4343,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4423,7 +4424,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4454,9 +4455,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4803,15 +4804,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4825,15 +4826,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4858,7 +4859,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4877,7 +4878,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4915,7 +4916,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4985,7 +4986,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -5003,12 +5004,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5020,8 +5021,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5029,15 +5030,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5124,8 +5125,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5141,7 +5142,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5149,11 +5150,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5177,7 +5178,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5197,8 +5198,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5219,7 +5220,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5249,7 +5250,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5318,7 +5319,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5330,7 +5331,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5347,11 +5348,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5386,7 +5387,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5517,8 +5518,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5535,7 +5536,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5630,9 +5631,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5641,11 +5642,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5697,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5770,8 +5771,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5810,7 +5811,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5840,8 +5841,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5857,7 +5858,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5865,11 +5866,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5884,7 +5885,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5910,7 +5911,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5951,7 +5952,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5980,7 +5981,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6008,7 +6009,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6034,11 +6035,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6075,8 +6076,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,11 +6158,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6278,11 +6283,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6311,7 +6316,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6320,8 +6325,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6386,7 +6391,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6431,7 +6436,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6456,7 +6461,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6465,7 +6470,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6503,7 +6508,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6662,11 +6667,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6686,12 +6691,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6782,7 +6787,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6800,11 +6805,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6848,13 +6853,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6884,12 +6889,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6906,23 +6911,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6998,12 +7003,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7084,11 +7089,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7172,7 +7177,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7235,8 +7240,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7258,7 +7263,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7268,7 +7273,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7292,7 +7297,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7399,7 +7404,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7619,7 +7624,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7654,7 +7659,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7700,7 +7705,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7721,7 +7726,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7733,6 +7738,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7741,7 +7750,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7774,20 +7783,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7874,7 +7883,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7935,7 +7944,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7951,7 +7960,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7969,7 +7978,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8021,20 +8030,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8096,7 +8105,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8182,8 +8191,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8202,7 +8211,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Creditor Invoice"
@@ -8218,7 +8227,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8241,7 +8250,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Creditor missing!"
 
@@ -8278,7 +8287,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8355,7 +8364,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8371,7 +8380,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8429,7 +8438,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8448,11 +8457,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8519,7 +8528,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8563,7 +8572,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/en_NZ.po
+++ b/locale/po/en_NZ.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: paul bolger <pbolger@gmail.com>, 2015-2016\n"
 "Language-Team: English (New Zealand) (http://www.transifex.com/ledgersmb/"
@@ -189,7 +189,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -197,9 +197,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -207,7 +207,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -427,7 +427,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -463,11 +463,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -475,7 +475,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr "Add Creditor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -541,15 +541,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -577,8 +577,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -687,9 +687,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -792,8 +792,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -831,20 +831,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Are you sure you want to delete Order Number?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Are you sure you want to delete Quotation Number?"
 
@@ -917,16 +917,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -957,31 +957,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1014,7 +1014,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1083,7 +1083,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1210,14 +1210,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1380,7 +1380,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1388,19 +1388,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1409,15 +1409,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1647,7 +1648,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1707,7 +1708,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1974,7 +1975,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Debtor Number"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Debtor missing!"
 
@@ -2070,7 +2071,7 @@ msgstr "Debtor not on file!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2143,7 +2144,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2270,7 +2271,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2452,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2478,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2641,7 +2642,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Email"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3123,20 +3124,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3144,7 +3145,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3268,7 +3269,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3470,7 +3471,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3478,7 +3479,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3858,11 +3859,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3870,8 +3871,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3889,22 +3890,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3920,8 +3921,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3930,7 +3931,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3988,7 +3989,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4016,7 +4017,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4057,7 +4058,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4121,7 +4122,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4342,11 +4343,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4423,7 +4424,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4454,9 +4455,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4803,15 +4804,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4825,15 +4826,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4858,7 +4859,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4877,7 +4878,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4915,7 +4916,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4985,7 +4986,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -5003,12 +5004,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5020,8 +5021,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5029,15 +5030,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5124,8 +5125,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5141,7 +5142,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5149,11 +5150,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5177,7 +5178,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5197,8 +5198,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5219,7 +5220,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5249,7 +5250,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5318,7 +5319,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5330,7 +5331,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5347,11 +5348,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5386,7 +5387,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5517,8 +5518,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5535,7 +5536,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5630,9 +5631,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5641,11 +5642,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5697,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5770,8 +5771,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5810,7 +5811,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5840,8 +5841,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5857,7 +5858,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5865,11 +5866,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5884,7 +5885,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5910,7 +5911,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5951,7 +5952,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5980,7 +5981,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6008,7 +6009,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6034,11 +6035,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6075,8 +6076,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,11 +6158,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6278,11 +6283,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6311,7 +6316,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6320,8 +6325,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6386,7 +6391,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6431,7 +6436,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6456,7 +6461,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6465,7 +6470,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6503,7 +6508,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6662,11 +6667,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6686,12 +6691,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6782,7 +6787,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6800,11 +6805,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6848,13 +6853,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6884,12 +6889,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6906,23 +6911,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6998,12 +7003,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7084,11 +7089,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7172,7 +7177,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7235,8 +7240,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7258,7 +7263,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7268,7 +7273,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7292,7 +7297,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7399,7 +7404,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7619,7 +7624,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7654,7 +7659,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7700,7 +7705,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7721,7 +7726,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7733,6 +7738,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7741,7 +7750,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7774,20 +7783,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7874,7 +7883,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7935,7 +7944,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7951,7 +7960,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7969,7 +7978,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8021,20 +8030,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8096,7 +8105,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8182,8 +8191,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8202,7 +8211,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Creditor Invoice"
@@ -8218,7 +8227,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8241,7 +8250,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Creditor missing!"
 
@@ -8278,7 +8287,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8355,7 +8364,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8371,7 +8380,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8429,7 +8438,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8448,11 +8457,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8519,7 +8528,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8563,7 +8572,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/es.po
+++ b/locale/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Gabriel Díaz Campuzano <correototalmenteserio@gmail.com>, "
 "2020\n"
@@ -189,7 +189,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -197,9 +197,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -207,7 +207,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -427,7 +427,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Añadir Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Cotización de Moneda"
 
@@ -463,11 +463,11 @@ msgstr "Añadir artículo"
 msgid "Add Pricegroup"
 msgstr "Nuevo grupo de precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Añadir pedido"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Nueva cotización"
 
@@ -475,7 +475,7 @@ msgstr "Nueva cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Añadir Pedido de Cotización"
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Agregar CIS"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Añadir factura"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Añadir presupuesto"
 
@@ -507,7 +507,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr "Añadir usuario"
 msgid "Add Vendor"
 msgstr "Añadir proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Añadir factura de compra"
 
@@ -541,15 +541,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Deposito"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -577,8 +577,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -687,9 +687,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -792,8 +792,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -831,20 +831,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Seguro que desea borrar la Orden de Compra/Pedido?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "¿Está seguro que desea borrar la Cotización número"
 
@@ -917,16 +917,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -957,31 +957,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1014,7 +1014,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1083,7 +1083,7 @@ msgid "Balance"
 msgstr "Balance"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Hoja de balance"
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1143,7 +1143,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1210,14 +1210,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Bin"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1325,12 +1325,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1382,7 +1382,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "¡No se puede borrar el artículo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "¡No se puede borrar el pedido!"
 
@@ -1390,19 +1390,19 @@ msgstr "¡No se puede borrar el pedido!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "No se puede borrar presupuesto!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "¡No se puede registrar una factura en un periodo ya cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "¡No se puede registrar un pago en un periodo ya cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "¡No se puede registrar una transacción para un periodo cerrado"
 
@@ -1413,15 +1413,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "¡No se puede registrar la transacción"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "¡No se puede guardar el pedido!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "¡No se puede guardar la Cotización!"
 
@@ -1441,7 +1441,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Efectivo"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1502,7 +1503,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1618,7 +1619,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Compañía"
 
@@ -1651,7 +1652,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1703,7 +1704,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar"
 
@@ -1711,7 +1712,7 @@ msgstr "Confirmar"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1754,8 +1755,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1766,7 +1767,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1815,7 +1816,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1827,19 +1828,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "No pude guardar"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir el inventario"
 
@@ -1859,8 +1860,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1924,7 +1925,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1945,7 +1946,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1969,7 +1970,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Mon."
 
@@ -1978,7 +1979,7 @@ msgstr "Mon."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2015,7 +2016,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2045,7 +2046,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2058,7 +2059,7 @@ msgstr "Número de cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
@@ -2074,7 +2075,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2098,7 +2099,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2147,7 +2148,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2162,11 +2163,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2204,7 +2205,7 @@ msgstr "Fecha de pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha de recibo"
 
@@ -2228,7 +2229,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Faltas datos"
 
@@ -2274,7 +2275,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2387,9 +2388,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2439,16 +2440,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2456,11 +2457,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2482,7 +2483,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2534,13 +2535,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2557,7 +2558,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2628,16 +2629,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2645,7 +2646,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2653,7 +2654,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2669,7 +2670,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Hecho"
 
@@ -2689,7 +2690,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2731,14 +2732,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta la fecha de vencimiento"
 
@@ -2750,8 +2751,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Correo electrónico"
 
@@ -3053,11 +3054,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3073,7 +3074,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3095,7 +3096,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3119,7 +3120,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3127,20 +3128,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Cambio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
@@ -3148,7 +3149,7 @@ msgstr "¡Falta la tasa de cambio para el pago!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "¡Falta la tasa de cambio!"
 
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Tasa de Cambio"
 
@@ -3272,7 +3273,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3286,17 +3287,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3333,7 +3334,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3393,7 +3394,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3425,7 +3426,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3474,7 +3475,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3482,7 +3483,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3511,11 +3512,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Elaborar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
@@ -3560,8 +3561,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3803,8 +3804,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Anotaciones Internas"
 
@@ -3864,11 +3865,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "¡Inventario guardado!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
@@ -3876,8 +3877,8 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3895,22 +3896,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "No se ha definido la fecha de la factura"
 
@@ -3926,8 +3927,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3936,7 +3937,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "No se ha definido el número de la factura"
 
@@ -3994,7 +3995,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "¡Concepto borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "El concepto no se encuentra en ningún archivo"
 
@@ -4022,7 +4023,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4063,7 +4064,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4127,7 +4128,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "T. de Ent."
 
@@ -4348,11 +4349,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrar"
 
@@ -4429,7 +4430,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4460,9 +4461,9 @@ msgid "May"
 msgstr "May"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4809,15 +4810,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4831,15 +4832,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "¡No se suministro nada!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "¡No es seleccionado nada!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "¡Nada que transferir!"
 
@@ -4864,7 +4865,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4883,7 +4884,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato de número"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4921,7 +4922,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4936,7 +4937,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4991,7 +4992,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5009,12 +5010,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de elaboración"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "No se ha definido la fecha de la elaboración"
 
@@ -5026,8 +5027,8 @@ msgstr "Presupuestos y pedidos"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5035,15 +5036,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número de orden"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "No se ha definido el número de la orden"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "¡Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
@@ -5130,8 +5131,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5147,7 +5148,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5155,11 +5156,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Albarán"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "¡Falta Fecha de Lista de Empaque!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "No se ha definido el número del albarán"
 
@@ -5183,7 +5184,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artículo"
 
@@ -5203,8 +5204,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5225,7 +5226,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5255,7 +5256,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5324,7 +5325,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "No se encuentra la fecha de pago"
 
@@ -5336,7 +5337,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5345,7 +5346,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Vencimientos impagados"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5353,11 +5354,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5392,7 +5393,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5523,8 +5524,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5541,7 +5542,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como nuevo"
 
@@ -5636,9 +5637,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5647,11 +5648,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y Salvar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5703,15 +5704,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5733,7 +5734,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5776,8 +5777,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5816,7 +5817,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5846,8 +5847,8 @@ msgid "Quarter"
 msgstr "Cuarto"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5863,7 +5864,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de Cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "¡Falta la fecha de la cotización!"
 
@@ -5871,11 +5872,11 @@ msgstr "¡Falta la fecha de la cotización!"
 msgid "Quotation Number"
 msgstr "Número de cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "¡Falta Número de Cotización!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Presupuesto eliminado!"
 
@@ -5890,7 +5891,7 @@ msgstr "Presupuestos"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5916,7 +5917,7 @@ msgstr "Sols. de Cots."
 msgid "ROP"
 msgstr "Tope de envio"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5957,7 +5958,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Cobrado"
 
@@ -5986,7 +5987,7 @@ msgstr "Por cobrar"
 msgid "Receive"
 msgstr "Recibir"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recibir mercancia"
 
@@ -6014,7 +6015,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6040,11 +6041,11 @@ msgstr "Trans. Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6081,9 +6082,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resto"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6111,7 +6116,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6123,7 +6128,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6159,11 +6164,11 @@ msgstr "Informes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6284,11 +6289,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6317,7 +6322,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Facturas de ventas"
@@ -6326,8 +6331,8 @@ msgstr "Facturas de ventas"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6392,7 +6397,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6437,7 +6442,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6445,7 +6450,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6462,7 +6467,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6471,7 +6476,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6509,7 +6514,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6522,12 +6527,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar Recurrencia"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6668,11 +6673,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccione el proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6692,12 +6697,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "¡Seleccione postscript o PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione Texto, Postscript o PDF!"
 
@@ -6788,7 +6793,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Núm. de serie"
 
@@ -6806,11 +6811,11 @@ msgstr "Serial"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6854,13 +6859,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Envio"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Despachar Mercancia"
 
@@ -6890,12 +6895,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Destino"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6912,23 +6917,23 @@ msgstr "Envio por"
 msgid "Shipping"
 msgstr "Despacho"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de Envio"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "¡Falta la fecha de envío!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7004,12 +7009,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7090,11 +7095,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7178,7 +7183,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7241,8 +7246,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7264,7 +7269,7 @@ msgstr "Impuesto"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7274,7 +7279,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7298,7 +7303,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7306,7 +7311,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impuestos incluidos en el precio"
@@ -7405,7 +7410,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7628,7 +7633,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7663,7 +7668,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7709,7 +7714,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7730,7 +7735,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7742,6 +7747,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7750,7 +7759,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento por Intercambio"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7783,20 +7792,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Transacciones"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferir"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir existencia"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7883,7 +7892,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7944,7 +7953,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7960,7 +7969,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7978,7 +7987,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8030,20 +8039,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "¡Actualizado!"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8105,7 +8114,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8191,8 +8200,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8211,7 +8220,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historia de Proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de compras"
@@ -8227,7 +8236,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8250,7 +8259,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
@@ -8287,7 +8296,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8364,7 +8373,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿De qué tipo es este concepto?"
 
@@ -8380,7 +8389,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8438,7 +8447,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8457,11 +8466,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8528,7 +8537,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8572,7 +8581,7 @@ msgstr "Hecho"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "unid."
 

--- a/locale/po/es_AR.po
+++ b/locale/po/es_AR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/es_AR/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso Denegado"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Agregar Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Tasa de Cambio"
 
@@ -459,11 +459,11 @@ msgstr "Agregar Parte"
 msgid "Add Pricegroup"
 msgstr "Agregar Grupo de Precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Agregar Orden de Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Agregar Presupuesto"
 
@@ -471,7 +471,7 @@ msgstr "Agregar Presupuesto"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Agregar Pedido de Presupuesto"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Agregar SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Nueva Factura de Venta"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Nueva Orden de Venta"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Ficha de Horario"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Agregar Usuario"
 msgid "Add Vendor"
 msgstr "Agregar Proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Agregar Factura de Proveedor"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Deposito"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Esta seguro de eliminar el Numero de Orden?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Esta seguro de eliminar el Numero de Presupuesto?"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Hoja de Balance"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Empaque"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "No se puede eliminar articulo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "No se puede eliminar la orden!"
 
@@ -1386,19 +1386,19 @@ msgstr "No se puede eliminar la orden!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "No se puede borrar presupuesto!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "No se puede anunciar una factura para un periodo cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "No se puede anunciar un pago para un periodo cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "No se puede anunciar la transaccion para un periodo cerrado!"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "No se puede anunciar la transaccion con un debito y credito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "No se puede anunciar la transaccion!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "No se puede salvar la orden!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "No se puede salvar presupuesto!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Dinero"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Compañía"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar!"
 
@@ -1707,7 +1708,7 @@ msgstr "Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "No se puede salvar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "No se puede transferir Inventario!"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Haber"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Moneda"
 
@@ -1974,7 +1975,7 @@ msgstr "Moneda"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Numero de Cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Falta el Cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "Archivo sin cliente!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha de Recibido"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Falta la Fecha de Recibido!"
 
@@ -2270,7 +2271,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debe"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha Entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Hecho"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de Vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta fecha de vencimiento!"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Inter"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de Cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Falta la tasa de cambio para el pago!"
 
@@ -3144,7 +3145,7 @@ msgstr "Falta la tasa de cambio para el pago!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Falta la tasa de cambio!"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Tasa de Cambio"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3470,7 +3471,7 @@ msgstr "Numero de Referencia para Libro Mayor"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Generar Ordenes"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar Ordenes de Compra"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas Internas"
 
@@ -3859,11 +3860,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventario guardado!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
@@ -3871,8 +3872,8 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3890,22 +3891,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de Factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Falta la fecha de factura!"
 
@@ -3921,8 +3922,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3931,7 +3932,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Numero de Factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Falta el Número de Factura!"
 
@@ -3989,7 +3990,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "Articulo eliminado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "¡El artículo no se encuentra en archivo!"
 
@@ -4017,7 +4018,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4058,7 +4059,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4122,7 +4123,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Lider"
 
@@ -4343,11 +4344,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrada al sistema"
 
@@ -4424,7 +4425,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4455,9 +4456,9 @@ msgid "May"
 msgstr "May"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4804,15 +4805,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4826,15 +4827,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "No se ingreso nada!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nada fue seleccionado!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nada para transferir!"
 
@@ -4859,7 +4860,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4878,7 +4879,7 @@ msgstr "Numero"
 msgid "Number Format"
 msgstr "Formato de Número"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4916,7 +4917,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4931,7 +4932,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "En Mano"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4986,7 +4987,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5004,12 +5005,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de Orden"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Falta la Fecha de Orden!"
 
@@ -5021,8 +5022,8 @@ msgstr "Entrada de Orden"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5030,15 +5031,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Numero de Orden"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Falta el Numero de Orden!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Orden eliminada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo la generacion de Orden!"
 
@@ -5125,8 +5126,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5142,7 +5143,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5150,11 +5151,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Envios"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "¡Falta Fecha de Lista de Empaque!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "!Falta nzmero en lista de empaque!"
 
@@ -5178,7 +5179,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Parte"
 
@@ -5198,8 +5199,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5220,7 +5221,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5250,7 +5251,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5319,7 +5320,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Falta la fecha de pago!"
 
@@ -5331,7 +5332,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5340,7 +5341,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5348,11 +5349,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5387,7 +5388,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5518,8 +5519,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Anunciar"
@@ -5536,7 +5537,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Anunciar como nuevo"
 
@@ -5631,9 +5632,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5642,11 +5643,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y Salvar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Salvar como nuevo"
 
@@ -5698,15 +5699,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5728,7 +5729,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5771,8 +5772,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5811,7 +5812,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5841,8 +5842,8 @@ msgid "Quarter"
 msgstr "Cuarto"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5858,7 +5859,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de Presupuesto"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Falta la Fecha de Presupuesto!"
 
@@ -5866,11 +5867,11 @@ msgstr "Falta la Fecha de Presupuesto!"
 msgid "Quotation Number"
 msgstr "Numero de Presupuesto"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Falta el Numero de Presupuesto!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Presupuesto eliminado!"
 
@@ -5885,7 +5886,7 @@ msgstr "Presupuestos"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5911,7 +5912,7 @@ msgstr "Pedio de Presupuestos"
 msgid "ROP"
 msgstr "Existencia mínima"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5952,7 +5953,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Rcbdo."
 
@@ -5981,7 +5982,7 @@ msgstr "Por cobrar"
 msgid "Receive"
 msgstr "Recibo"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recibo de Mercancias"
 
@@ -6009,7 +6010,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Grabar en"
 
@@ -6035,11 +6036,11 @@ msgstr "Trans. Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6076,9 +6077,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Sobrantes"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6106,7 +6111,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6118,7 +6123,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6154,11 +6159,11 @@ msgstr "Reportes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6279,11 +6284,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6312,7 +6317,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura de Ventas"
@@ -6321,8 +6326,8 @@ msgstr "Factura de Ventas"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6387,7 +6392,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6432,7 +6437,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6440,7 +6445,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6457,7 +6462,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6466,7 +6471,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6504,7 +6509,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6517,12 +6522,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Temporizar"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6663,11 +6668,11 @@ msgstr "Seleccionar Cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccionar Proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6687,12 +6692,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Seleccione postscript o PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione Texto, Postscript o PDF!"
 
@@ -6783,7 +6788,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Numero de Serie"
 
@@ -6801,11 +6806,11 @@ msgstr "Numero de Serie"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6849,13 +6854,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Despachar"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Despachar Mercancia"
 
@@ -6885,12 +6890,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Despachar a"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6907,23 +6912,23 @@ msgstr "Despachar mediante"
 msgid "Shipping"
 msgstr "Envio"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de Envio"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Falta la Fecha de Envio!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6999,12 +7004,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7085,11 +7090,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7173,7 +7178,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7236,8 +7241,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7259,7 +7264,7 @@ msgstr "Impuesto"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7269,7 +7274,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7293,7 +7298,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7301,7 +7306,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impuestos Incluidos"
@@ -7400,7 +7405,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7623,7 +7628,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7658,7 +7663,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "A Deposito"
 
@@ -7704,7 +7709,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7725,7 +7730,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7737,6 +7742,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7745,7 +7754,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento de Cambio"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7778,20 +7787,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Transacciones"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferir"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir Inventario"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7878,7 +7887,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7939,7 +7948,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7955,7 +7964,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7973,7 +7982,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8025,20 +8034,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Actualizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8100,7 +8109,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8186,8 +8195,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8206,7 +8215,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historia de Proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
@@ -8222,7 +8231,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8245,7 +8254,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Falta el proveedor!"
 
@@ -8282,7 +8291,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿Que tipo de Item es este?"
 
@@ -8375,7 +8384,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8433,7 +8442,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8452,11 +8461,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8523,7 +8532,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8567,7 +8576,7 @@ msgstr "hecho"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "pza"
 

--- a/locale/po/es_CO.po
+++ b/locale/po/es_CO.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Colombia) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/es_CO/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Agregar Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Tasa de Cambio"
 
@@ -459,11 +459,11 @@ msgstr "Añadir Artículo"
 msgid "Add Pricegroup"
 msgstr "Añadir Grupo de Precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Añadir Pedido"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Agregar Cotización"
 
@@ -471,7 +471,7 @@ msgstr "Agregar Cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Pedir Cotización"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Agregar SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Añadir Factura de Venta"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Añadir Cotización"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Añadir Usuario"
 msgid "Add Vendor"
 msgstr "Añadir Proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Agregar Factura de Proveedor"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Bodega"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Esta seguro de que desea borrar la orden número?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Seguro que quiere borrar la cotización número"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Balance"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Hoja de balance"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Empaque"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "¡No se puede borrar el artículo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "¡No se puede borrar el pedido!"
 
@@ -1386,19 +1386,19 @@ msgstr "¡No se puede borrar el pedido!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "No puedo borrar cotización!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "¡No se puede registrar una factura en un periodo ya cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "¡No se puede registrar un pago en un periodo ya cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "¡No se puede registrar una transacción para un periodo cerrado"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "¡No se puede registrar la transacción"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "¡No se puede guardar el pedido!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "No puedo guardar cotización!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Efectivo"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Empresa"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar"
 
@@ -1707,7 +1708,7 @@ msgstr "Confirmar"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "No pude guardar"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "No puedo transferir inventario!"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Mon."
 
@@ -1974,7 +1975,7 @@ msgstr "Mon."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Número del cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha recibido"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Faltas datos"
 
@@ -2270,7 +2271,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Hecho"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta la fecha de vencimiento"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Correo electrónico"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Cambio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de Cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Falta Tasa de Cambio"
 
@@ -3144,7 +3145,7 @@ msgstr "Falta Tasa de Cambio"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Falta Tasa de Cambio"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Tasa de Cambio"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3470,7 +3471,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Elaborar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Elaborar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Elaborar Orden de Venta"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas internas"
 
@@ -3860,11 +3861,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventario guardado!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
@@ -3872,8 +3873,8 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3891,22 +3892,22 @@ msgstr "Factura de Venta"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "No se ha definido la fecha de la factura"
 
@@ -3922,8 +3923,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3932,7 +3933,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "No se ha definido el número de la factura"
 
@@ -3990,7 +3991,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "¡Concepto borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "El concepto no se encuentra en ningún archivo"
 
@@ -4018,7 +4019,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4059,7 +4060,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4123,7 +4124,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Entrega"
 
@@ -4344,11 +4345,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrar"
 
@@ -4425,7 +4426,7 @@ msgstr "Administrador"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4456,9 +4457,9 @@ msgid "May"
 msgstr "Mayo"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4805,15 +4806,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4827,15 +4828,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Información Incompleta"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "¡No es seleccionado nada!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nada para transferir"
 
@@ -4860,7 +4861,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4879,7 +4880,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato de número"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4917,7 +4918,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4932,7 +4933,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4987,7 +4988,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5005,12 +5006,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de elaboración"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "No se ha definido la fecha de la elaboración"
 
@@ -5022,8 +5023,8 @@ msgstr "Cotizaciones y pedidos"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5031,15 +5032,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número de orden"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "No se ha definido el número de la orden"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "¡Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
@@ -5126,8 +5127,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5143,7 +5144,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5151,11 +5152,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Albarán"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "No se ha definido la fecha del albarán"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "No se ha definido el número del albarán"
 
@@ -5179,7 +5180,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artículo"
 
@@ -5199,8 +5200,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5221,7 +5222,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5251,7 +5252,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "No se encuentra la fecha de pago"
 
@@ -5332,7 +5333,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5349,11 +5350,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5388,7 +5389,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5519,8 +5520,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5537,7 +5538,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como Nuevo"
 
@@ -5632,9 +5633,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5643,11 +5644,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y Registrar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5699,15 +5700,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5729,7 +5730,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5772,8 +5773,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5812,7 +5813,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5842,8 +5843,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5859,7 +5860,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Falta fecha de cotización"
 
@@ -5867,11 +5868,11 @@ msgstr "Falta fecha de cotización"
 msgid "Quotation Number"
 msgstr "Número cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Falta número de cotización"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Cotización borrado"
 
@@ -5886,7 +5887,7 @@ msgstr "Cotizaciones"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5912,7 +5913,7 @@ msgstr "Cotizaciones solicitados"
 msgid "ROP"
 msgstr "Tope de envio"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5953,7 +5954,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Cobrado"
 
@@ -5982,7 +5983,7 @@ msgstr "Cobros"
 msgid "Receive"
 msgstr "Recibir"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recibir mercancia"
 
@@ -6010,7 +6011,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6036,11 +6037,11 @@ msgstr "Transacciones Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6077,9 +6078,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resto"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6107,7 +6112,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6119,7 +6124,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,11 +6160,11 @@ msgstr "Informes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Pedido"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6280,11 +6285,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6313,7 +6318,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Facturas de Ventas"
@@ -6322,8 +6327,8 @@ msgstr "Facturas de Ventas"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6433,7 +6438,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6441,7 +6446,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6458,7 +6463,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6467,7 +6472,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6505,7 +6510,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6518,12 +6523,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar Recurrencia"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6664,11 +6669,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccionar Proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6688,12 +6693,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "¡Seleccione postscript o PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione txt, postscript o PDF!"
 
@@ -6784,7 +6789,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "No de Serial"
 
@@ -6802,11 +6807,11 @@ msgstr "Número del Serial"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6850,13 +6855,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Envio"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Enviar Mercancía"
 
@@ -6886,12 +6891,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Destino"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6908,23 +6913,23 @@ msgstr "Envio por"
 msgid "Shipping"
 msgstr "Envio"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha del Envio"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Falta Fecha del Envio"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7000,12 +7005,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7086,11 +7091,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Departamento"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7174,7 +7179,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7237,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7260,7 +7265,7 @@ msgstr "Impuestos"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7270,7 +7275,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7294,7 +7299,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7302,7 +7307,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impuestos Incluidos"
@@ -7401,7 +7406,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7624,7 +7629,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7659,7 +7664,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7705,7 +7710,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7726,7 +7731,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7738,6 +7743,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7746,7 +7755,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7779,20 +7788,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Transacciones"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir Inventario"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7879,7 +7888,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7940,7 +7949,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7956,7 +7965,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7974,7 +7983,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8026,20 +8035,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "¡Actualizado!"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8101,7 +8110,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8187,8 +8196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8207,7 +8216,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historial Proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
@@ -8223,7 +8232,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8246,7 +8255,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
@@ -8283,7 +8292,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8360,7 +8369,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿De qué tipo es este concepto?"
 
@@ -8376,7 +8385,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8434,7 +8443,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8453,11 +8462,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8524,7 +8533,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8568,7 +8577,7 @@ msgstr "hecho"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "unid."
 

--- a/locale/po/es_EC.po
+++ b/locale/po/es_EC.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Ecuador) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/es_EC/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Añadir Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Cotización de Moneda"
 
@@ -459,11 +459,11 @@ msgstr "Añadir artículo"
 msgid "Add Pricegroup"
 msgstr "Añadir Preciogrupal"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Añadir pedido"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Añadir Cotización"
 
@@ -471,7 +471,7 @@ msgstr "Añadir Cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Añadir Pedido de Cotización"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Adicionar SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Añadir factura"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Añadir cotización"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Añadir Usuario"
 msgid "Add Vendor"
 msgstr "Añadir proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Agregar Factura de Proveedor"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Adicionar Bodega"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Esta seguro de que desea borrar la orden número?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "¿Está seguro que quiere borrar el número de la Cotización?"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Balance"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Hoja de balance"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Compatimiento"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "¡No se puede borrar el artículo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "¡No se puede borrar el pedido!"
 
@@ -1386,19 +1386,19 @@ msgstr "¡No se puede borrar el pedido!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "¡No se puede borrar la cotización!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "¡No se puede registrar una factura en un periodo ya cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "¡No se puede registrar un pago en un periodo ya cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "¡No se puede registrar una transacción para un periodo cerrado"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "¡No se puede registrar la transacción"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "¡No se puede guardar el pedido!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "¡No se puede guardar cotización!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Efectivo"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Empresa"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar"
 
@@ -1707,7 +1708,7 @@ msgstr "Confirmar"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "¡No se puede grabar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "¡No se puede transferir el Inventario!"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Mon."
 
@@ -1974,7 +1975,7 @@ msgstr "Mon."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Número de Cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha de recibo"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "¡Falta Fecha de recepción!"
 
@@ -2270,7 +2271,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Hecho"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta la fecha de vencimiento"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Correo electrónico"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Cambio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de Cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta tasa de Cambio para pago!"
 
@@ -3144,7 +3145,7 @@ msgstr "¡Falta tasa de Cambio para pago!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "¡Falta Tasa de Cambio!"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Tasa de Cambio"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3470,7 +3471,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Elaborar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas Internas"
 
@@ -3860,11 +3861,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "¡Inventario salvado!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "¡Inventario transferido!"
 
@@ -3872,8 +3873,8 @@ msgstr "¡Inventario transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3891,22 +3892,22 @@ msgstr "Factura de Venta"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "No se ha definido la fecha de la factura"
 
@@ -3922,8 +3923,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3932,7 +3933,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "No se ha definido el número de la factura"
 
@@ -3990,7 +3991,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "¡Concepto borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "El concepto no se encuentra en ningún archivo"
 
@@ -4018,7 +4019,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4059,7 +4060,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4123,7 +4124,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "T. de Ent."
 
@@ -4344,11 +4345,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrar"
 
@@ -4425,7 +4426,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4456,9 +4457,9 @@ msgid "May"
 msgstr "May"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4805,15 +4806,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4827,15 +4828,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "¡Nada ingresado!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "¡No es seleccionado nada!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "¡Nada para Transferir!"
 
@@ -4860,7 +4861,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4879,7 +4880,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato de número"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4917,7 +4918,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4932,7 +4933,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4987,7 +4988,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5005,12 +5006,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de elaboración"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "No se ha definido la fecha de la elaboración"
 
@@ -5022,8 +5023,8 @@ msgstr "Cotizaciones y pedidos"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5031,15 +5032,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número de orden"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "No se ha definido el número de la orden"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "¡Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
@@ -5126,8 +5127,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5143,7 +5144,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5151,11 +5152,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Empaque"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "No se ha definido la fecha del albarán"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "No se ha definido el número del albarán"
 
@@ -5179,7 +5180,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Parte"
 
@@ -5199,8 +5200,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5221,7 +5222,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5251,7 +5252,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "No se encuentra la fecha de pago"
 
@@ -5332,7 +5333,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Vencimientos impagados"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5349,11 +5350,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5388,7 +5389,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5519,8 +5520,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5537,7 +5538,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como nuevo"
 
@@ -5632,9 +5633,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5643,11 +5644,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y Salve"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5699,15 +5700,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5729,7 +5730,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5772,8 +5773,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5812,7 +5813,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5842,8 +5843,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5859,7 +5860,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de Cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Falta Fecha de Cotización"
 
@@ -5867,11 +5868,11 @@ msgstr "Falta Fecha de Cotización"
 msgid "Quotation Number"
 msgstr "Número de Cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Falta número de Cotización"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
@@ -5886,7 +5887,7 @@ msgstr "Cotizaciones"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5912,7 +5913,7 @@ msgstr "Requerimiento de Cotizaciónes"
 msgid "ROP"
 msgstr "Tope de envio"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5953,7 +5954,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Cobrado"
 
@@ -5982,7 +5983,7 @@ msgstr "Cobros"
 msgid "Receive"
 msgstr "Cobro"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recepción de Mercadería"
 
@@ -6010,7 +6011,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6036,11 +6037,11 @@ msgstr "Trans. Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6077,9 +6078,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resto"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6107,7 +6112,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6119,7 +6124,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,11 +6160,11 @@ msgstr "Reportes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6280,11 +6285,11 @@ msgstr "Código Industrial Estandard"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "Unidad de Mantenimiento de Stock"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6313,7 +6318,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura de venta"
@@ -6322,8 +6327,8 @@ msgstr "Factura de venta"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6433,7 +6438,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6441,7 +6446,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6458,7 +6463,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6467,7 +6472,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6505,7 +6510,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6518,12 +6523,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar Recurrencia"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6664,11 +6669,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccione el proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6688,12 +6693,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "¡Seleccione postscript o PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione txt, postscript o PDF!"
 
@@ -6784,7 +6789,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Nº de Serie"
 
@@ -6802,11 +6807,11 @@ msgstr "Número Serie"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6850,13 +6855,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Envio"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Envío de Mercadería"
 
@@ -6886,12 +6891,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Destino"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6908,23 +6913,23 @@ msgstr "Envio por"
 msgid "Shipping"
 msgstr "Despacho"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de Embarque"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "¡Falta Fecha de Embarque!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7000,12 +7005,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7086,11 +7091,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7174,7 +7179,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7237,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7260,7 +7265,7 @@ msgstr "Impuestos"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7270,7 +7275,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7294,7 +7299,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7302,7 +7307,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impuestos incluidos en el precio"
@@ -7401,7 +7406,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7624,7 +7629,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7659,7 +7664,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7705,7 +7710,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7726,7 +7731,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7738,6 +7743,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7746,7 +7755,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento por Intercambio"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7779,20 +7788,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Transacciones"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir Inventario"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7879,7 +7888,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7940,7 +7949,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7956,7 +7965,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7974,7 +7983,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8026,20 +8035,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "¡Actualizado!"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8101,7 +8110,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8187,8 +8196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8207,7 +8216,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historia de Proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de proveedor"
@@ -8223,7 +8232,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8246,7 +8255,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
@@ -8283,7 +8292,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8360,7 +8369,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿De qué tipo es este concepto?"
 
@@ -8376,7 +8385,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8434,7 +8443,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8453,11 +8462,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8524,7 +8533,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8568,7 +8577,7 @@ msgstr "hecho"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "unid."
 

--- a/locale/po/es_MX.po
+++ b/locale/po/es_MX.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/es_MX/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Nuevo empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Nuevo tipo de cambio"
 
@@ -459,11 +459,11 @@ msgstr "Nueva parte"
 msgid "Add Pricegroup"
 msgstr "Nuevo grupo de precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Nueva orden de compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Nueva cotización"
 
@@ -471,7 +471,7 @@ msgstr "Nueva cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Nueva solicitud de cotización"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Nuevo SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Nueva factura de venta"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Nueva orden de venta"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Nuevo usuario"
 msgid "Add Vendor"
 msgstr "Nuevo proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Nueva factura de compra"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Nuevo almacén"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Está Ud. seguro de querer borrar la orden No.:"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "¿Está Ud. seguro de querer borrar la cotización No.:"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balance general"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Ubicación"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "¡No se puede borrar el artículo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "¡No se puede borrar la orden!"
 
@@ -1386,19 +1386,19 @@ msgstr "¡No se puede borrar la orden!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "¡No se puede borrar la cotización!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "¡No se puede registrar una factura para un periodo cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "¡No se puede registrar un pago para un periodo cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "¡No se puede registrar un movimiento para un periodo cerrado!"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "¡No se puede registrar el movimiento!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "¡No se puede guardar la orden!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "¡No se puede guardar la cotización!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Bancos"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Empresa"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
@@ -1707,7 +1708,7 @@ msgstr "¡Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "¡No se pudo guardar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir el inventario"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Abono"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Mon."
 
@@ -1974,7 +1975,7 @@ msgstr "Mon."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Número de cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "¡El cliente no está registrado!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha de recibo"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "¡Falta la fecha de recibo!"
 
@@ -2270,7 +2271,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Cargo"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Listo"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta fecha de vencimiento!"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Correo-e"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "T. de C."
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tipo de cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta el tipo de cambio para el pago!"
 
@@ -3144,7 +3145,7 @@ msgstr "¡Falta el tipo de cambio para el pago!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "¡Falta el tipo de cambio!"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3470,7 +3471,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Elaborar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas internas"
 
@@ -3860,11 +3861,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "¡Existencias guardadas!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "¡Existencias transferidas!"
 
@@ -3872,8 +3873,8 @@ msgstr "¡Existencias transferidas!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3891,22 +3892,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "¡Falta la fecha de la factura!"
 
@@ -3922,8 +3923,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3932,7 +3933,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Falta el número de factura!"
 
@@ -3990,7 +3991,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "¡Articulo borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "¡El artículo no está registrado!"
 
@@ -4018,7 +4019,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4059,7 +4060,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4123,7 +4124,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "T. de Ent."
 
@@ -4344,11 +4345,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrada al sistema"
 
@@ -4425,7 +4426,7 @@ msgstr "Administrador"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4456,9 +4457,9 @@ msgid "May"
 msgstr "May"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Nota"
@@ -4805,15 +4806,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4827,15 +4828,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "¡No se suministro nada!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "¡No se seleccionó nada!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "¡Nada que transferir!"
 
@@ -4860,7 +4861,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4879,7 +4880,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato de número"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4917,7 +4918,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4932,7 +4933,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Existencias"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4987,7 +4988,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5005,12 +5006,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la orden"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "¡Falta la fecha de la orden!"
 
@@ -5022,8 +5023,8 @@ msgstr "Ordenes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5031,15 +5032,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número de la orden"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Falta el número de la orden!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "¡Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
@@ -5126,8 +5127,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5143,7 +5144,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5151,11 +5152,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de empaque"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "¡Falta la fecha en la lista de empaque!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "¡Falta le número en la lista de empaque!"
 
@@ -5179,7 +5180,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Parte"
 
@@ -5199,8 +5200,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5221,7 +5222,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5251,7 +5252,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "¡Falta la fecha del pago!"
 
@@ -5332,7 +5333,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5349,11 +5350,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5388,7 +5389,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5519,8 +5520,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5537,7 +5538,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como nuevo"
 
@@ -5632,9 +5633,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Vista Preliminar"
@@ -5643,11 +5644,11 @@ msgstr "Vista Preliminar"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y Guardar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5699,15 +5700,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5729,7 +5730,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5772,8 +5773,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5812,7 +5813,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5842,8 +5843,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5859,7 +5860,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "¡Falta la fecha de la cotización!"
 
@@ -5867,11 +5868,11 @@ msgstr "¡Falta la fecha de la cotización!"
 msgid "Quotation Number"
 msgstr "Número de cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "¡Falta el número de la cotización!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
@@ -5886,7 +5887,7 @@ msgstr "Cotizaciones"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5912,7 +5913,7 @@ msgstr "Sols. de Cots."
 msgid "ROP"
 msgstr "Pto. de Reord."
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5953,7 +5954,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Recb."
 
@@ -5982,7 +5983,7 @@ msgstr "Por cobrar"
 msgid "Receive"
 msgstr "Recibir"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recibir mercancía"
 
@@ -6010,7 +6011,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6036,11 +6037,11 @@ msgstr "Trans. Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6077,9 +6078,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Disponible"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6107,7 +6112,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6119,7 +6124,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,11 +6160,11 @@ msgstr "Reportes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6280,11 +6285,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6313,7 +6318,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura de venta"
@@ -6322,8 +6327,8 @@ msgstr "Factura de venta"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6433,7 +6438,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6441,7 +6446,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6458,7 +6463,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6467,7 +6472,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6505,7 +6510,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6518,12 +6523,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar Recurrencia"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6664,11 +6669,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccione el proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6688,12 +6693,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Seleccione Postcript o PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione txt, postscript o PDF!"
 
@@ -6784,7 +6789,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Núm. de serie"
 
@@ -6802,11 +6807,11 @@ msgstr "Número de serie"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6850,13 +6855,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Enviar"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Enviar mercancías"
 
@@ -6886,12 +6891,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Enviar a"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6908,23 +6913,23 @@ msgstr "Enviar por"
 msgid "Shipping"
 msgstr "Envío"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de envío"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "¡Falta la fecha de envío!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7000,12 +7005,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7086,11 +7091,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7174,7 +7179,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7237,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7260,7 +7265,7 @@ msgstr "Impuesto"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7270,7 +7275,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7294,7 +7299,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7302,7 +7307,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impuesto Incluido"
@@ -7401,7 +7406,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7624,7 +7629,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7659,7 +7664,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7705,7 +7710,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7726,7 +7731,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7738,6 +7743,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7746,7 +7755,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento comercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7779,20 +7788,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Movimientos"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferir"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir inventario"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7879,7 +7888,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7940,7 +7949,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7956,7 +7965,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7974,7 +7983,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8026,20 +8035,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Actualizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8101,7 +8110,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8187,8 +8196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8207,7 +8216,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historia de proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de compra"
@@ -8223,7 +8232,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8246,7 +8255,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "¡Falta el proveedor!"
 
@@ -8283,7 +8292,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8360,7 +8369,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿Que tipo de articulo es este?"
 
@@ -8376,7 +8385,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8434,7 +8443,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8453,11 +8462,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8524,7 +8533,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8568,7 +8577,7 @@ msgstr "listo"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "pza"
 

--- a/locale/po/es_PA.po
+++ b/locale/po/es_PA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Panama) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/es_PA/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Agregar Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Cotización de Moneda"
 
@@ -459,11 +459,11 @@ msgstr "Agregar Artículo"
 msgid "Add Pricegroup"
 msgstr "Agregar Grupo de Precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Agregar Orden de Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Agregar Cotización"
 
@@ -471,7 +471,7 @@ msgstr "Agregar Cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Pedir Cotización"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Agregar CIS"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Agregar Factura de Venta"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Agregar Orden de Venta"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Agregar Usuario"
 msgid "Add Vendor"
 msgstr "Agregar Proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Agregar Factura de Proveedor"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Almacén"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Seguro que desea borrar la Orden de Compra/Pedido?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "¿Seguro que desea borrar la Cotización?"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balance General"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Ubicación"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "¡No se puede borrar el Artículo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "¡No se puede borrar la Orden!"
 
@@ -1386,19 +1386,19 @@ msgstr "¡No se puede borrar la Orden!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "¡No se puede borrar la Cotización!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "¡No se puede registrar una Factura para un periodo cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "¡No se puede registrar un Pago para un periodo cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "¡No se puede registrar un Asiento para un periodo cerrado!"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "¡No se puede registrar el Asiento!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "¡No se puede guardar la Orden!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "¡No se puede guardar la Cotización!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Efectivo"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Empresa"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
@@ -1707,7 +1708,7 @@ msgstr "¡Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "¡No se pudo guardar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir existencia!"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Div"
 
@@ -1974,7 +1975,7 @@ msgstr "Div"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Código del Cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "¡Falta el Cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de Pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha de recepción"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "¡Falta la fecha de recepción!"
 
@@ -2270,7 +2271,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Terminado"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "¡Falta fecha de vencimiento!"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Correo electrónico"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Cambio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de Cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
@@ -3144,7 +3145,7 @@ msgstr "¡Falta la tasa de cambio para el pago!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "¡Falta la tasa de cambio!"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Cotización de Monedas"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3470,7 +3471,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Elaborar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas internas"
 
@@ -3859,11 +3860,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "¡Inventario guardado!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "¡Inventario transferido!"
 
@@ -3871,8 +3872,8 @@ msgstr "¡Inventario transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3890,22 +3891,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "¡Falta la fecha de la factura!"
 
@@ -3921,8 +3922,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3931,7 +3932,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "¡Falta el Número de Factura!"
 
@@ -3989,7 +3990,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "¡Concepto borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "¡El concepto no está registrado!"
 
@@ -4017,7 +4018,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4058,7 +4059,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4122,7 +4123,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "T. de Ent."
 
@@ -4343,11 +4344,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrada al sistema"
 
@@ -4424,7 +4425,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4455,9 +4456,9 @@ msgid "May"
 msgstr "Mayo"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Nota"
@@ -4804,15 +4805,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4826,15 +4827,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "¡No se suministró nada!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "¡No se seleccionó nada!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "¡Nada que transferir!"
 
@@ -4859,7 +4860,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4878,7 +4879,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato Numérico"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4916,7 +4917,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4931,7 +4932,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Existencia"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4986,7 +4987,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5004,12 +5005,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la orden"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "¡Falta la fecha de la orden!"
 
@@ -5021,8 +5022,8 @@ msgstr "Carga de Ordenes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5030,15 +5031,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número de la orden"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "No se ha definido el número de la orden"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "¡Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
@@ -5125,8 +5126,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5142,7 +5143,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5150,11 +5151,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Empaque"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "¡Falta la fecha en la lista de empaque!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "¡Falta el número en la lista de empaque!"
 
@@ -5178,7 +5179,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artículo"
 
@@ -5198,8 +5199,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5220,7 +5221,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5250,7 +5251,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5319,7 +5320,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "¡Falta la fecha del pago!"
 
@@ -5331,7 +5332,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5340,7 +5341,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5348,11 +5349,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5387,7 +5388,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5518,8 +5519,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5536,7 +5537,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como nuevo"
 
@@ -5631,9 +5632,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5642,11 +5643,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y guardar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5698,15 +5699,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5728,7 +5729,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5771,8 +5772,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5811,7 +5812,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5841,8 +5842,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5858,7 +5859,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de Cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "¡Falta la Fecha de Cotización!"
 
@@ -5866,11 +5867,11 @@ msgstr "¡Falta la Fecha de Cotización!"
 msgid "Quotation Number"
 msgstr "Número de Cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "¡Falta el Número de Cotización!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
@@ -5885,7 +5886,7 @@ msgstr "Cotizaciones"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5911,7 +5912,7 @@ msgstr "Solicitudes de cotización"
 msgid "ROP"
 msgstr "Existencia mínima"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5952,7 +5953,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Recb."
 
@@ -5981,7 +5982,7 @@ msgstr "Cuentas por Cobrar"
 msgid "Receive"
 msgstr "Recibir"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recibir mercadería"
 
@@ -6009,7 +6010,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6035,11 +6036,11 @@ msgstr "Trans. Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6076,9 +6077,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Remanente"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6106,7 +6111,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6118,7 +6123,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6154,11 +6159,11 @@ msgstr "Informes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6279,11 +6284,11 @@ msgstr "CIS"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6312,7 +6317,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura (venta)"
@@ -6321,8 +6326,8 @@ msgstr "Factura (venta)"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6387,7 +6392,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6432,7 +6437,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6440,7 +6445,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6457,7 +6462,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6466,7 +6471,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6504,7 +6509,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6517,12 +6522,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar Recurrencia"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6663,11 +6668,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccione el proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6687,12 +6692,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "¡Seleccione postscript o PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione Texto, Postscript o PDF!"
 
@@ -6783,7 +6788,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Núm. de serie"
 
@@ -6801,11 +6806,11 @@ msgstr "Número de serie"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6849,13 +6854,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Enviar"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Enviar Mercadería"
 
@@ -6885,12 +6890,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Enviar a"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6907,23 +6912,23 @@ msgstr "Enviar por"
 msgid "Shipping"
 msgstr "Envío"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de envío"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "¡Falta la fecha de envío!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6999,12 +7004,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7085,11 +7090,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Departamento"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7173,7 +7178,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7236,8 +7241,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7259,7 +7264,7 @@ msgstr "Impuestos"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7269,7 +7274,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7293,7 +7298,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7301,7 +7306,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "IVA Incluido"
@@ -7400,7 +7405,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7623,7 +7628,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7658,7 +7663,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7704,7 +7709,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7725,7 +7730,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7737,6 +7742,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7745,7 +7754,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento comercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7778,20 +7787,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Asientos"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir existencia"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7878,7 +7887,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7939,7 +7948,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7955,7 +7964,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7973,7 +7982,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8025,20 +8034,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Actualizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8100,7 +8109,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8186,8 +8195,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8206,7 +8215,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historial del Proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
@@ -8222,7 +8231,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8245,7 +8254,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "¡Falta el Proveedor!"
 
@@ -8282,7 +8291,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿Que tipo de articulo es este?"
 
@@ -8375,7 +8384,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8433,7 +8442,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8452,11 +8461,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8523,7 +8532,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8567,7 +8576,7 @@ msgstr "Terminado"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "c/u"
 

--- a/locale/po/es_PY.po
+++ b/locale/po/es_PY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Paraguay) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/es_PY/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Agregar Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Cotización de Moneda"
 
@@ -459,11 +459,11 @@ msgstr "Agregar Artículo"
 msgid "Add Pricegroup"
 msgstr "Agregar Grupo de Precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Agregar Orden de Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Agregar Cotización"
 
@@ -471,7 +471,7 @@ msgstr "Agregar Cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Pedir Cotización"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Agregar CIS"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Agregar Factura de Venta"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Agregar Orden de Venta"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Agregar Usuario"
 msgid "Add Vendor"
 msgstr "Agregar Proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Agregar Factura de Proveedor"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Almacén"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Seguro que desea borrar la Orden de Compra/Pedido?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "¿Seguro que desea borrar la Cotización?"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balance General"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Ubicación"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "¡No se puede borrar el Artículo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "¡No se puede borrar la Orden!"
 
@@ -1386,19 +1386,19 @@ msgstr "¡No se puede borrar la Orden!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "¡No se puede borrar la Cotización!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "¡No se puede registrar una Factura para un periodo cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "¡No se puede registrar un Pago para un periodo cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "¡No se puede registrar un Asiento para un periodo cerrado!"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "¡No se puede registrar el Asiento!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "¡No se puede guardar la Orden!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "¡No se puede guardar la Cotización!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Efectivo"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Empresa"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "¡Confirmar!"
 
@@ -1707,7 +1708,7 @@ msgstr "¡Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "¡No se pudo guardar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir existencia!"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Div"
 
@@ -1974,7 +1975,7 @@ msgstr "Div"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Código del Cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "¡Falta el Cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "¡El cliente no existe!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de Pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha de recepción"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "¡Falta la fecha de recepción!"
 
@@ -2270,7 +2271,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Terminado"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "¡Falta fecha de vencimiento!"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Correo electrónico"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Cambio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de Cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
@@ -3144,7 +3145,7 @@ msgstr "¡Falta la tasa de cambio para el pago!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "¡Falta la tasa de cambio!"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Cotización de Monedas"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3470,7 +3471,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Elaborar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas internas"
 
@@ -3859,11 +3860,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "¡Existencias guardadas!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "¡Existencias transferidas!"
 
@@ -3871,8 +3872,8 @@ msgstr "¡Existencias transferidas!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3890,22 +3891,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "¡Falta la fecha de la factura!"
 
@@ -3921,8 +3922,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3931,7 +3932,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "¡Falta el Número de Factura!"
 
@@ -3989,7 +3990,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "¡Concepto borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "¡El concepto no está registrado!"
 
@@ -4017,7 +4018,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4058,7 +4059,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4122,7 +4123,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "T. de Ent."
 
@@ -4343,11 +4344,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrada al sistema"
 
@@ -4424,7 +4425,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4455,9 +4456,9 @@ msgid "May"
 msgstr "Mayo"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Nota"
@@ -4804,15 +4805,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4826,15 +4827,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "¡No se suministró nada!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "¡No se seleccionó nada!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "¡Nada que transferir!"
 
@@ -4859,7 +4860,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4878,7 +4879,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato Numérico"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4916,7 +4917,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4931,7 +4932,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Existencia"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4986,7 +4987,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5004,12 +5005,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la orden"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "¡Falta la fecha de la orden!"
 
@@ -5021,8 +5022,8 @@ msgstr "Carga de Ordenes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5030,15 +5031,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número de la orden"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "No se ha definido el número de la orden"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "¡Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
@@ -5125,8 +5126,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5142,7 +5143,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5150,11 +5151,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Empaque"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "¡Falta la fecha en la lista de empaque!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "¡Falta el número en la lista de empaque!"
 
@@ -5178,7 +5179,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artículo"
 
@@ -5198,8 +5199,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5220,7 +5221,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5250,7 +5251,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5319,7 +5320,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "¡Falta la fecha del pago!"
 
@@ -5331,7 +5332,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5340,7 +5341,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5348,11 +5349,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5387,7 +5388,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5518,8 +5519,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5536,7 +5537,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como nuevo"
 
@@ -5631,9 +5632,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5642,11 +5643,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y guardar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5698,15 +5699,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5728,7 +5729,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5771,8 +5772,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5811,7 +5812,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5841,8 +5842,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5858,7 +5859,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de Cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "¡Falta la Fecha de Cotización!"
 
@@ -5866,11 +5867,11 @@ msgstr "¡Falta la Fecha de Cotización!"
 msgid "Quotation Number"
 msgstr "Número de Cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "¡Falta el Número de Cotización!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
@@ -5885,7 +5886,7 @@ msgstr "Cotizaciones"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5911,7 +5912,7 @@ msgstr "Solicitudes de cotización"
 msgid "ROP"
 msgstr "Existencia mínima"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5952,7 +5953,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Recb."
 
@@ -5981,7 +5982,7 @@ msgstr "Cuentas a Cobrar"
 msgid "Receive"
 msgstr "Recibir"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recibir mercadería"
 
@@ -6009,7 +6010,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6035,11 +6036,11 @@ msgstr "Trans. Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6076,9 +6077,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Remanente"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6106,7 +6111,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6118,7 +6123,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6154,11 +6159,11 @@ msgstr "Informes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6279,11 +6284,11 @@ msgstr "CIS"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6312,7 +6317,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura (venta)"
@@ -6321,8 +6326,8 @@ msgstr "Factura (venta)"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6387,7 +6392,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6432,7 +6437,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6440,7 +6445,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6457,7 +6462,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6466,7 +6471,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6504,7 +6509,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6517,12 +6522,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar Recurrencia"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6663,11 +6668,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccione el proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6687,12 +6692,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "¡Seleccione postscript o PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione Texto, Postscript o PDF!"
 
@@ -6783,7 +6788,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Núm. de serie"
 
@@ -6801,11 +6806,11 @@ msgstr "Número de serie"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6849,13 +6854,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Enviar"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Enviar Mercadería"
 
@@ -6885,12 +6890,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Enviar a"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6907,23 +6912,23 @@ msgstr "Enviar por"
 msgid "Shipping"
 msgstr "Envío"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de envío"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "¡Falta la fecha de envío!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6999,12 +7004,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7085,11 +7090,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Departamento"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7173,7 +7178,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7236,8 +7241,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7259,7 +7264,7 @@ msgstr "Impuestos"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7269,7 +7274,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7293,7 +7298,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7301,7 +7306,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "IVA Incluido"
@@ -7400,7 +7405,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7623,7 +7628,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7658,7 +7663,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7704,7 +7709,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7725,7 +7730,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7737,6 +7742,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7745,7 +7754,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento comercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7778,20 +7787,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Asientos"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir existencia"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7878,7 +7887,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7939,7 +7948,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7955,7 +7964,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7973,7 +7982,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8025,20 +8034,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Actualizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8100,7 +8109,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8186,8 +8195,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8206,7 +8215,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historial del Proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
@@ -8222,7 +8231,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8245,7 +8254,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "¡Falta el Proveedor!"
 
@@ -8282,7 +8291,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿Que tipo de articulo es este?"
 
@@ -8375,7 +8384,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8433,7 +8442,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8452,11 +8461,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8523,7 +8532,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8567,7 +8576,7 @@ msgstr "Terminado"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "c/u"
 

--- a/locale/po/es_SV.po
+++ b/locale/po/es_SV.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (El Salvador) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/es_SV/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Añadir Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Cotización de Moneda"
 
@@ -459,11 +459,11 @@ msgstr "Agregar Parte"
 msgid "Add Pricegroup"
 msgstr "Nuevo grupo de precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Agregar Orden de Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Nueva cotización"
 
@@ -471,7 +471,7 @@ msgstr "Nueva cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Añadir Pedido de Cotización"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Agregar CIS"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Agregar Factura de Venta"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Agregar Nota de Remisión"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Agregar Usuario"
 msgid "Add Vendor"
 msgstr "Agregar Proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Agregar Factura Proveedor"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Deposito"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Seguro que desea borrar la Orden de Compra/Pedido?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "¿Está seguro que desea borrar la Cotización número"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Balance"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Hoja de Balance"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Bin"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "No puede borrar ítem!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "No puede borrar pedido!"
 
@@ -1386,19 +1386,19 @@ msgstr "No puede borrar pedido!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "No se puede borrar presupuesto!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "No se puede registrar factura para un periodo cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "No se puede registrar pago para un periodo cerrado"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "No se puede registrar una transacción para un periodo cerrado"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "No puede registrar transacción!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "No puede guardar órden!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "¡No se puede guardar la Cotización!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Caja"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Compañía"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar!"
 
@@ -1707,7 +1708,7 @@ msgstr "Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "No pude guardar"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "¡No se pudo transferir el inventario"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Mon."
 
@@ -1974,7 +1975,7 @@ msgstr "Mon."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Número de cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Falta cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "Cliente no existe en archivo!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha de recibo"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Faltas datos"
 
@@ -2270,7 +2271,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de Entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Listo"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de Vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta Fecha de Vencimiento!"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Correo Electrónico"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Interc."
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de Intercambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "No se encuentra pago por cambio de moneda"
 
@@ -3144,7 +3145,7 @@ msgstr "No se encuentra pago por cambio de moneda"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "No se encuentra cambio de moneda"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde Deposito"
 
@@ -3470,7 +3471,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Elaborar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Anotaciones Internas"
 
@@ -3860,11 +3861,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "¡Inventario guardado!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
@@ -3872,8 +3873,8 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3891,22 +3892,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de Factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Falta la Fecha de la Factura!"
 
@@ -3922,8 +3923,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3932,7 +3933,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de Factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Falta el Número de Factura!"
 
@@ -3990,7 +3991,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "Item borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "¡El artículo no se encuentra en archivo!"
 
@@ -4018,7 +4019,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4059,7 +4060,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4123,7 +4124,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "T. de Ent."
 
@@ -4344,11 +4345,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Nombre de Acceso"
 
@@ -4425,7 +4426,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4456,9 +4457,9 @@ msgid "May"
 msgstr "May"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4805,15 +4806,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4827,15 +4828,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "¡No se suministro nada!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nada seleccionado!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "¡Nada que transferir!"
 
@@ -4860,7 +4861,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4879,7 +4880,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato de Numero"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4917,7 +4918,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4932,7 +4933,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "En Existencia"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4987,7 +4988,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5005,12 +5006,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de Orden"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "No se encuentra la fecha de orden!"
 
@@ -5022,8 +5023,8 @@ msgstr "Orden de Entrada"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5031,15 +5032,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Orden Número"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "No se encuentra el número de orden!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Fallo Elaboración Pedido"
 
@@ -5126,8 +5127,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5143,7 +5144,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5151,11 +5152,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Empaque"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "¡Falta Fecha de Lista de Empaque!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "!Falta nzmero en lista de empaque!"
 
@@ -5179,7 +5180,7 @@ msgstr "Total Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Partes"
 
@@ -5199,8 +5200,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5221,7 +5222,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5251,7 +5252,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "No se encuentra la fecha de Pago!"
 
@@ -5332,7 +5333,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5349,11 +5350,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5388,7 +5389,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5519,8 +5520,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5537,7 +5538,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como nuevo"
 
@@ -5632,9 +5633,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5643,11 +5644,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y Salvar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5699,15 +5700,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5729,7 +5730,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5772,8 +5773,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5812,7 +5813,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5842,8 +5843,8 @@ msgid "Quarter"
 msgstr "Cuarto"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5859,7 +5860,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de Cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "¡Falta la fecha de la cotización!"
 
@@ -5867,11 +5868,11 @@ msgstr "¡Falta la fecha de la cotización!"
 msgid "Quotation Number"
 msgstr "Número de cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "¡Falta Número de Cotización!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Presupuesto eliminado!"
 
@@ -5886,7 +5887,7 @@ msgstr "Presupuestos"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5912,7 +5913,7 @@ msgstr "Sols. de Cots."
 msgid "ROP"
 msgstr "ROP"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5953,7 +5954,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Rec"
 
@@ -5982,7 +5983,7 @@ msgstr "Por cobrar"
 msgid "Receive"
 msgstr "Recibir"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Recibir mercancia"
 
@@ -6010,7 +6011,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6036,11 +6037,11 @@ msgstr "Trans. Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6077,9 +6078,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Faltan"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6107,7 +6112,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6119,7 +6124,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,11 +6160,11 @@ msgstr "Reportes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6280,11 +6285,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6313,7 +6318,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura de Venta"
@@ -6322,8 +6327,8 @@ msgstr "Factura de Venta"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Factura/Numero de Transaccion para Ingreso"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6433,7 +6438,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6441,7 +6446,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6458,7 +6463,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6467,7 +6472,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6505,7 +6510,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6518,12 +6523,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar Recurrencia"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6664,11 +6669,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccione el proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecciones una Impresora!"
 
@@ -6688,12 +6693,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Seleccione postscript o PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione Texto, Postscript o PDF!"
 
@@ -6784,7 +6789,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Núm. de serie"
 
@@ -6802,11 +6807,11 @@ msgstr "Serial"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6850,13 +6855,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Envíe"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Despachar Mercancia"
 
@@ -6886,12 +6891,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Envíe a"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6908,23 +6913,23 @@ msgstr "Envía vía"
 msgid "Shipping"
 msgstr "Despacho"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de Envio"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "¡Falta la fecha de envío!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7000,12 +7005,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7086,11 +7091,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7174,7 +7179,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7237,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7260,7 +7265,7 @@ msgstr "Impuesto"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7270,7 +7275,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7294,7 +7299,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7302,7 +7307,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impuesto Incluido"
@@ -7401,7 +7406,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7624,7 +7629,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7659,7 +7664,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7705,7 +7710,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7726,7 +7731,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7738,6 +7743,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7746,7 +7755,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento por Intercambio"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7779,20 +7788,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Transacciones"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir existencia"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7879,7 +7888,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7940,7 +7949,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7956,7 +7965,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7974,7 +7983,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8026,20 +8035,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Actalizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8101,7 +8110,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8187,8 +8196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8207,7 +8216,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historia de Proveedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de Proveedor"
@@ -8223,7 +8232,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8246,7 +8255,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Falta proveedor!"
 
@@ -8283,7 +8292,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8360,7 +8369,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿Que tipo de Item es este?"
 
@@ -8376,7 +8385,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8434,7 +8443,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8453,11 +8462,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8524,7 +8533,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8568,7 +8577,7 @@ msgstr "Hecho"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "c/u"
 

--- a/locale/po/es_VE.po
+++ b/locale/po/es_VE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/es_VE/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Acceso restringido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Depre. Acumulada"
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Agregar Empleado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Agregar Tasa de Cambio"
 
@@ -459,11 +459,11 @@ msgstr "Agregar Artículo"
 msgid "Add Pricegroup"
 msgstr "Agregar Grupo de Precios"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Agregar Orden de Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Agregar Cotización"
 
@@ -471,7 +471,7 @@ msgstr "Agregar Cotización"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Agregar Solicitud de Cotización"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Agregar SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Agregar Factura"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Agregar Pedido"
 
@@ -503,7 +503,7 @@ msgstr "Agregar Forma de Impuesto"
 msgid "Add Timecard"
 msgstr "Agregar Hoja de Tiempo"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Agregar Usuario"
 msgid "Add Vendor"
 msgstr "Agregar Proveedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Agregar Factura de Proveedor"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Almacén"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Ajustar Basicos"
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Aprobar"
@@ -827,20 +827,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valor Adquirido"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Valor Adquirido Remanente"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "¿Seguro que desea borrar la Orden de Compra/Pedido?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "¿Está seguro que desea borrar la Cotización número"
 
@@ -913,16 +913,16 @@ msgstr "Etiqueta de Activo"
 msgid "Assets"
 msgstr "Activos"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Total de Capital y Pasivos"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Adjuntar"
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Adjuntado A"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Adjuntado al Tipo"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Archivos Adjuntado y Enlazados"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Adjuntado en"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Adjuntado por"
@@ -1010,7 +1010,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Balance"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Hoja de Balance"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basico"
 
@@ -1139,7 +1139,7 @@ msgstr "Lote"
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Anaquel/Cesta"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Calcular Impuestos"
 
@@ -1321,12 +1321,12 @@ msgstr "Calcular Impuestos"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr "No se puede crear el servicio; No existe la cuenta de ingreso!"
 msgid "Cannot delete item!"
 msgstr "¡No se puede borrar el artículo!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "¡No se puede borrar el pedido!"
 
@@ -1386,19 +1386,19 @@ msgstr "¡No se puede borrar el pedido!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "¡No puedo borrar la cotización!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "¡No se puede registrar una factura en un periodo cerrado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "¡No se puede registrar un pago en un periodo cerrado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "¡No se puede registrar un asiento en un periodo cerrado"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "¡No se puede registrar un asiento con un débito y un crédito para la misma "
 "cuenta!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "¡No se puede registrar el asiento!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "¡No se puede guardar el pedido!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "¡No se puede guardar la cotización!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Caja"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Compañía"
 
@@ -1647,7 +1648,7 @@ msgstr "Telefono de la Empresa"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "¡Favor Confirmar!"
 
@@ -1707,7 +1708,7 @@ msgstr "¡Favor Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Costo"
 
@@ -1823,19 +1824,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "No se puede salvar la informacion. Por favor vuelva a intentarlo"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "¡No se pudo guardar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "No se pudo transferir Inventario!"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1941,7 +1942,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Factura de Credito"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr "Creditos"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Mon."
 
@@ -1974,7 +1975,7 @@ msgstr "Mon."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Código de Cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "¡Falta el cliente!"
 
@@ -2070,7 +2071,7 @@ msgstr "¡El cliente no existe en la base datos!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Informacion no salvada. Por favor vuelva a intentarlo."
 
@@ -2143,7 +2144,7 @@ msgstr "La base de datos no existe."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Fecha de Pago"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Fecha Recibido"
 
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Fecha de Nacimiento"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "¡Falta fecha de recibo!"
 
@@ -2270,7 +2271,7 @@ msgstr "Días"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Fecha de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Depresiacion Basica"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Metodo de Depresiacion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Comienzo de Depreciacion"
 
@@ -2452,11 +2453,11 @@ msgstr "Comienzo de Depreciacion"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Depre. de año hasta la fecha"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Depre. esta corrida"
 
@@ -2478,7 +2479,7 @@ msgstr "Depreciar"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Depreciacion"
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Valor de Dispo. Adquirida"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Fecha de Disposicion"
 
@@ -2641,7 +2642,7 @@ msgstr "Fecha de Disposicion"
 msgid "Disposal Method"
 msgstr "Metodo de Disposicion"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Hecho"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Borrador Anunciado"
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Fecha de Vencimiento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta la Fecha de Vencimiento"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Vida Estimada"
 
@@ -3123,20 +3124,20 @@ msgstr "Vida Estimada"
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Cambio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasa de Cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "¡Falta la tasa de cambio para el pago!"
 
@@ -3144,7 +3145,7 @@ msgstr "¡Falta la tasa de cambio para el pago!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "¡Falta tasa de cambio!"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Divisas"
 
@@ -3268,7 +3269,7 @@ msgstr "cincuenta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Archivo Importado!"
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nombre de Archivo"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tipo de Archivo"
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nombre"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "catorce"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Desde almacén"
 
@@ -3470,7 +3471,7 @@ msgstr "N. Referencia Mayor General"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Ganancia (Perdida)"
 
@@ -3478,7 +3479,7 @@ msgstr "Ganancia (Perdida)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Generar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Generar órdenes"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generar órdenes de compra"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Anotaciones Internas"
 
@@ -3860,11 +3861,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventario guardado!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventario transferido!"
 
@@ -3872,8 +3873,8 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3891,22 +3892,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fecha de Factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "¡Falta Fecha de Factura!"
 
@@ -3922,8 +3923,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3932,7 +3933,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de Factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "¡Falta Número de Factura!"
 
@@ -3990,7 +3991,7 @@ msgstr "Articulo"
 msgid "Item deleted!"
 msgstr "¡Artículo borrado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "¡El artículo no se encuentra en la base de datos!"
 
@@ -4018,7 +4019,7 @@ msgstr "Ene"
 msgid "January"
 msgstr "Enero"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4059,7 +4060,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junio"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4123,7 +4124,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "T. de Ent."
 
@@ -4344,11 +4345,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4425,7 +4426,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4456,9 +4457,9 @@ msgid "May"
 msgstr "May"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4805,15 +4806,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4827,15 +4828,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "No hay nada ingresado"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "¡No se ha seleccionado nada!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "¡No hay nada que transferir!"
 
@@ -4860,7 +4861,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4879,7 +4880,7 @@ msgstr "Código"
 msgid "Number Format"
 msgstr "Formato de Número"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4917,7 +4918,7 @@ msgstr "Oct"
 msgid "October"
 msgstr "Octubre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4932,7 +4933,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "En Espera"
@@ -4987,7 +4988,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orden"
 
@@ -5005,12 +5006,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la Orden"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "¡Falta fecha de la Orden!"
 
@@ -5022,8 +5023,8 @@ msgstr "Órdenes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5031,15 +5032,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Orden N°"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "¡Falta Número de la Orden!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "¡Orden borrada!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "¡No se pudo generar la orden!"
 
@@ -5126,8 +5127,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5143,7 +5144,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5151,11 +5152,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Empaque"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "¡Falta Fecha de Lista de Empaque!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "¡Falta Código de Lista de Empaque!"
 
@@ -5179,7 +5180,7 @@ msgstr "Pagado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Parte"
 
@@ -5199,8 +5200,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5221,7 +5222,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5251,7 +5252,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Falta fecha de pago"
 
@@ -5332,7 +5333,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5349,11 +5350,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Porcentaje Disposcionado"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Porcentaje Remanente"
 
@@ -5388,7 +5389,7 @@ msgstr "Teléfono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5519,8 +5520,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registrar"
@@ -5537,7 +5538,7 @@ msgstr "Fecha Anuncio"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Registrar como nuevo"
 
@@ -5632,9 +5633,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5643,11 +5644,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir y Guardar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir y Guardar como Nuevo"
 
@@ -5699,15 +5700,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Depre. Previa"
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Atravez Previo"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Recaudacion"
 
@@ -5729,7 +5730,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5772,8 +5773,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5812,7 +5813,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5842,8 +5843,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5859,7 +5860,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Fecha de Cotización"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Falta Fecha de Cotización"
 
@@ -5867,11 +5868,11 @@ msgstr "Falta Fecha de Cotización"
 msgid "Quotation Number"
 msgstr "Número de Cotización"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "¡Falta Número de Cotización!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "¡Cotización borrada!"
 
@@ -5886,7 +5887,7 @@ msgstr "Cotizaciones"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5912,7 +5913,7 @@ msgstr "Solicitudes de Cotización"
 msgid "ROP"
 msgstr "Existencia Mínima"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5953,7 +5954,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Rcbdo"
 
@@ -5982,7 +5983,7 @@ msgstr "CxC"
 msgid "Receive"
 msgstr "Almacenar"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Almacenar Mercancía"
 
@@ -6010,7 +6011,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar en"
 
@@ -6036,11 +6037,11 @@ msgstr "Transacciones Recurrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6077,9 +6078,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Vida Remanente"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resto"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6107,7 +6112,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resultados de Reportes"
 
@@ -6119,7 +6124,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,11 +6160,11 @@ msgstr "Reportes"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Ped."
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6280,11 +6285,11 @@ msgstr "CIE"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6313,7 +6318,7 @@ msgstr "Venta"
 msgid "Sales"
 msgstr "Ventas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura de Ventas"
@@ -6322,8 +6327,8 @@ msgstr "Factura de Ventas"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "N° Factura/Transacción de CxC"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6433,7 +6438,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6441,7 +6446,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6458,7 +6463,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -6467,7 +6472,7 @@ msgstr "Guardar como nuevo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6505,7 +6510,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6518,12 +6523,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programar"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programada"
 
@@ -6664,11 +6669,11 @@ msgstr "Seleccione el cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Seleccione el proveedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "¡Seleccione una impresora!"
 
@@ -6688,12 +6693,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "¡Seleccione postscript o PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "¡Seleccione txt, postscript o PDF!"
 
@@ -6784,7 +6789,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serial"
 
@@ -6802,11 +6807,11 @@ msgstr "Serial"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servicio"
 
@@ -6850,13 +6855,13 @@ msgstr "diecisiete"
 msgid "Seventy"
 msgstr "setenta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Envío"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Enviar Mercancía"
 
@@ -6886,12 +6891,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Destino"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6908,23 +6913,23 @@ msgstr "Envío por"
 msgid "Shipping"
 msgstr "Envío"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Fecha de Envío"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Falta Fecha de Envío"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7000,12 +7005,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7086,11 +7091,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7174,7 +7179,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7237,8 +7242,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Etiqueta"
 
@@ -7260,7 +7265,7 @@ msgstr "Impuesto"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Codigo de Impuesto"
 
@@ -7270,7 +7275,7 @@ msgstr "Codigo de Impuesto"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Forma de Impuesto Aplicada"
 
@@ -7294,7 +7299,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Formas de Impuesto"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "ID Impuesto"
 
@@ -7302,7 +7307,7 @@ msgstr "ID Impuesto"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impuesto Incluído"
@@ -7401,7 +7406,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7624,7 +7629,7 @@ msgstr "Veces"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7659,7 +7664,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Hacia almacén"
 
@@ -7705,7 +7710,7 @@ msgstr "Nivel Raiz"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7726,7 +7731,7 @@ msgstr "Nivel Raiz"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Depre. Acumulada Total"
 
@@ -7738,6 +7743,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Partes"
@@ -7746,7 +7755,7 @@ msgstr "Partes"
 msgid "Trade Discount"
 msgstr "Descuento Comercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Asiento"
 
@@ -7779,20 +7788,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Asientos"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferir Inventario"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transferir desde"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir a"
 
@@ -7879,7 +7888,7 @@ msgstr "dos"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7940,7 +7949,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7956,7 +7965,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7974,7 +7983,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Se encontro una base de datos desconocida."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8026,20 +8035,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Actualizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8101,7 +8110,7 @@ msgstr "Usar Sobrepago de Ingreso"
 msgid "Use Overpayment"
 msgstr "Usar Sobrepago"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8187,8 +8196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8207,7 +8216,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Histórico de Proveedores"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de Compra"
@@ -8223,7 +8232,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8246,7 +8255,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "¡Falta Proveedor!"
 
@@ -8283,7 +8292,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8360,7 +8369,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "¿Qué tipo de artículo es este?"
 
@@ -8376,7 +8385,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8434,7 +8443,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sí"
@@ -8453,11 +8462,11 @@ msgstr ""
 msgid "Zero"
 msgstr "cero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8524,7 +8533,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8568,7 +8577,7 @@ msgstr "hecho"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "c/u"
 

--- a/locale/po/et.po
+++ b/locale/po/et.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>, 2015\n"
 "Language-Team: Estonian (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -186,7 +186,7 @@ msgstr "Loobumine"
 msgid "Access Denied"
 msgstr "Ligipääs keelatud"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -194,9 +194,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -204,7 +204,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -315,7 +315,7 @@ msgstr "Tekkepõhine"
 msgid "Accrual Basis:"
 msgstr "Tekkepõhine:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgstr "Lisa deebet märkus"
 msgid "Add Employee"
 msgstr "Lisa Töötaja"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Lisa Valuutakurss"
 
@@ -460,11 +460,11 @@ msgstr "Lisa Detail"
 msgid "Add Pricegroup"
 msgstr "Lisa Hinnagrupp"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Lisa Hanketellimus"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Lisa Koteering"
 
@@ -472,7 +472,7 @@ msgstr "Lisa Koteering"
 msgid "Add Reporting Unit"
 msgstr "Lisa aruande ühik"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Lisa Hinnapakkumuse Taotlus"
 
@@ -484,11 +484,11 @@ msgstr "Lisa tagastus"
 msgid "Add SIC"
 msgstr "Lisa Standardiseeritud Tööstuskood"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Lisa Müügiarve"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Lisa Müügitellimus"
 
@@ -504,7 +504,7 @@ msgstr "Lisa maksuvorm"
 msgid "Add Timecard"
 msgstr "Lisa ajakaart"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Lisa listi"
 
@@ -526,7 +526,7 @@ msgstr "Lisa Kasutaja"
 msgid "Add Vendor"
 msgstr "Lisa Tarnija"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Lisa Ostuarve"
 
@@ -538,15 +538,15 @@ msgstr "Lisa tarnijale tagastus"
 msgid "Add Warehouse"
 msgstr "Lisa Kaubaladu"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Lisa rida 1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Lisa rida 2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Lisa rida 3"
 
@@ -574,8 +574,8 @@ msgstr "Lisatud id [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -607,7 +607,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -684,9 +684,9 @@ msgstr "Luba sisestus"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -789,8 +789,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Kiida heaks"
@@ -828,20 +828,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "Aprill"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Kas oled kindel, et soovid kustutada Tellimuse Number"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Kas oled kindel, et soovid Koteeringu Number"
 
@@ -914,16 +914,16 @@ msgstr "Vara silt"
 msgid "Assets"
 msgstr "Varad"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Varad omakapitali suhe"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr "Varad kohustustesse suhe"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Manusta"
@@ -954,31 +954,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1011,7 +1011,7 @@ msgstr "August"
 msgid "Author: [_1]"
 msgstr "Autor: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automaatne"
 
@@ -1080,7 +1080,7 @@ msgid "Balance"
 msgstr "Bilanss"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilansiaruanne"
@@ -1127,8 +1127,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1140,7 +1140,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1207,14 +1207,14 @@ msgstr "miljard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Pakendit"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1314,7 +1314,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Arvuta maksud"
 
@@ -1322,12 +1322,12 @@ msgstr "Arvuta maksud"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Tühistatud arvet ei saa tühistada!"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Kaubaartiklit ei saa kustutada!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Tellimust ei saa kustutada!"
 
@@ -1385,19 +1385,19 @@ msgstr "Tellimust ei saa kustutada!"
 msgid "Cannot delete posted transaction"
 msgstr "Kannet ei saa kustutada!"
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Koteeringut ei saa kustutada!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Arvet ei saa salvestada suletud perioodile!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Makset ei saa salvestada suletud perioodile!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Kannet ei saa salvestada suletud perioodile!"
 
@@ -1406,15 +1406,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "Ei saa postitada tehingut deebeti ja kreediti väljadega samal kontol!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Tehingut ei saa salvestada!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Tellimust ei saa salvestada!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Koteeringut ei saa salvestada!"
 
@@ -1434,7 +1434,8 @@ msgstr "Kaardi ID"
 msgid "Cash"
 msgstr "Kassaseis"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Raha konto"
 
@@ -1495,7 +1496,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1611,7 +1612,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firma"
 
@@ -1644,7 +1645,7 @@ msgstr "Ettevõtte telefon"
 msgid "Company Sales Tax ID"
 msgstr "Ettevõtte KM-kohuslase number"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1696,7 +1697,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Kinnita!"
 
@@ -1704,7 +1705,7 @@ msgstr "Kinnita!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1747,8 +1748,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1759,7 +1760,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1808,7 +1809,7 @@ msgid "Copy to New Name"
 msgstr "Kopeeri uueks nimega"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Omahind"
 
@@ -1820,19 +1821,19 @@ msgstr "Müüdud kauba kulu"
 msgid "Could Not Load Template from DB"
 msgstr "Ei õnnestu laadida malli andmebaasist"
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Salvestamine ebaõnnestus. Palun proovige uuesti"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Ei saa salvestada!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Laoseisu ei saa ümber paigutada!"
 
@@ -1852,8 +1853,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1917,7 +1918,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kreedit"
 
@@ -1938,7 +1939,7 @@ msgstr "Kreeditkontod"
 msgid "Credit Invoice"
 msgstr "Kreeditarve"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1962,7 +1963,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Val."
 
@@ -1971,7 +1972,7 @@ msgstr "Val."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2008,7 +2009,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2038,7 +2039,7 @@ msgstr "Kliendi nimi"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2051,7 +2052,7 @@ msgstr "Kliendi Number"
 msgid "Customer Search"
 msgstr "Kliendi otsing"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Klienti puudu!"
 
@@ -2067,7 +2068,7 @@ msgstr "Klient puudub failis!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Andmed ei ole salvestatud. Palun proovige uuesti."
 
@@ -2140,7 +2141,7 @@ msgstr ""
 msgid "Database exists."
 msgstr "Andmebaas eksisteerib."
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2155,11 +2156,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2197,7 +2198,7 @@ msgstr "Maksekuupäev"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Kättesaamise kuupäev"
 
@@ -2221,7 +2222,7 @@ msgstr "Kuupäev alates"
 msgid "Date of Birth"
 msgstr "Sünnikuupäev"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Kattesaamise kuupäev puudub!"
 
@@ -2267,7 +2268,7 @@ msgstr "Päeva"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Deebet"
 
@@ -2380,9 +2381,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2432,16 +2433,16 @@ msgstr "Üleandmine"
 msgid "Delivery Date"
 msgstr "Tarnetähtaeg"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2449,11 +2450,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2475,7 +2476,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2527,13 +2528,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2550,7 +2551,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2621,16 +2622,16 @@ msgstr "Allahindluse %"
 msgid "Discount:"
 msgstr "Allahindlus:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Näita soetusmaksumust"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Realiseerimine"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Realiseerimise kuupäev"
 
@@ -2638,7 +2639,7 @@ msgstr "Realiseerimise kuupäev"
 msgid "Disposal Method"
 msgstr "Realiseerimise meetod"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Realiseerimise aruanne [_1] kuupäeval [_2]"
 
@@ -2646,7 +2647,7 @@ msgstr "Realiseerimise aruanne [_1] kuupäeval [_2]"
 msgid "Division by 0 error"
 msgstr "Viga nulliga jagamisel"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr "Ära jära lahtrit tühjaks [_1]"
 
@@ -2662,7 +2663,7 @@ msgstr "Dokumendi tüüp"
 msgid "Don't know what to do with backup"
 msgstr "Ei tea, mida teha varukoopiaga"
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Valmis"
 
@@ -2682,7 +2683,7 @@ msgstr ""
 msgid "Dr."
 msgstr "Doktor"
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Mustand salvestatud"
 
@@ -2724,14 +2725,14 @@ msgstr "Tähtaeg"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Maksetähtaeg"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Maksetähtaeg puudub!"
 
@@ -2743,8 +2744,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr "Töötaja number topelt"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-post"
 
@@ -3046,11 +3047,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "Ümbrik"
@@ -3088,7 +3089,7 @@ msgstr "Total de Capital y Pasivos"
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3112,7 +3113,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3120,20 +3121,20 @@ msgstr ""
 msgid "Every"
 msgstr "Iga"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Kurss"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Valuutakurss"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Maksel puudub valuutakurss!"
 
@@ -3141,7 +3142,7 @@ msgstr "Maksel puudub valuutakurss!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Valuutakurss puudu!"
 
@@ -3186,8 +3187,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Valuutavahetus"
 
@@ -3265,7 +3266,7 @@ msgstr "viiskümmend"
 msgid "File"
 msgstr "Fail"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Fail imporditud"
 
@@ -3279,17 +3280,17 @@ msgstr "Faili nimi"
 msgid "File Type"
 msgstr "Faili tüüp"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Faili nimi"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Faili tüüp"
@@ -3326,7 +3327,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Eesnimi"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3386,7 +3387,7 @@ msgstr "neliteist"
 msgid "Fri"
 msgstr "Reede"
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3418,7 +3419,7 @@ msgstr "Alates"
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Tuleb Kaubalaost"
 
@@ -3467,7 +3468,7 @@ msgstr "Pearaamatu Viitenumber"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3475,7 +3476,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3504,11 +3505,11 @@ msgstr "Genereeri"
 msgid "Generate Control Code"
 msgstr "Genereeri kontrollkood"
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Genereeri Tellimused"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Genereeri Ostutellimused"
 
@@ -3553,8 +3554,8 @@ msgid "Grand Total"
 msgstr "Kokku"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupeeri"
 
@@ -3796,8 +3797,8 @@ msgstr "Andmebaasi sisene viga"
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Sisemärkused"
 
@@ -3855,11 +3856,11 @@ msgstr "Enne komplekti aegunuks märkimist peab laoseis null olema!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr "Enne toote aegunuks märkimist peab laoseis null olema!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Laoseis salvestatud!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Laoseis üle kantud!"
 
@@ -3867,8 +3868,8 @@ msgstr "Laoseis üle kantud!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3886,22 +3887,22 @@ msgstr "Kaubaarve"
 msgid "Invoice #"
 msgstr "Arve nr"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Arve loonud"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Arve koostamise kuupäev puudub!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Kaubaarve Kuupäev"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Kaubaarvel Kuupäev puudu!"
 
@@ -3917,8 +3918,8 @@ msgstr "Arve nr"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3927,7 +3928,7 @@ msgstr "Arve nr"
 msgid "Invoice Number"
 msgstr "Kaubaarve Number"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Kaubaarve Number puudu!"
 
@@ -3985,7 +3986,7 @@ msgstr "AR."
 msgid "Item deleted!"
 msgstr "Kaubaartikkel kustutatud!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Kaubaartikkel pole failis !"
 
@@ -4013,7 +4014,7 @@ msgstr "Jaan"
 msgid "January"
 msgstr "Jaanuar"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4054,7 +4055,7 @@ msgstr "Juun"
 msgid "June"
 msgstr "Juuni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4118,7 +4119,7 @@ msgstr "Viimati uuendatud"
 msgid "Last name"
 msgstr "Perekonnanimi"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Juhtimine"
 
@@ -4339,11 +4340,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Logi sisse"
 
@@ -4420,7 +4421,7 @@ msgstr "Juhataja"
 msgid "Manager:"
 msgstr "Juhataja:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Manuaalne"
 
@@ -4451,9 +4452,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4800,15 +4801,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4822,15 +4823,15 @@ msgstr "Märkused"
 msgid "Notes:<br />"
 msgstr "Märkused:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Midagi pole sisestatud!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Valik puudub!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Pole midagi ümber paigutada!"
 
@@ -4855,7 +4856,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4874,7 +4875,7 @@ msgstr "Number"
 msgid "Number Format"
 msgstr "Numbri Formaat"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4912,7 +4913,7 @@ msgstr "Okt"
 msgid "October"
 msgstr "Oktoober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4927,7 +4928,7 @@ msgstr "Kehtiv salasõna"
 msgid "On Hand"
 msgstr "Saadaval"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4982,7 +4983,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Tellimus"
 
@@ -5000,12 +5001,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tellimuse Kuupäev"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Tellimuse Kuupäev puudub!"
 
@@ -5017,8 +5018,8 @@ msgstr "Tellimuse Sisestus"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5026,15 +5027,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Tellimuse Number"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Tellimuse Number puudub"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Tellimus kustutatud!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Arve genereerimine ebaõnnestus!"
 
@@ -5121,8 +5122,8 @@ msgstr "Ostutellimus"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5138,7 +5139,7 @@ msgstr "Salvesta"
 msgid "POST AND PRINT"
 msgstr "Salvesta ja trüki"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5146,11 +5147,11 @@ msgstr "Salvesta ja trüki"
 msgid "Packing List"
 msgstr "Saateleht"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Saatelehe Kuupäev puudu!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Saateelehe Number puudu!"
 
@@ -5174,7 +5175,7 @@ msgstr "Makstud"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Detail"
 
@@ -5194,8 +5195,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5216,7 +5217,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5246,7 +5247,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Parool"
 
@@ -5315,7 +5316,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Maksekuupäev puudu!"
 
@@ -5327,7 +5328,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5336,7 +5337,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Maksed"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5344,11 +5345,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5383,7 +5384,7 @@ msgstr "Telefon"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5514,8 +5515,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Postita"
@@ -5532,7 +5533,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Postita uuena"
 
@@ -5627,9 +5628,9 @@ msgid "Primary Phone"
 msgstr "Peamine telefon"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Trüki"
@@ -5638,11 +5639,11 @@ msgstr "Trüki"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Trüki ja Salvesta"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Trüki ja Salvesta uuena"
 
@@ -5694,15 +5695,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5724,7 +5725,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5767,8 +5768,8 @@ msgstr "Ostu kuupäev:"
 msgid "Purchase History"
 msgstr "Ostu ajalugu"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5807,7 +5808,7 @@ msgstr "Ostetud"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5837,8 +5838,8 @@ msgid "Quarter"
 msgstr "Kvartal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5854,7 +5855,7 @@ msgstr "Müügipakkumine nr"
 msgid "Quotation Date"
 msgstr "Koteeringu kuupäev"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Koteeringu Kuupäev puudu!"
 
@@ -5862,11 +5863,11 @@ msgstr "Koteeringu Kuupäev puudu!"
 msgid "Quotation Number"
 msgstr "Koteeringu Number"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Koteeringu Number puudub!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Koteering kustutatud!"
 
@@ -5881,7 +5882,7 @@ msgstr "Koteeringud"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5907,7 +5908,7 @@ msgstr "Hinnapakkumuse Taotlused"
 msgid "ROP"
 msgstr "Pakendis tk."
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5948,7 +5949,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Kätte saadud"
 
@@ -5977,7 +5978,7 @@ msgstr "Debitoorne võlgnevus"
 msgid "Receive"
 msgstr "Vastuvõtt"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Kauba Vastuvõtt"
 
@@ -6005,7 +6006,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Sihtkonto"
 
@@ -6031,11 +6032,11 @@ msgstr "Korduvad Tehingud"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Teatis"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6072,9 +6073,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Jääk"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6102,7 +6107,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Aruande nimi"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6114,7 +6119,7 @@ msgstr ""
 msgid "Report Type"
 msgstr "Aruande tüüp"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6150,11 +6155,11 @@ msgstr "Aruanded"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Vajalik"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6275,11 +6280,11 @@ msgstr "Standardiseeritud Tööstuskood"
 msgid "SIC:"
 msgstr "Standardiseeritud tööstuskood:"
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "Asenduskaup"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6308,7 +6313,7 @@ msgstr "Müük"
 msgid "Sales"
 msgstr "Müük"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Müügiarve"
@@ -6317,8 +6322,8 @@ msgstr "Müügiarve"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Müügiarve/MR Tehingu Number"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6383,7 +6388,7 @@ msgstr "Laup"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6428,7 +6433,7 @@ msgstr "Salvesta mustand"
 msgid "Save Groups"
 msgstr "Salvesta grupid"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Salvesta asukoht"
 
@@ -6436,7 +6441,7 @@ msgstr "Salvesta asukoht"
 msgid "Save New"
 msgstr "Salvesta uus"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr "Salvesta uus asukoht"
 
@@ -6453,7 +6458,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Salvesta uuena"
@@ -6462,7 +6467,7 @@ msgstr "Salvesta uuena"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6500,7 +6505,7 @@ msgstr "Salvestan"
 msgid "Saving over an existing document.  Continue?"
 msgstr "Kas salvestada üle olemasolev dokument?"
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6513,12 +6518,12 @@ msgstr "Kas salvestada üle olemasolev dokument?"
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Ajakava"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Planeeritud"
 
@@ -6659,11 +6664,11 @@ msgstr "Vali Klient"
 msgid "Select Templates to Load"
 msgstr "Vali mall mida laadida"
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Vali Tarnija"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Vali Printer"
 
@@ -6683,12 +6688,12 @@ msgstr "Vali arved"
 msgid "Select or Enter User"
 msgstr "Vali või sisesta kasutaja"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Vali kas postscript või PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Valida .txt, postscript või PDF!"
 
@@ -6779,7 +6784,7 @@ msgstr ""
 msgid "Serial #"
 msgstr "Seeria #"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Seerianr."
 
@@ -6797,11 +6802,11 @@ msgstr "Seerianumber"
 msgid "Serialnumber"
 msgstr "Seerianumber"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Teenus"
 
@@ -6845,13 +6850,13 @@ msgstr "seitseteist"
 msgid "Seventy"
 msgstr "seitsekümmend"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Saatmine"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Kauba Saatmine"
 
@@ -6881,12 +6886,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Kaubasaaja"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6903,23 +6908,23 @@ msgstr "Tarneviis"
 msgid "Shipping"
 msgstr "Saadetised"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Saatmise Kuupäev"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Saatmise Kuupäev puudub"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6995,12 +7000,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7081,11 +7086,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Riik"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7169,7 +7174,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7232,8 +7237,8 @@ msgstr "KOKKU"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7255,7 +7260,7 @@ msgstr "Maks"
 msgid "Tax Account"
 msgstr "Maksukonto"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7265,7 +7270,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7289,7 +7294,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7297,7 +7302,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Sisaldab Käibemaksu"
@@ -7396,7 +7401,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr "Mallide nimekiri"
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Mall salvestatud!"
 
@@ -7618,7 +7623,7 @@ msgstr "Korda"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7653,7 +7658,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Kaubalattu"
 
@@ -7699,7 +7704,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7720,7 +7725,7 @@ msgstr ""
 msgid "Total"
 msgstr "Kokku"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7732,6 +7737,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr "Kokku makstud"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Jälgitavad Kaubaartikleid"
@@ -7740,7 +7749,7 @@ msgstr "Jälgitavad Kaubaartikleid"
 msgid "Trade Discount"
 msgstr "Kaubanduslik Mahahindlus"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Tehing"
 
@@ -7773,20 +7782,20 @@ msgstr "Kande tüüp"
 msgid "Transactions"
 msgstr "Tehingud"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Tsessioon"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Laoliikumine"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Liikumine laost"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Liikumine lattu"
 
@@ -7873,7 +7882,7 @@ msgstr "kaks"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7934,7 +7943,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7950,7 +7959,7 @@ msgstr "Ühiku hind"
 msgid "Unknown "
 msgstr "Tundmatu"
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7968,7 +7977,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Tundmatu andmebaas leitud."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8020,20 +8029,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Värskenda"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Värskendatud"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8095,7 +8104,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8181,8 +8190,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8201,7 +8210,7 @@ msgstr "Tarnija konto"
 msgid "Vendor History"
 msgstr "Tarnija Ajalugu"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Tarnija Kaubaarve"
@@ -8217,7 +8226,7 @@ msgstr "Tarnija nimi"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8240,7 +8249,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr "Tarnija otsing"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Tarnija puudu!"
 
@@ -8277,7 +8286,7 @@ msgstr "Palgad ja kinnipidamised"
 msgid "Wages/Deductions"
 msgstr "Palgad/kinnipidamised"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8354,7 +8363,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Mis tüüpi kaubaartikliga on tegemist?"
 
@@ -8370,7 +8379,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8428,7 +8437,7 @@ msgstr "Kasumi eraldamine tehtud"
 msgid "Years"
 msgstr "Aastat"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Jah"
@@ -8447,11 +8456,11 @@ msgstr "Postiindeks"
 msgid "Zero"
 msgstr "null"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Postiindeks"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Postiindeks"
 
@@ -8520,7 +8529,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "linn"
 
@@ -8564,7 +8573,7 @@ msgstr "tehtud"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "tk"
 

--- a/locale/po/fa_IR.po
+++ b/locale/po/fa_IR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/fa_IR/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -458,11 +458,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr ""
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr ""
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1383,19 +1383,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1702,7 +1703,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4011,7 +4012,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4418,7 +4419,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5015,8 +5016,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5172,7 +5173,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5636,11 +5637,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,8 +6071,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6315,8 +6320,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6460,7 +6465,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/fi.po
+++ b/locale/po/fi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Juha Eerola <juhaeerola@outlook.com>, 2017\n"
 "Language-Team: Finnish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -195,9 +195,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -205,7 +205,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -316,7 +316,7 @@ msgstr "Varaukset"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Lisää työntekijä"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Lisää vaihtokurssi"
 
@@ -461,11 +461,11 @@ msgstr "Lisää raaka-aine/tarvike"
 msgid "Add Pricegroup"
 msgstr "Lisää hintaryhmä"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Ostotilaus"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Lisää tarjous"
 
@@ -473,7 +473,7 @@ msgstr "Lisää tarjous"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Lisää tarjouspyyntö"
 
@@ -485,11 +485,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Lisää teollisuusluokite"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Lisää myyntilasku"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Lisää tilausvahvistus"
 
@@ -505,7 +505,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr "Lisää aikakortti"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr "Lisää käyttäjä"
 msgid "Add Vendor"
 msgstr "Lisää toimittaja"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Lisää ostolasku"
 
@@ -539,15 +539,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Lisää varasto"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -575,8 +575,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -685,9 +685,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -790,8 +790,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Hyväksy"
@@ -829,20 +829,20 @@ msgstr "Huh"
 msgid "April"
 msgstr "Huhtikuu"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Haluatko poistaa tilauksen numero"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Haluatko poistaa tarjouksen numero"
 
@@ -915,16 +915,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -955,31 +955,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr "Elokuu"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1081,7 +1081,7 @@ msgid "Balance"
 msgstr "Tase"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Taselaskelma"
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1208,14 +1208,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Varastopaikka"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1323,12 +1323,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Nimikettä ei voi poistaa!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Tilausta ei voi poistaa!"
 
@@ -1386,19 +1386,19 @@ msgstr "Tilausta ei voi poistaa!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Tarjouspyyntöä ei voi poistaa!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Laskun kirjaus suljetulle ajanjaksolle kielletty!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Maksun kirjaus suljetulle ajanjaksolle kielletty!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Viennin kirjaus suljetulle ajanjaksolle kielletty!"
 
@@ -1407,15 +1407,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "En voi suorittaa vientiä missä debet ja kredit on samalle tilille!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Vientiä ei voi kirjata"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Tilauksen tallennus ei onnistu!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Tarjousta ei voi tallentaa!"
 
@@ -1435,7 +1435,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Käteiskauppa"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1496,7 +1497,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1612,7 +1613,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Yritys"
 
@@ -1645,7 +1646,7 @@ msgstr "Yrityksen puhelinnumero"
 msgid "Company Sales Tax ID"
 msgstr "Alv-numero"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Vahvista!"
 
@@ -1705,7 +1706,7 @@ msgstr "Vahvista!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1748,8 +1749,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1760,7 +1761,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1809,7 +1810,7 @@ msgid "Copy to New Name"
 msgstr "Kopioi uudelle nimelle"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Kustannus"
 
@@ -1821,19 +1822,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Tallentaminen ei onnistu"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Varaston siirto ei onnistu"
 
@@ -1853,8 +1854,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1918,7 +1919,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredit"
 
@@ -1939,7 +1940,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr "Hyvityslasku"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1963,7 +1964,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Valuutta"
 
@@ -1972,7 +1973,7 @@ msgstr "Valuutta"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2009,7 +2010,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2039,7 +2040,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2052,7 +2053,7 @@ msgstr "Asiakasnumero"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Asiakas puuttuu!"
 
@@ -2068,7 +2069,7 @@ msgstr "Asiakas ei järjestelmässä!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2141,7 +2142,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2156,11 +2157,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2198,7 +2199,7 @@ msgstr "Maksettu päivänä"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Vastaanotettu"
 
@@ -2222,7 +2223,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Vastaanottopvm puuttuu"
 
@@ -2268,7 +2269,7 @@ msgstr "Päivät"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debet"
 
@@ -2381,9 +2382,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2433,16 +2434,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Toimituspäivä"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2450,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2476,7 +2477,7 @@ msgstr "Poisto"
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2528,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2551,7 +2552,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2622,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2639,7 +2640,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2663,7 +2664,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Suoritettu"
 
@@ -2683,7 +2684,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2725,14 +2726,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Eräpäivä"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Eräpäivä puuttuu!"
 
@@ -2744,8 +2745,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Sähköposti"
 
@@ -3047,11 +3048,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3067,7 +3068,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3089,7 +3090,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3113,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3121,20 +3122,20 @@ msgstr ""
 msgid "Every"
 msgstr "Jokainen"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Vaihtokurssi"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Vaihtokurssi"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Maksun vaihtokurssi puuttuu"
 
@@ -3142,7 +3143,7 @@ msgstr "Maksun vaihtokurssi puuttuu"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Vaihtokurssi puuttuu"
 
@@ -3187,8 +3188,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Valuutat"
 
@@ -3266,7 +3267,7 @@ msgstr ""
 msgid "File"
 msgstr "Tiedosto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3280,17 +3281,17 @@ msgstr "Tiedoston nimi"
 msgid "File Type"
 msgstr "Tiedoston tyyppi"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Tiedoston nimi"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Tiedoston tyyppi"
@@ -3327,7 +3328,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Etunimi"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3387,7 +3388,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3419,7 +3420,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Varastosta"
 
@@ -3468,7 +3469,7 @@ msgstr "Pääkirjan viitenumero"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3476,7 +3477,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3505,11 +3506,11 @@ msgstr "Luo"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Luo tilaukset"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Luo ostotilaukset"
 
@@ -3554,8 +3555,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Ryhmä"
 
@@ -3797,8 +3798,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Sisäiset viestit"
 
@@ -3856,11 +3857,11 @@ msgstr "Tuotteen varaston on oltava nolla ennen asettamista epäkurantiksi!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Varasto tallennettu!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Varasto siirretty!"
 
@@ -3868,8 +3869,8 @@ msgstr "Varasto siirretty!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3887,22 +3888,22 @@ msgstr "Lasku"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Laskun päiväys"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Laskun päiväys puuttuu!"
 
@@ -3918,8 +3919,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3928,7 +3929,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Laskun numero"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Laskun numero puuttuu!"
 
@@ -3986,7 +3987,7 @@ msgstr "Nimike"
 msgid "Item deleted!"
 msgstr "Nimike poistettu!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Nimikettä ei ole järjestelmässä!"
 
@@ -4014,7 +4015,7 @@ msgstr "Tam"
 msgid "January"
 msgstr "Tammikuu"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4055,7 +4056,7 @@ msgstr "Kes"
 msgid "June"
 msgstr "Kesäkuu"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4119,7 +4120,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Johtolanka"
 
@@ -4340,11 +4341,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Nimi"
 
@@ -4421,7 +4422,7 @@ msgstr "Vastuuhenkilö"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4452,9 +4453,9 @@ msgid "May"
 msgstr "Tou"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Muistio"
@@ -4801,15 +4802,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4823,15 +4824,15 @@ msgstr "Lisätietoja"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Ei syötettä"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Mitään valitsematta!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Ei siirrettävää!"
 
@@ -4856,7 +4857,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4875,7 +4876,7 @@ msgstr "Numero"
 msgid "Number Format"
 msgstr "Numeron muoto"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4913,7 +4914,7 @@ msgstr "Lok"
 msgid "October"
 msgstr "Lokakuu"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4928,7 +4929,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Varastossa"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4983,7 +4984,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Tilaus"
 
@@ -5001,12 +5002,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tilauspäivämäärä"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Tilauspäivämäärä puuttuu!"
 
@@ -5018,8 +5019,8 @@ msgstr "Tilauksen kirjaus"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5027,15 +5028,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Tilausnumero"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Tilausnumero puuttuu!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Tilaus poistettu!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Tilausten luonti ei onnistunut"
 
@@ -5122,8 +5123,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5139,7 +5140,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5147,11 +5148,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Pakkauslista"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Pakkauslistan päiväys puuttuu!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Pakkauslistan numero puuttuu!"
 
@@ -5175,7 +5176,7 @@ msgstr "Maksettu"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Tarvike"
 
@@ -5195,8 +5196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5217,7 +5218,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5247,7 +5248,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Salasana"
 
@@ -5316,7 +5317,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Eräpäivä puuttuu!"
 
@@ -5328,7 +5329,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5337,7 +5338,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Maksut"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5345,11 +5346,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5384,7 +5385,7 @@ msgstr "Puhelin"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5515,8 +5516,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Kirjaa"
@@ -5533,7 +5534,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Kirjaa uutena"
 
@@ -5628,9 +5629,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Tulosta"
@@ -5639,11 +5640,11 @@ msgstr "Tulosta"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Tulosta ja tallenna"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Tulosta ja tallenna uutena"
 
@@ -5695,15 +5696,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5726,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5768,8 +5769,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5808,7 +5809,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5838,8 +5839,8 @@ msgid "Quarter"
 msgstr "Neljännes"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5855,7 +5856,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Tarjouksen pvm"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Tarjouksen pvm puuttuu"
 
@@ -5863,11 +5864,11 @@ msgstr "Tarjouksen pvm puuttuu"
 msgid "Quotation Number"
 msgstr "Tarjousnumero"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Tarjousnumero puuttuu"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Tarjous poistettu"
 
@@ -5882,7 +5883,7 @@ msgstr "Tarjoukset"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5908,7 +5909,7 @@ msgstr "Tarjouspyynnöt"
 msgid "ROP"
 msgstr "Uudelleentilauspiste"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5949,7 +5950,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Vastaanotettu"
 
@@ -5978,7 +5979,7 @@ msgstr "Saatavat"
 msgid "Receive"
 msgstr "Vastaanota"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Vastaanota tuotteet"
 
@@ -6006,7 +6007,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Talleta tilille"
 
@@ -6032,11 +6033,11 @@ msgstr "Toistuvat siirrit"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Viite"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr "Viitenumero puuttuu"
 
@@ -6073,9 +6074,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Jäljellä"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6103,7 +6108,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6115,7 +6120,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6151,11 +6156,11 @@ msgstr "Raportit"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Pyyntö"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6276,11 +6281,11 @@ msgstr "Teollisuusluokite"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "Varastoyksikkö"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6309,7 +6314,7 @@ msgstr "Myynti"
 msgid "Sales"
 msgstr "Myynnit"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Myyntilasku"
@@ -6318,8 +6323,8 @@ msgstr "Myyntilasku"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Myyntilaskun/viennin numero"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6384,7 +6389,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6429,7 +6434,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6437,7 +6442,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6454,7 +6459,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Tallenna uutena"
@@ -6463,7 +6468,7 @@ msgstr "Tallenna uutena"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6501,7 +6506,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6514,12 +6519,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Aikataulu"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Aikataulutettu"
 
@@ -6660,11 +6665,11 @@ msgstr "Valitse asiakas"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Valitse toimittaja"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Valitse tulostin"
 
@@ -6684,12 +6689,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Valitse postscript tai PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Valitse tekstitiedosto, postscript tai PDF!"
 
@@ -6780,7 +6785,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Sarjan:o"
 
@@ -6798,11 +6803,11 @@ msgstr "Sarjanumero"
 msgid "Serialnumber"
 msgstr "Sarjanumero"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Palvelu"
 
@@ -6846,13 +6851,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Toimita"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Toimita kauppatavara"
 
@@ -6882,12 +6887,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Toimitusosoite"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6904,23 +6909,23 @@ msgstr "Toimita käyttäen"
 msgid "Shipping"
 msgstr "Toimitukset"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Toimituspvm"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Toimituspvm puuttuu"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6996,12 +7001,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7082,11 +7087,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Osavaltio"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7170,7 +7175,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7233,8 +7238,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7256,7 +7261,7 @@ msgstr "Vero"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7266,7 +7271,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7290,7 +7295,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7298,7 +7303,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "ALV sisältyy"
@@ -7397,7 +7402,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7617,7 +7622,7 @@ msgstr "Kertaa"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7652,7 +7657,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Varastoon"
 
@@ -7698,7 +7703,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7719,7 +7724,7 @@ msgstr ""
 msgid "Total"
 msgstr "Yhteensä"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,6 +7736,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Seurattavia nimikkeitä"
@@ -7739,7 +7748,7 @@ msgstr "Seurattavia nimikkeitä"
 msgid "Trade Discount"
 msgstr "Alennus"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Vienti"
 
@@ -7772,20 +7781,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Tapahtumat"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Siirto"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Siirrä varasto"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Siirrö hetkestä"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Siirrä hetkeen"
 
@@ -7872,7 +7881,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7933,7 +7942,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7949,7 +7958,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7967,7 +7976,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8019,20 +8028,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Päivitä"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Päivitetty"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8094,7 +8103,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8180,8 +8189,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8200,7 +8209,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Toimittajahistoria"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Ostolasku"
@@ -8216,7 +8225,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8239,7 +8248,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Toimittaja puuttuu!"
 
@@ -8276,7 +8285,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8353,7 +8362,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Minkä tyyppinen nimike tämä on?"
 
@@ -8369,7 +8378,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8427,7 +8436,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Kyllä"
@@ -8446,11 +8455,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8517,7 +8526,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8561,7 +8570,7 @@ msgstr "valmis"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "kpl"
 

--- a/locale/po/fr.po
+++ b/locale/po/fr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: French (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "fr/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Accès refusé"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr "Accumulation"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Ajouter employé"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Ajouter taux de change"
 
@@ -459,11 +459,11 @@ msgstr "Ajouter marchandise"
 msgid "Add Pricegroup"
 msgstr "Ajouter groupe de prix"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Établir commande d'achat"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Établir devis"
 
@@ -471,7 +471,7 @@ msgstr "Établir devis"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Établir demande de devis"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Ajouter code secteur économique"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Établir facture de vente"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Établir commande de vente"
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Ajouter utilisateur"
 msgid "Add Vendor"
 msgstr "Ajouter fournisseur"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Établir facture d'achat"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr "Avril"
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Êtes vous sûr de vouloir supprimer la commande n°"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 
@@ -913,16 +913,16 @@ msgstr ""
 msgid "Assets"
 msgstr "Actifs"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr "Août"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Solde"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilan"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr "Milliard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Lieu stockage"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Impossible de supprimer l'objet!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Impossible de supprimer la commande!"
 
@@ -1384,19 +1384,19 @@ msgstr "Impossible de supprimer la commande!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Impossible de supprimer le devis!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Impossible d'enregistrer la facture sur un exercice clos!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Impossible d'enregistrer le paiement sur un exercice clos!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Impossible d'enregistrer l'écriture sur un exercice clos!"
 
@@ -1407,15 +1407,15 @@ msgstr ""
 "Impossible d'enregistrer l'écriture avec un débit et un crédit sur le même "
 "compte!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Impossible d'enregistrer l'écriture!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Impossible d'enregistrer la commande!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Impossible d'enregistrer le devis!"
 
@@ -1435,7 +1435,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Financier"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Compte comptant"
 
@@ -1496,7 +1497,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1612,7 +1613,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Société"
 
@@ -1645,7 +1646,7 @@ msgstr "Téléphone"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmer!"
 
@@ -1705,7 +1706,7 @@ msgstr "Confirmer!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1748,8 +1749,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1760,7 +1761,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1809,7 +1810,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Coût"
 
@@ -1821,19 +1822,19 @@ msgstr "Coût des produits vendus"
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Enregistrement impossible!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
@@ -1853,8 +1854,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1918,7 +1919,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédit"
 
@@ -1939,7 +1940,7 @@ msgstr "Comptes de crédit"
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1963,7 +1964,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Dev."
 
@@ -1972,7 +1973,7 @@ msgstr "Dev."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2009,7 +2010,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2039,7 +2040,7 @@ msgstr "Nom du client"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2052,7 +2053,7 @@ msgstr "Numéro de client"
 msgid "Customer Search"
 msgstr "Recherche client"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
@@ -2068,7 +2069,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr "Comptes Clients/Fournisseurs"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2141,7 +2142,7 @@ msgstr "Base de données inexistante."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2156,11 +2157,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2198,7 +2199,7 @@ msgstr "Date de paiement"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Date de réception"
 
@@ -2222,7 +2223,7 @@ msgstr "De"
 msgid "Date of Birth"
 msgstr "Date de naissance"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Date de réception manquante!"
 
@@ -2268,7 +2269,7 @@ msgstr "Jours"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débit"
 
@@ -2381,9 +2382,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2433,16 +2434,16 @@ msgstr "Livraison"
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2450,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2476,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2528,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2551,7 +2552,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2622,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2639,7 +2640,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2663,7 +2664,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Fait!"
 
@@ -2683,7 +2684,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2725,14 +2726,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Échéance"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Date d'échéance manquante!"
 
@@ -2744,8 +2745,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3047,11 +3048,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3067,7 +3068,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3089,7 +3090,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3113,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3121,20 +3122,20 @@ msgstr ""
 msgid "Every"
 msgstr "Chaque"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Change"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Taux de change"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
@@ -3142,7 +3143,7 @@ msgstr "Taux de change manquant pour le paiement!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
@@ -3187,8 +3188,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Devises"
 
@@ -3266,7 +3267,7 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3280,17 +3281,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3327,7 +3328,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Prénom"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3387,7 +3388,7 @@ msgstr "Quatorze"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3419,7 +3420,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Du entrepôt"
 
@@ -3468,7 +3469,7 @@ msgstr "Numéro de réf. Grand-livre"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3476,7 +3477,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3505,11 +3506,11 @@ msgstr "Générer"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Générer commandes"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Générer commandes d'achat"
 
@@ -3554,8 +3555,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Groupe"
 
@@ -3797,8 +3798,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notes internes"
 
@@ -3858,11 +3859,11 @@ msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 "La quantité en stock doit être zero avant de pouvoir annuler cette pièce!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventaire enregistré!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
@@ -3870,8 +3871,8 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3889,22 +3890,22 @@ msgstr "Facture"
 msgid "Invoice #"
 msgstr "Facture #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Facture créée"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Date de création de facture manquante!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Date de facture manquante!"
 
@@ -3920,8 +3921,8 @@ msgstr "N° de Facture"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3930,7 +3931,7 @@ msgstr "N° de Facture"
 msgid "Invoice Number"
 msgstr "Numéro de facture"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
@@ -3988,7 +3989,7 @@ msgstr "Article"
 msgid "Item deleted!"
 msgstr "Objet supprimé!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Objet non-listé!"
 
@@ -4016,7 +4017,7 @@ msgstr "Jan."
 msgid "January"
 msgstr "Janvier"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4057,7 +4058,7 @@ msgstr "Juin"
 msgid "June"
 msgstr "Juin"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4121,7 +4122,7 @@ msgstr ""
 msgid "Last name"
 msgstr "Nom"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Délai"
 
@@ -4342,11 +4343,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4423,7 +4424,7 @@ msgstr "Gestionnaire"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4454,9 +4455,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Mémo"
@@ -4803,15 +4804,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4825,15 +4826,15 @@ msgstr "Notes"
 msgid "Notes:<br />"
 msgstr "Notes:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Rien n'a été saisi!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Pas de sélection!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Rien à transférer!"
 
@@ -4858,7 +4859,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4877,7 +4878,7 @@ msgstr "Numéro"
 msgid "Number Format"
 msgstr "Format des numéros"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4915,7 +4916,7 @@ msgstr "Oct."
 msgid "October"
 msgstr "Octobre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "En Stock / disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4985,7 +4986,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Commande"
 
@@ -5003,12 +5004,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Date de commande manquante!"
 
@@ -5020,8 +5021,8 @@ msgstr "Commandes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5029,15 +5030,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Numéro de commande"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Numéro de commande manquant!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Commande supprimée!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Génération commande échouée!"
 
@@ -5124,8 +5125,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5141,7 +5142,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5149,11 +5150,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Liste d'envoi"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "La liste d'envoi n'a pas de date!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Le numéro de la liste d'envoi est manquant!"
 
@@ -5177,7 +5178,7 @@ msgstr "Total payé"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Marchandise"
 
@@ -5197,8 +5198,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5219,7 +5220,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5249,7 +5250,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -5318,7 +5319,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Date de paiement manquante!"
 
@@ -5330,7 +5331,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Paiements"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5347,11 +5348,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5386,7 +5387,7 @@ msgstr "Tél."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5517,8 +5518,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Enregistrer"
@@ -5535,7 +5536,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Enregistrer comme nouveau"
 
@@ -5630,9 +5631,9 @@ msgid "Primary Phone"
 msgstr "Téléphone principal"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimer"
@@ -5641,11 +5642,11 @@ msgstr "Imprimer"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimer et sauver"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimer et enregister comme nouveau"
 
@@ -5697,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5770,8 +5771,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5810,7 +5811,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5840,8 +5841,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5857,7 +5858,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Date de devis"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Date de devis manqante!"
 
@@ -5865,11 +5866,11 @@ msgstr "Date de devis manqante!"
 msgid "Quotation Number"
 msgstr "Numéro de devis"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Numéro de devis manquant!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
@@ -5884,7 +5885,7 @@ msgstr "Devis"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5910,7 +5911,7 @@ msgstr "Demandes de devis"
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5951,7 +5952,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5980,7 +5981,7 @@ msgstr "À recevoir"
 msgid "Receive"
 msgstr "Réception"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
@@ -6008,7 +6009,7 @@ msgstr "Rapport de rapprochement"
 msgid "Reconciliation Reports"
 msgstr "Rapports de rapprochement"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Enregistrer dans"
 
@@ -6034,11 +6035,11 @@ msgstr "Transactions périodiques"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Référence"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6075,9 +6076,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Restant"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,11 +6158,11 @@ msgstr "Rapports"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Exigence"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6278,11 +6283,11 @@ msgstr "Code secteur économique"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6311,7 +6316,7 @@ msgstr "Vente"
 msgid "Sales"
 msgstr "Ventes"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Facture de vente"
@@ -6320,8 +6325,8 @@ msgstr "Facture de vente"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Numéro facture de vente/écriture recette"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6386,7 +6391,7 @@ msgstr "Sam."
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6431,7 +6436,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6456,7 +6461,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
@@ -6465,7 +6470,7 @@ msgstr "Enregistrer comme nouveau"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6503,7 +6508,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Planification"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Planifié"
 
@@ -6662,11 +6667,11 @@ msgstr "Séléctionner client"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Sélectionner vendeur"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Sélectionner une imprimante!"
 
@@ -6686,12 +6691,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Sélectionner Postscript ou PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Sélectionner Txt, Postscript ou PDF!"
 
@@ -6782,7 +6787,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "N° série"
 
@@ -6800,11 +6805,11 @@ msgstr "Numéro de série"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Prestation de service"
 
@@ -6848,13 +6853,13 @@ msgstr "Dix-sept"
 msgid "Seventy"
 msgstr "Soixante-dix"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Expédier"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Expédier marchandise"
 
@@ -6884,12 +6889,12 @@ msgstr "Expédier à:"
 msgid "Ship Via"
 msgstr "Expédier via"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Expédier à"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6906,23 +6911,23 @@ msgstr "Expédier via"
 msgid "Shipping"
 msgstr "Expédition"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Date d'expédition"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Date d'expédition manquante!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6998,12 +7003,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7084,11 +7089,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Etat"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7172,7 +7177,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7235,8 +7240,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7258,7 +7263,7 @@ msgstr "Taxe"
 msgid "Tax Account"
 msgstr "Compte de taxe"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7268,7 +7273,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7292,7 +7297,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Taxe incluse"
@@ -7399,7 +7404,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Squelette enregistré!"
 
@@ -7619,7 +7624,7 @@ msgstr "Temps"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7654,7 +7659,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Vers entrepôt"
 
@@ -7700,7 +7705,7 @@ msgstr "Description principale"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7721,7 +7726,7 @@ msgstr "Description principale"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7733,6 +7738,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Objets référencés"
@@ -7741,7 +7750,7 @@ msgstr "Objets référencés"
 msgid "Trade Discount"
 msgstr "Escompte commercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Écriture"
 
@@ -7774,20 +7783,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Mouvements"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transfert"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transfert inventaire"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transférer de"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transférer vers"
 
@@ -7874,7 +7883,7 @@ msgstr "Deux"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7935,7 +7944,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7951,7 +7960,7 @@ msgstr "Prix unitaire"
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7969,7 +7978,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8021,20 +8030,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8096,7 +8105,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8182,8 +8191,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8202,7 +8211,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historique fournisseurs"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
@@ -8218,7 +8227,7 @@ msgstr "Nom du fournisseur"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8241,7 +8250,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
@@ -8278,7 +8287,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8355,7 +8364,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "De quel type est cet objet?"
 
@@ -8371,7 +8380,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8429,7 +8438,7 @@ msgstr "Écriture de fin d'exercice complétée"
 msgid "Years"
 msgstr "Années"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Oui"
@@ -8448,11 +8457,11 @@ msgstr "Code Postal"
 msgid "Zero"
 msgstr "Zéro"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Code Postal"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Code Postal"
 
@@ -8519,7 +8528,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "ville"
 
@@ -8563,7 +8572,7 @@ msgstr "fait"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "ch"
 

--- a/locale/po/fr_BE.po
+++ b/locale/po/fr_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: French (Belgium) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/fr_BE/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Accès refusé"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr "Accumulation"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Ajouter employé"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Ajouter taux de change"
 
@@ -459,11 +459,11 @@ msgstr "Ajouter marchandise"
 msgid "Add Pricegroup"
 msgstr "Ajouter groupe de prix"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Établir commande d'achat"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Établir devis"
 
@@ -471,7 +471,7 @@ msgstr "Établir devis"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Établir demande de devis"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Ajouter code secteur économique"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Établir facture de vente"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Établir commande de vente"
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Ajouter utilisateur"
 msgid "Add Vendor"
 msgstr "Ajouter fournisseur"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Établir facture d'achat"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr "Avril"
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Êtes vous sûr de vouloir supprimer la commande n°"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 
@@ -913,16 +913,16 @@ msgstr ""
 msgid "Assets"
 msgstr "Actifs"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr "Août"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Solde"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilan"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr "Milliard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Lieu stockage"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Impossible de supprimer l'objet!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Impossible de supprimer la commande!"
 
@@ -1384,19 +1384,19 @@ msgstr "Impossible de supprimer la commande!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Impossible de supprimer le devis!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Impossible d'enregistrer la facture sur un exercice clos!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Impossible d'enregistrer le paiement sur un exercice clos!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Impossible d'enregistrer l'écriture sur un exercice clos!"
 
@@ -1407,15 +1407,15 @@ msgstr ""
 "Impossible d'enregistrer la transaction avec un débit et crédit pour le même "
 "compte!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Impossible d'enregistrer l'écriture!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Impossible d'enregistrer la commande!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Impossible d'enregistrer le devis!"
 
@@ -1435,7 +1435,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Financier"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Compte comptant"
 
@@ -1496,7 +1497,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1612,7 +1613,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Société"
 
@@ -1645,7 +1646,7 @@ msgstr "Téléphone"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmer!"
 
@@ -1705,7 +1706,7 @@ msgstr "Confirmer!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1748,8 +1749,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1760,7 +1761,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1809,7 +1810,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Coût"
 
@@ -1821,19 +1822,19 @@ msgstr "Coût des produits vendus"
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Enregistrement impossible!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
@@ -1853,8 +1854,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1918,7 +1919,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédit"
 
@@ -1939,7 +1940,7 @@ msgstr "Comptes de crédit"
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1963,7 +1964,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Dev."
 
@@ -1972,7 +1973,7 @@ msgstr "Dev."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2009,7 +2010,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2039,7 +2040,7 @@ msgstr "Nom du client"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2052,7 +2053,7 @@ msgstr "Numéro de client"
 msgid "Customer Search"
 msgstr "Recherche client"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
@@ -2068,7 +2069,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr "Comptes Clients/Fournisseurs"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2141,7 +2142,7 @@ msgstr "Base de données inexistante."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2156,11 +2157,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2198,7 +2199,7 @@ msgstr "Date de paiement"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Date de réception"
 
@@ -2222,7 +2223,7 @@ msgstr "De"
 msgid "Date of Birth"
 msgstr "Date de naissance"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Date de réception manquante!"
 
@@ -2268,7 +2269,7 @@ msgstr "Jours"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débit"
 
@@ -2381,9 +2382,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2433,16 +2434,16 @@ msgstr "Livraison"
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2450,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2476,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2528,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2551,7 +2552,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2622,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2639,7 +2640,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2663,7 +2664,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Fait!"
 
@@ -2683,7 +2684,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2725,14 +2726,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Échéance"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Date d'échéance manquante!"
 
@@ -2744,8 +2745,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3047,11 +3048,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3067,7 +3068,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3089,7 +3090,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3113,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3121,20 +3122,20 @@ msgstr ""
 msgid "Every"
 msgstr "Chaque"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Change"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Taux de change"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
@@ -3142,7 +3143,7 @@ msgstr "Taux de change manquant pour le paiement!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
@@ -3187,8 +3188,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Devises"
 
@@ -3266,7 +3267,7 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3280,17 +3281,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3327,7 +3328,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Prénom"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3387,7 +3388,7 @@ msgstr "Quatorze"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3419,7 +3420,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Du entrepôt"
 
@@ -3468,7 +3469,7 @@ msgstr "Numéro de réf. Grand-livre"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3476,7 +3477,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3505,11 +3506,11 @@ msgstr "Générer"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Générer commandes"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Générer commandes d'achat"
 
@@ -3554,8 +3555,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Groupe"
 
@@ -3797,8 +3798,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notes internes"
 
@@ -3858,11 +3859,11 @@ msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 "La quantité en stock doit être zero avant de pouvoir annuler cette pièce!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventaire enregistré!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
@@ -3870,8 +3871,8 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3889,22 +3890,22 @@ msgstr "Facture"
 msgid "Invoice #"
 msgstr "Facture #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Facture créée"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Date de création de facture manquante!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Date de facture manquante!"
 
@@ -3920,8 +3921,8 @@ msgstr "N° de Facture"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3930,7 +3931,7 @@ msgstr "N° de Facture"
 msgid "Invoice Number"
 msgstr "Numéro de facture"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
@@ -3988,7 +3989,7 @@ msgstr "Article"
 msgid "Item deleted!"
 msgstr "Objet supprimé!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Objet non-listé!"
 
@@ -4016,7 +4017,7 @@ msgstr "Jan."
 msgid "January"
 msgstr "Janvier"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4057,7 +4058,7 @@ msgstr "Juin"
 msgid "June"
 msgstr "Juin"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4121,7 +4122,7 @@ msgstr ""
 msgid "Last name"
 msgstr "Nom"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Délai"
 
@@ -4342,11 +4343,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4423,7 +4424,7 @@ msgstr "Gestionnaire"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4454,9 +4455,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Mémo"
@@ -4803,15 +4804,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4825,15 +4826,15 @@ msgstr "Notes"
 msgid "Notes:<br />"
 msgstr "Notes:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Rien n'a été saisi!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Pas de sélection!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Rien à transférer!"
 
@@ -4858,7 +4859,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4877,7 +4878,7 @@ msgstr "Numéro"
 msgid "Number Format"
 msgstr "Format des numéros"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4915,7 +4916,7 @@ msgstr "Oct."
 msgid "October"
 msgstr "Octobre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "En Stock / disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4985,7 +4986,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Commande"
 
@@ -5003,12 +5004,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Date de commande manquante!"
 
@@ -5020,8 +5021,8 @@ msgstr "Commandes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5029,15 +5030,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Numéro de commande"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Numéro de commande manquant!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Commande supprimée!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Génération commande échouée!"
 
@@ -5124,8 +5125,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5141,7 +5142,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5149,11 +5150,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Liste d'envoi"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "La liste d'envoi n'a pas de date!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Le numéro de la liste d'envoi est manquant!"
 
@@ -5177,7 +5178,7 @@ msgstr "Total payé"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Marchandise"
 
@@ -5197,8 +5198,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5219,7 +5220,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5249,7 +5250,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -5318,7 +5319,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Date de paiement manquante!"
 
@@ -5330,7 +5331,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Paiements"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5347,11 +5348,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5386,7 +5387,7 @@ msgstr "Tél."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5517,8 +5518,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Enregistrer"
@@ -5535,7 +5536,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Enregistrer comme nouveau"
 
@@ -5630,9 +5631,9 @@ msgid "Primary Phone"
 msgstr "Téléphone principal"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimer"
@@ -5641,11 +5642,11 @@ msgstr "Imprimer"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimer et sauver"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimer et enregister comme nouveau"
 
@@ -5697,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5770,8 +5771,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5810,7 +5811,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5840,8 +5841,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5857,7 +5858,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Date de devis"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Date de devis manqante!"
 
@@ -5865,11 +5866,11 @@ msgstr "Date de devis manqante!"
 msgid "Quotation Number"
 msgstr "Numéro de devis"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Numéro de devis manquant!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
@@ -5884,7 +5885,7 @@ msgstr "Devis"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5910,7 +5911,7 @@ msgstr "Demandes de devis"
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5951,7 +5952,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5980,7 +5981,7 @@ msgstr "À recevoir"
 msgid "Receive"
 msgstr "Réception"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
@@ -6008,7 +6009,7 @@ msgstr "Rapport de rapprochement"
 msgid "Reconciliation Reports"
 msgstr "Rapports de rapprochement"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Enregistrer dans"
 
@@ -6034,11 +6035,11 @@ msgstr "Transactions périodiques"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Référence"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6075,9 +6076,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Restant"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,11 +6158,11 @@ msgstr "Rapports"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Exigence"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6278,11 +6283,11 @@ msgstr "Code secteur économique"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6311,7 +6316,7 @@ msgstr "Vente"
 msgid "Sales"
 msgstr "Ventes"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Facture de vente"
@@ -6320,8 +6325,8 @@ msgstr "Facture de vente"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Numéro facture de vente/écriture recette"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6386,7 +6391,7 @@ msgstr "Sam."
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6431,7 +6436,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6456,7 +6461,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
@@ -6465,7 +6470,7 @@ msgstr "Enregistrer comme nouveau"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6503,7 +6508,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Planification"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Planifié"
 
@@ -6662,11 +6667,11 @@ msgstr "Séléctionner client"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Sélectionner vendeur"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Sélectionner une imprimante!"
 
@@ -6686,12 +6691,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Sélectionner Postscript ou PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Sélectionner Txt, Postscript ou PDF!"
 
@@ -6782,7 +6787,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "N° série"
 
@@ -6800,11 +6805,11 @@ msgstr "Numéro de série"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Prestation de service"
 
@@ -6848,13 +6853,13 @@ msgstr "Dix-sept"
 msgid "Seventy"
 msgstr "Septante"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Expédier"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Expédier marchandise"
 
@@ -6884,12 +6889,12 @@ msgstr "Expédier à:"
 msgid "Ship Via"
 msgstr "Expédier via"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Expédier à"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6906,23 +6911,23 @@ msgstr "Expédier via"
 msgid "Shipping"
 msgstr "Expédition"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Date d'expédition"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Date d'expédition manquante!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6998,12 +7003,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7084,11 +7089,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Etat"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7172,7 +7177,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7235,8 +7240,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7258,7 +7263,7 @@ msgstr "Taxe"
 msgid "Tax Account"
 msgstr "Compte de taxe"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7268,7 +7273,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7292,7 +7297,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Taxe incluse"
@@ -7399,7 +7404,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Squelette enregistré!"
 
@@ -7619,7 +7624,7 @@ msgstr "Temps"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7654,7 +7659,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Vers entrepôt"
 
@@ -7700,7 +7705,7 @@ msgstr "Description principale"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7721,7 +7726,7 @@ msgstr "Description principale"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7733,6 +7738,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Objets référencés"
@@ -7741,7 +7750,7 @@ msgstr "Objets référencés"
 msgid "Trade Discount"
 msgstr "Escompte commercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Écriture"
 
@@ -7774,20 +7783,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Mouvements"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transfert"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transfert inventaire"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transfert à partir"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transférer vers"
 
@@ -7874,7 +7883,7 @@ msgstr "Deux"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7935,7 +7944,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7951,7 +7960,7 @@ msgstr "Prix unitaire"
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7969,7 +7978,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8021,20 +8030,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8096,7 +8105,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8182,8 +8191,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8202,7 +8211,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historique fournisseurs"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
@@ -8218,7 +8227,7 @@ msgstr "Nom du fournisseur"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8241,7 +8250,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
@@ -8278,7 +8287,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8355,7 +8364,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "De quel type est cet objet?"
 
@@ -8371,7 +8380,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8429,7 +8438,7 @@ msgstr "Écriture de fin d'exercice complétée"
 msgid "Years"
 msgstr "Années"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Oui"
@@ -8448,11 +8457,11 @@ msgstr "Code Postal"
 msgid "Zero"
 msgstr "Zéro"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Code Postal"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Code Postal"
 
@@ -8519,7 +8528,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "ville"
 
@@ -8563,7 +8572,7 @@ msgstr "fait"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "ch"
 

--- a/locale/po/fr_CA.po
+++ b/locale/po/fr_CA.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: ylavoie <ylavoie@yveslavoie.com>, 2016,2020\n"
 "Language-Team: French (Canada) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Accès refusé"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -195,9 +195,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -205,7 +205,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -316,7 +316,7 @@ msgstr "Accumulation"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Ajouter employé"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Ajouter taux de change"
 
@@ -461,11 +461,11 @@ msgstr "Ajouter marchandise"
 msgid "Add Pricegroup"
 msgstr "Ajouter groupe de prix"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Établir commande d'achat"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Établir devis"
 
@@ -473,7 +473,7 @@ msgstr "Établir devis"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Établir demande de devis"
 
@@ -485,11 +485,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Ajouter code secteur économique"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Établir facture de vente"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Établir commande de vente"
 
@@ -505,7 +505,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr "Ajouter utilisateur"
 msgid "Add Vendor"
 msgstr "Ajouter fournisseur"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Établir facture d'achat"
 
@@ -539,15 +539,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -575,8 +575,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -685,9 +685,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -790,8 +790,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -829,20 +829,20 @@ msgstr "Avril"
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Êtes vous sûr de vouloir supprimer la commande n°"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 
@@ -915,16 +915,16 @@ msgstr ""
 msgid "Assets"
 msgstr "Actifs"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -955,31 +955,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr "Août"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1081,7 +1081,7 @@ msgid "Balance"
 msgstr "Solde"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilan"
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1208,14 +1208,14 @@ msgstr "Milliard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Lieu stockage"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1323,12 +1323,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Impossible de supprimer l'objet!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Impossible de supprimer la commande!"
 
@@ -1386,19 +1386,19 @@ msgstr "Impossible de supprimer la commande!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Impossible de supprimer le devis!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Impossible d'enregistrer la facture sur un exercice clos!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Impossible d'enregistrer le paiement sur un exercice clos!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Impossible d'enregistrer l'écriture sur un exercice clos!"
 
@@ -1409,15 +1409,15 @@ msgstr ""
 "Impossible d'enregistrer l'écriture avec un débit et un crédit sur le même "
 "compte!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Impossible d'enregistrer l'écriture!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Impossible d'enregistrer la commande!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Impossible d'enregistrer le devis!"
 
@@ -1437,7 +1437,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Financier"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Compte comptant"
 
@@ -1498,7 +1499,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1614,7 +1615,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Société"
 
@@ -1647,7 +1648,7 @@ msgstr "Téléphone"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1699,7 +1700,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmer!"
 
@@ -1707,7 +1708,7 @@ msgstr "Confirmer!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1750,8 +1751,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1762,7 +1763,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1811,7 +1812,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Coût"
 
@@ -1823,19 +1824,19 @@ msgstr "Coût des produits vendus"
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Enregistrement impossible!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
@@ -1855,8 +1856,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1920,7 +1921,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédit"
 
@@ -1941,7 +1942,7 @@ msgstr "Comptes de crédit"
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1965,7 +1966,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Dev."
 
@@ -1974,7 +1975,7 @@ msgstr "Dev."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2011,7 +2012,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2041,7 +2042,7 @@ msgstr "Nom du client"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2054,7 +2055,7 @@ msgstr "Numéro de client"
 msgid "Customer Search"
 msgstr "Recherche client"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
@@ -2070,7 +2071,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr "Comptes Clients/Fournisseurs"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2094,7 +2095,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2143,7 +2144,7 @@ msgstr "Base de données inexistante."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2200,7 +2201,7 @@ msgstr "Date de paiement"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Date de réception"
 
@@ -2224,7 +2225,7 @@ msgstr "De"
 msgid "Date of Birth"
 msgstr "Date de naissance"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Date de réception manquante!"
 
@@ -2270,7 +2271,7 @@ msgstr "Jours"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débit"
 
@@ -2383,9 +2384,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2435,16 +2436,16 @@ msgstr "Livraison"
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2452,11 +2453,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2478,7 +2479,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2530,13 +2531,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2553,7 +2554,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2624,16 +2625,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2641,7 +2642,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2649,7 +2650,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Fait!"
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2727,14 +2728,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Échéance"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Date d'échéance manquante!"
 
@@ -2746,8 +2747,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3049,11 +3050,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3123,20 +3124,20 @@ msgstr ""
 msgid "Every"
 msgstr "Chaque"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Change"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Taux de change"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
@@ -3144,7 +3145,7 @@ msgstr "Taux de change manquant pour le paiement!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
@@ -3189,8 +3190,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Devises"
 
@@ -3268,7 +3269,7 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3282,17 +3283,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3329,7 +3330,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Prénom"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3389,7 +3390,7 @@ msgstr "Quatorze"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3421,7 +3422,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Du entrepôt"
 
@@ -3470,7 +3471,7 @@ msgstr "Numéro de réf. Grand-livre"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3478,7 +3479,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3507,11 +3508,11 @@ msgstr "Générer"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Générer commandes"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Générer commandes d'achat"
 
@@ -3556,8 +3557,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Groupe"
 
@@ -3799,8 +3800,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notes internes"
 
@@ -3860,11 +3861,11 @@ msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 "La quantité en stock doit être zero avant de pouvoir annuler cette pièce!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventaire enregistré!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
@@ -3872,8 +3873,8 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3891,22 +3892,22 @@ msgstr "Facture"
 msgid "Invoice #"
 msgstr "Facture #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Facture créée"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Date de création de facture manquante!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Date de facture manquante!"
 
@@ -3922,8 +3923,8 @@ msgstr "N° de Facture"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3932,7 +3933,7 @@ msgstr "N° de Facture"
 msgid "Invoice Number"
 msgstr "Numéro de facture"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
@@ -3990,7 +3991,7 @@ msgstr "Objet"
 msgid "Item deleted!"
 msgstr "Objet supprimé!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Objet non-listé!"
 
@@ -4018,7 +4019,7 @@ msgstr "Jan."
 msgid "January"
 msgstr "Janvier"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4059,7 +4060,7 @@ msgstr "Juin"
 msgid "June"
 msgstr "Juin"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4123,7 +4124,7 @@ msgstr ""
 msgid "Last name"
 msgstr "Nom"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Délai"
 
@@ -4344,11 +4345,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4425,7 +4426,7 @@ msgstr "Gestionnaire"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4456,9 +4457,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Mémo"
@@ -4805,15 +4806,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4827,15 +4828,15 @@ msgstr "Notes"
 msgid "Notes:<br />"
 msgstr "Notes:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Rien n'a été saisi!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Pas de sélection!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Rien à transférer!"
 
@@ -4860,7 +4861,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4879,7 +4880,7 @@ msgstr "Numéro"
 msgid "Number Format"
 msgstr "Format des numéros"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4917,7 +4918,7 @@ msgstr "Oct."
 msgid "October"
 msgstr "Octobre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4932,7 +4933,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "En Stock / disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4987,7 +4988,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Commande"
 
@@ -5005,12 +5006,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Date de commande manquante!"
 
@@ -5022,8 +5023,8 @@ msgstr "Commandes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5031,15 +5032,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Numéro de commande"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Numéro de commande manquant!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Commande supprimée!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Génération commande échouée!"
 
@@ -5126,8 +5127,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5143,7 +5144,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5151,11 +5152,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Liste d'envoi"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "La liste d'envoi n'a pas de date!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Le numéro de la liste d'envoi est manquant!"
 
@@ -5179,7 +5180,7 @@ msgstr "Total payé"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Marchandise"
 
@@ -5199,8 +5200,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5221,7 +5222,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5251,7 +5252,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Date de paiement manquante!"
 
@@ -5332,7 +5333,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Paiements"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5349,11 +5350,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5388,7 +5389,7 @@ msgstr "Tél."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5519,8 +5520,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Enregistrer"
@@ -5537,7 +5538,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Enregistrer comme nouveau"
 
@@ -5632,9 +5633,9 @@ msgid "Primary Phone"
 msgstr "Téléphone principal"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimer"
@@ -5643,11 +5644,11 @@ msgstr "Imprimer"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimer et sauver"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimer et enregister comme nouveau"
 
@@ -5699,15 +5700,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5729,7 +5730,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5772,8 +5773,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5812,7 +5813,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5842,8 +5843,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5859,7 +5860,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Date de devis"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Date de devis manqante!"
 
@@ -5867,11 +5868,11 @@ msgstr "Date de devis manqante!"
 msgid "Quotation Number"
 msgstr "Numéro de devis"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Numéro de devis manquant!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
@@ -5886,7 +5887,7 @@ msgstr "Devis"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5912,7 +5913,7 @@ msgstr "Demandes de devis"
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5953,7 +5954,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5982,7 +5983,7 @@ msgstr "À recevoir"
 msgid "Receive"
 msgstr "Réception"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
@@ -6010,7 +6011,7 @@ msgstr "Rapport de rapprochement"
 msgid "Reconciliation Reports"
 msgstr "Rapports de rapprochement"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Enregistrer dans"
 
@@ -6036,11 +6037,11 @@ msgstr "Transactions périodiques"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Référence"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6077,9 +6078,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Restant"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6107,7 +6112,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6119,7 +6124,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6155,11 +6160,11 @@ msgstr "Rapports"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Exigence"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6280,11 +6285,11 @@ msgstr "Code secteur économique"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6313,7 +6318,7 @@ msgstr "Vente"
 msgid "Sales"
 msgstr "Ventes"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Facture de vente"
@@ -6322,8 +6327,8 @@ msgstr "Facture de vente"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Numéro facture de vente/écriture recette"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6388,7 +6393,7 @@ msgstr "Sam."
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6433,7 +6438,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6441,7 +6446,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6458,7 +6463,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
@@ -6467,7 +6472,7 @@ msgstr "Enregistrer comme nouveau"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6505,7 +6510,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6518,12 +6523,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Planification"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Planifié"
 
@@ -6664,11 +6669,11 @@ msgstr "Séléctionner client"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Sélectionner vendeur"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Sélectionner une imprimante!"
 
@@ -6688,12 +6693,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Sélectionner Postscript ou PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Sélectionner Txt, Postscript ou PDF!"
 
@@ -6784,7 +6789,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "N° série"
 
@@ -6802,11 +6807,11 @@ msgstr "Numéro de série"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Prestation de service"
 
@@ -6850,13 +6855,13 @@ msgstr "Dix-sept"
 msgid "Seventy"
 msgstr "Soixante-dix"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Expédier"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Expédier marchandise"
 
@@ -6886,12 +6891,12 @@ msgstr "Expédier à:"
 msgid "Ship Via"
 msgstr "Expédier via"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Expédier à"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6908,23 +6913,23 @@ msgstr "Expédier via"
 msgid "Shipping"
 msgstr "Expédition"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Date d'expédition"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Date d'expédition manquante!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7000,12 +7005,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7086,11 +7091,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Etat"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7174,7 +7179,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7237,8 +7242,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7260,7 +7265,7 @@ msgstr "Taxe"
 msgid "Tax Account"
 msgstr "Compte de taxe"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7270,7 +7275,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7294,7 +7299,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7302,7 +7307,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Taxe incluse"
@@ -7401,7 +7406,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Squelette enregistré!"
 
@@ -7621,7 +7626,7 @@ msgstr "Temps"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7656,7 +7661,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Vers entrepôt"
 
@@ -7702,7 +7707,7 @@ msgstr "Description principale"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7723,7 +7728,7 @@ msgstr "Description principale"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7735,6 +7740,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Objets référencés"
@@ -7743,7 +7752,7 @@ msgstr "Objets référencés"
 msgid "Trade Discount"
 msgstr "Escompte commercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Écriture"
 
@@ -7776,20 +7785,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Mouvements"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transfert"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transfert inventaire"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transférer de"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transférer vers"
 
@@ -7876,7 +7885,7 @@ msgstr "Deux"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7937,7 +7946,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7953,7 +7962,7 @@ msgstr "Prix unitaire"
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7971,7 +7980,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8023,20 +8032,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8098,7 +8107,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8184,8 +8193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8204,7 +8213,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historique fournisseurs"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
@@ -8220,7 +8229,7 @@ msgstr "Nom du fournisseur"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8243,7 +8252,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
@@ -8280,7 +8289,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8357,7 +8366,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "De quel type est cet objet?"
 
@@ -8373,7 +8382,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8431,7 +8440,7 @@ msgstr "Écriture de fin d'exercice complétée"
 msgid "Years"
 msgstr "Années"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Oui"
@@ -8450,11 +8459,11 @@ msgstr "Code Postal"
 msgid "Zero"
 msgstr "Zéro"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Code Postal"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Code Postal"
 
@@ -8521,7 +8530,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "ville"
 
@@ -8565,7 +8574,7 @@ msgstr "fait"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "pièce(s)"
 

--- a/locale/po/fr_FR.po
+++ b/locale/po/fr_FR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: French (France) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/fr_FR/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Accès refusé"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr "Accumulation"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Ajouter employé"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Ajouter taux de change"
 
@@ -459,11 +459,11 @@ msgstr "Ajouter marchandise"
 msgid "Add Pricegroup"
 msgstr "Ajouter groupe de prix"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Établir commande d'achat"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Établir devis"
 
@@ -471,7 +471,7 @@ msgstr "Établir devis"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Établir demande de devis"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Ajouter code secteur économique"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Établir facture de vente"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Établir commande de vente"
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Ajouter utilisateur"
 msgid "Add Vendor"
 msgstr "Ajouter fournisseur"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Établir facture d'achat"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr "Avril"
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Êtes vous sûr de vouloir supprimer la commande n°"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 
@@ -913,16 +913,16 @@ msgstr ""
 msgid "Assets"
 msgstr "Actifs"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr "Août"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Solde"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilan"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr "Milliard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Lieu stockage"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Impossible de supprimer l'objet!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Impossible de supprimer la commande!"
 
@@ -1384,19 +1384,19 @@ msgstr "Impossible de supprimer la commande!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Impossible de supprimer le devis!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Impossible d'enregistrer la facture sur un exercice clos!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Impossible d'enregistrer le paiement sur un exercice clos!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Impossible d'enregistrer l'écriture sur un exercice clos!"
 
@@ -1407,15 +1407,15 @@ msgstr ""
 "Impossible d'enregistrer l'écriture avec un débit et un crédit sur le même "
 "compte!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Impossible d'enregistrer l'écriture!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Impossible d'enregistrer la commande!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Impossible d'enregistrer le devis!"
 
@@ -1435,7 +1435,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Financier"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Compte comptant"
 
@@ -1496,7 +1497,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1612,7 +1613,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Société"
 
@@ -1645,7 +1646,7 @@ msgstr "Téléphone"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmer!"
 
@@ -1705,7 +1706,7 @@ msgstr "Confirmer!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1748,8 +1749,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1760,7 +1761,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1809,7 +1810,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Coût"
 
@@ -1821,19 +1822,19 @@ msgstr "Coût des produits vendus"
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Enregistrement impossible!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
@@ -1853,8 +1854,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1918,7 +1919,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédit"
 
@@ -1939,7 +1940,7 @@ msgstr "Comptes de crédit"
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1963,7 +1964,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Dev."
 
@@ -1972,7 +1973,7 @@ msgstr "Dev."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2009,7 +2010,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2039,7 +2040,7 @@ msgstr "Nom du client"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2052,7 +2053,7 @@ msgstr "Numéro de client"
 msgid "Customer Search"
 msgstr "Recherche client"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
@@ -2068,7 +2069,7 @@ msgstr "Client absent du fichier!"
 msgid "Customer/Vendor Accounts"
 msgstr "Comptes Clients/Fournisseurs"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2141,7 +2142,7 @@ msgstr "Base de données inexistante."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2156,11 +2157,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2198,7 +2199,7 @@ msgstr "Date de paiement"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Date de réception"
 
@@ -2222,7 +2223,7 @@ msgstr "De"
 msgid "Date of Birth"
 msgstr "Date de naissance"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Date de réception manquante!"
 
@@ -2268,7 +2269,7 @@ msgstr "Jours"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débit"
 
@@ -2381,9 +2382,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2433,16 +2434,16 @@ msgstr "Livraison"
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2450,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2476,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2528,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2551,7 +2552,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2622,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2639,7 +2640,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2663,7 +2664,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Fait!"
 
@@ -2683,7 +2684,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2725,14 +2726,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Échéance"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Date d'échéance manquante!"
 
@@ -2744,8 +2745,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3047,11 +3048,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3067,7 +3068,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3089,7 +3090,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3113,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3121,20 +3122,20 @@ msgstr ""
 msgid "Every"
 msgstr "Chaque"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Change"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Taux de change"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
@@ -3142,7 +3143,7 @@ msgstr "Taux de change manquant pour le paiement!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
@@ -3187,8 +3188,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Devises"
 
@@ -3266,7 +3267,7 @@ msgstr "Cinquante"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3280,17 +3281,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3327,7 +3328,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Prénom"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3387,7 +3388,7 @@ msgstr "Quatorze"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3419,7 +3420,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Du entrepôt"
 
@@ -3468,7 +3469,7 @@ msgstr "Numéro de réf. Grand-livre"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3476,7 +3477,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3505,11 +3506,11 @@ msgstr "Générer"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Générer commandes"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Générer commandes d'achat"
 
@@ -3554,8 +3555,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Groupe"
 
@@ -3797,8 +3798,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notes internes"
 
@@ -3858,11 +3859,11 @@ msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 "La quantité en stock doit être zero avant de pouvoir annuler cette pièce!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventaire enregistré!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
@@ -3870,8 +3871,8 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3889,22 +3890,22 @@ msgstr "Facture"
 msgid "Invoice #"
 msgstr "Facture #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Facture créée"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Date de création de facture manquante!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Date de facture manquante!"
 
@@ -3920,8 +3921,8 @@ msgstr "N° de Facture"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3930,7 +3931,7 @@ msgstr "N° de Facture"
 msgid "Invoice Number"
 msgstr "Numéro de facture"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
@@ -3988,7 +3989,7 @@ msgstr "Article"
 msgid "Item deleted!"
 msgstr "Objet supprimé!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Objet non-listé!"
 
@@ -4016,7 +4017,7 @@ msgstr "Jan."
 msgid "January"
 msgstr "Janvier"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4057,7 +4058,7 @@ msgstr "Juin"
 msgid "June"
 msgstr "Juin"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4121,7 +4122,7 @@ msgstr ""
 msgid "Last name"
 msgstr "Nom"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Délai"
 
@@ -4342,11 +4343,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4423,7 +4424,7 @@ msgstr "Gestionnaire"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4454,9 +4455,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Mémo"
@@ -4803,15 +4804,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4825,15 +4826,15 @@ msgstr "Notes"
 msgid "Notes:<br />"
 msgstr "Notes:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Rien n'a été saisi!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Pas de sélection!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Rien à transférer!"
 
@@ -4858,7 +4859,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4877,7 +4878,7 @@ msgstr "Numéro"
 msgid "Number Format"
 msgstr "Format des numéros"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4915,7 +4916,7 @@ msgstr "Oct."
 msgid "October"
 msgstr "Octobre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "En Stock / disponible"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4985,7 +4986,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Commande"
 
@@ -5003,12 +5004,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Date de commande manquante!"
 
@@ -5020,8 +5021,8 @@ msgstr "Commandes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5029,15 +5030,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Numéro de commande"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Numéro de commande manquant!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Commande supprimée!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Génération commande échouée!"
 
@@ -5124,8 +5125,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5141,7 +5142,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5149,11 +5150,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Liste d'envoi"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "La liste d'envoi n'a pas de date!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Le numéro de la liste d'envoi est manquant!"
 
@@ -5177,7 +5178,7 @@ msgstr "Total payé"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Marchandise"
 
@@ -5197,8 +5198,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5219,7 +5220,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5249,7 +5250,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -5318,7 +5319,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Date de paiement manquante!"
 
@@ -5330,7 +5331,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Paiements"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5347,11 +5348,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5386,7 +5387,7 @@ msgstr "Tél."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5517,8 +5518,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Enregistrer"
@@ -5535,7 +5536,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Enregistrer comme nouveau"
 
@@ -5630,9 +5631,9 @@ msgid "Primary Phone"
 msgstr "Téléphone principal"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimer"
@@ -5641,11 +5642,11 @@ msgstr "Imprimer"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimer et sauver"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimer et enregister comme nouveau"
 
@@ -5697,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5770,8 +5771,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5810,7 +5811,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5840,8 +5841,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5857,7 +5858,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Date de devis"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Date de devis manqante!"
 
@@ -5865,11 +5866,11 @@ msgstr "Date de devis manqante!"
 msgid "Quotation Number"
 msgstr "Numéro de devis"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Numéro de devis manquant!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
@@ -5884,7 +5885,7 @@ msgstr "Devis"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5910,7 +5911,7 @@ msgstr "Demandes de devis"
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5951,7 +5952,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5980,7 +5981,7 @@ msgstr "À recevoir"
 msgid "Receive"
 msgstr "Réception"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
@@ -6008,7 +6009,7 @@ msgstr "Rapport de rapprochement"
 msgid "Reconciliation Reports"
 msgstr "Rapports de rapprochement"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Enregistrer dans"
 
@@ -6034,11 +6035,11 @@ msgstr "Transactions périodiques"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Référence"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6075,9 +6076,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Restant"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,11 +6158,11 @@ msgstr "Rapports"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Exigence"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6278,11 +6283,11 @@ msgstr "Code secteur économique"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6311,7 +6316,7 @@ msgstr "Vente"
 msgid "Sales"
 msgstr "Ventes"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Facture de vente"
@@ -6320,8 +6325,8 @@ msgstr "Facture de vente"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Numéro facture de vente/écriture recette"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6386,7 +6391,7 @@ msgstr "Sam."
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6431,7 +6436,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6456,7 +6461,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
@@ -6465,7 +6470,7 @@ msgstr "Enregistrer comme nouveau"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6503,7 +6508,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Planification"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Planifié"
 
@@ -6662,11 +6667,11 @@ msgstr "Séléctionner client"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Sélectionner vendeur"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Sélectionner une imprimante!"
 
@@ -6686,12 +6691,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Sélectionner Postscript ou PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Sélectionner Txt, Postscript ou PDF!"
 
@@ -6782,7 +6787,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "N° série"
 
@@ -6800,11 +6805,11 @@ msgstr "Numéro de série"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Prestation de service"
 
@@ -6848,13 +6853,13 @@ msgstr "Dix-sept"
 msgid "Seventy"
 msgstr "Soixante-dix"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Expédier"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Expédier marchandise"
 
@@ -6884,12 +6889,12 @@ msgstr "Expédier à:"
 msgid "Ship Via"
 msgstr "Expédier via"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Expédier à"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6906,23 +6911,23 @@ msgstr "Expédier via"
 msgid "Shipping"
 msgstr "Expédition"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Date d'expédition"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Date d'expédition manquante!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6998,12 +7003,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7084,11 +7089,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "État"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7172,7 +7177,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7235,8 +7240,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7258,7 +7263,7 @@ msgstr "Taxe"
 msgid "Tax Account"
 msgstr "Compte de taxe"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7268,7 +7273,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7292,7 +7297,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Taxe incluse"
@@ -7399,7 +7404,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Squelette enregistré!"
 
@@ -7619,7 +7624,7 @@ msgstr "Temps"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7654,7 +7659,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Vers entrepôt"
 
@@ -7700,7 +7705,7 @@ msgstr "Description principale"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7721,7 +7726,7 @@ msgstr "Description principale"
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7733,6 +7738,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Objets référencés"
@@ -7741,7 +7750,7 @@ msgstr "Objets référencés"
 msgid "Trade Discount"
 msgstr "Escompte commercial"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Écriture"
 
@@ -7774,20 +7783,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Mouvements"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transfert"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transfert inventaire"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Transférer de"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transférer vers"
 
@@ -7874,7 +7883,7 @@ msgstr "Deux"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7935,7 +7944,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7951,7 +7960,7 @@ msgstr "Prix unitaire"
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7969,7 +7978,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8021,20 +8030,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8096,7 +8105,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8182,8 +8191,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8202,7 +8211,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Historique fournisseurs"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
@@ -8218,7 +8227,7 @@ msgstr "Nom du fournisseur"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8241,7 +8250,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
@@ -8278,7 +8287,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8355,7 +8364,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "De quel type est cet objet?"
 
@@ -8371,7 +8380,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8429,7 +8438,7 @@ msgstr "Écriture de fin d'exercice complétée"
 msgid "Years"
 msgstr "Années"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Oui"
@@ -8448,11 +8457,11 @@ msgstr "Code Postal"
 msgid "Zero"
 msgstr "Zéro"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Code Postal"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Code Postal"
 
@@ -8519,7 +8528,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "ville"
 
@@ -8563,7 +8572,7 @@ msgstr "fait"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "pièce(s)"
 

--- a/locale/po/he.po
+++ b/locale/po/he.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Amir Inbar <amir@srvit.co.il>, 2022\n"
 "Language-Team: Hebrew (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -187,7 +187,7 @@ msgstr "נטישה"
 msgid "Access Denied"
 msgstr "גישה נדחתה"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -195,9 +195,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -205,7 +205,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "הוספת עובד"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "הוספת שער חליפין"
 
@@ -461,11 +461,11 @@ msgstr "הוספת חלק"
 msgid "Add Pricegroup"
 msgstr "הוספת קבוצתמחיר"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "הוספת הזמנת מכר"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "הוספת הצעת מחיר"
 
@@ -473,7 +473,7 @@ msgstr "הוספת הצעת מחיר"
 msgid "Add Reporting Unit"
 msgstr "הוספת יחידת דיווח"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "הוספת בקשה להצעת מחיר"
 
@@ -485,11 +485,11 @@ msgstr "הוספת החזר"
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "הוספת חשבונית מכירה"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "הוספת הזמנת מכירה"
 
@@ -505,7 +505,7 @@ msgstr "הוספת טופס מס"
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "הוספה לרשימה"
 
@@ -527,7 +527,7 @@ msgstr "הוספת משתמש"
 msgid "Add Vendor"
 msgstr "הוספת יצרן"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "הוספת חשבונית ספק"
 
@@ -539,15 +539,15 @@ msgstr "הוספת החזרה לספק"
 msgid "Add Warehouse"
 msgstr "הוספת מחסן"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "הוספת שורה1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "הוספת שורה2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "הוספת שורה3"
 
@@ -575,8 +575,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -608,7 +608,7 @@ msgstr "כון"
 msgid "Adjusted"
 msgstr "כוון"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -685,9 +685,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -790,8 +790,8 @@ msgstr "מצב אישור"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "אישור"
@@ -829,20 +829,20 @@ msgstr "אפר"
 msgid "April"
 msgstr "אפריל"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "בטוח למחוק מספר הזמנה"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "בטוח שברצונך למחוק מספר הצעה"
 
@@ -915,16 +915,16 @@ msgstr "תג נכס"
 msgid "Assets"
 msgstr "נכסים"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "צרף"
@@ -955,31 +955,31 @@ msgstr "צורף ב"
 msgid "Attached By"
 msgstr "צורף על ידי"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "צורף אל"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "צורף אל סוג"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "קבצים מצורפים ומקושרים"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "צורף ב"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "צורף על ידי"
@@ -1012,7 +1012,7 @@ msgstr "אוגוסט"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "אוטומטי"
 
@@ -1081,7 +1081,7 @@ msgid "Balance"
 msgstr "יתרה"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "דף יתרה"
@@ -1128,8 +1128,8 @@ msgstr "שער בסיס"
 msgid "Base system"
 msgstr "מערכת בסיס"
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "בסיס"
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1208,14 +1208,14 @@ msgstr "ביליון"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "חישוב מיסים"
 
@@ -1323,12 +1323,12 @@ msgstr "חישוב מיסים"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1386,19 +1386,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1407,15 +1407,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "לא יכול לשמור הזמנה!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "לא יכול לשמור הצעה!"
 
@@ -1435,7 +1435,8 @@ msgstr ""
 msgid "Cash"
 msgstr "מזומן"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "חשבון מזומן"
 
@@ -1496,7 +1497,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1612,7 +1613,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "חברה"
 
@@ -1645,7 +1646,7 @@ msgstr "טלפון חברה"
 msgid "Company Sales Tax ID"
 msgstr "מספר ח.פ או עוסק מורשה של החברה"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr "פעולת אישור"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "אישור!"
 
@@ -1705,7 +1706,7 @@ msgstr "אישור!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1748,8 +1749,8 @@ msgstr "תוכן"
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1760,7 +1761,7 @@ msgstr "תוכן"
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1809,7 +1810,7 @@ msgid "Copy to New Name"
 msgstr "העתק לשם חדש"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "עלות"
 
@@ -1821,19 +1822,19 @@ msgstr "עלות טובין נמכרים"
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "לא הצלחתי לשמור!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1853,8 +1854,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1918,7 +1919,7 @@ msgstr "נוצר ב"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "זכות"
 
@@ -1939,7 +1940,7 @@ msgstr "חשבונות זכות"
 msgid "Credit Invoice"
 msgstr "חשבונית זיכוי"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1963,7 +1964,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1972,7 +1973,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2009,7 +2010,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2039,7 +2040,7 @@ msgstr "שם לקוח"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2052,7 +2053,7 @@ msgstr "מספר לקוח"
 msgid "Customer Search"
 msgstr "חיפוש לקוח"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "לקוח חסר!"
 
@@ -2068,7 +2069,7 @@ msgstr "לקוח לא בקובץ!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2141,7 +2142,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2156,11 +2157,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2198,7 +2199,7 @@ msgstr "תאריך תשלום"
 msgid "Date Range"
 msgstr "טווח תאריכים"
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "תאריך קבלה"
 
@@ -2222,7 +2223,7 @@ msgstr "מתאריך"
 msgid "Date of Birth"
 msgstr "תאריך לידה"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2268,7 +2269,7 @@ msgstr "ימים"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "חוב"
 
@@ -2381,9 +2382,9 @@ msgstr "סוגי שערי חליפין מוגדרים"
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2433,16 +2434,16 @@ msgstr "משלוח"
 msgid "Delivery Date"
 msgstr "תאריך משלוח"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2450,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2476,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2528,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2551,7 +2552,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2622,16 +2623,16 @@ msgstr "הנחה (%)"
 msgid "Discount:"
 msgstr "הנחה:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "גריטה"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "תאריך גריטה"
 
@@ -2639,7 +2640,7 @@ msgstr "תאריך גריטה"
 msgid "Disposal Method"
 msgstr "שיטת גריטה"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr "שגיאת חלוקה ב 0"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2663,7 +2664,7 @@ msgstr "סוג מסמך"
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "בוצע"
 
@@ -2683,7 +2684,7 @@ msgstr ""
 msgid "Dr."
 msgstr "דר."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "טיוטא הוגשה"
 
@@ -2725,14 +2726,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2744,8 +2745,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3047,11 +3048,11 @@ msgstr "ישות"
 msgid "Entity Class"
 msgstr "מחלקת ישות"
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "קוד ישות"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3067,7 +3068,7 @@ msgstr "שם ישות"
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "מעטפת"
@@ -3089,7 +3090,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3113,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3121,20 +3122,20 @@ msgstr ""
 msgid "Every"
 msgstr "כל"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "שעח"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "שערי חליפין"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "שערי חליפין לתשלום חסרים!"
 
@@ -3142,7 +3143,7 @@ msgstr "שערי חליפין לתשלום חסרים!"
 msgid "Exchange rate hasn't been defined!"
 msgstr "שער חליפין לא הוגדר!"
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "שער חליפין חסר!"
 
@@ -3187,8 +3188,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3266,7 +3267,7 @@ msgstr "חמישים"
 msgid "File"
 msgstr "קובץ"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "קובץ יובא"
 
@@ -3280,17 +3281,17 @@ msgstr "שם קובץ"
 msgid "File Type"
 msgstr "סוג קובץ"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "שם קובץ"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "סוג קובץ"
@@ -3327,7 +3328,7 @@ msgstr "ראשון"
 msgid "First Name"
 msgstr "שם פרטי"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3387,7 +3388,7 @@ msgstr "ארבע עשרה"
 msgid "Fri"
 msgstr "שיש"
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3419,7 +3420,7 @@ msgstr "מתאריך"
 msgid "From File"
 msgstr "קובץ"
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "ממחסן"
 
@@ -3468,7 +3469,7 @@ msgstr ""
 msgid "Gain"
 msgstr "רווח"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "רווח (הפסד)"
 
@@ -3476,7 +3477,7 @@ msgstr "רווח (הפסד)"
 msgid "Gain Account"
 msgstr "חשבון רווח"
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr "רווח/הפסד"
 
@@ -3505,11 +3506,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3554,8 +3555,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "קבוצה"
 
@@ -3797,8 +3798,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr "פרטים פנימיים"
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3856,11 +3857,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "מלאי נשמר!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "מלאי הועבר!"
 
@@ -3868,8 +3869,8 @@ msgstr "מלאי הועבר!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3887,22 +3888,22 @@ msgstr "חשבונית"
 msgid "Invoice #"
 msgstr "חשבונית #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "חשבונית נוצרה"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "חסר תאריך יצירת החשבונית!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "תאריך חשבונית"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "תאריך חשבונית חסר!"
 
@@ -3918,8 +3919,8 @@ msgstr "חשבונית מס."
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3928,7 +3929,7 @@ msgstr "חשבונית מס."
 msgid "Invoice Number"
 msgstr "מספר חשבונית"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "מספר חשבונית חסר!"
 
@@ -3986,7 +3987,7 @@ msgstr "פריט"
 msgid "Item deleted!"
 msgstr "פריט נמחק!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "פריט לא בקובץ!"
 
@@ -4014,7 +4015,7 @@ msgstr "ינו"
 msgid "January"
 msgstr "ינואר"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4055,7 +4056,7 @@ msgstr "ינו"
 msgid "June"
 msgstr "יוני"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4119,7 +4120,7 @@ msgstr "עודכן לאחרונה"
 msgid "Last name"
 msgstr "שם משפחה"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "ליד"
 
@@ -4340,11 +4341,11 @@ msgstr "ננעל על ידי [_1]"
 msgid "Logged out due to inactivity"
 msgstr "התנתקות בשל חוסר פעילות"
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "התחברות"
 
@@ -4421,7 +4422,7 @@ msgstr "מנהל"
 msgid "Manager:"
 msgstr "הל:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "ידני"
 
@@ -4452,9 +4453,9 @@ msgid "May"
 msgstr "מאי"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "פתקית"
@@ -4801,15 +4802,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4823,15 +4824,15 @@ msgstr "פתקים"
 msgid "Notes:<br />"
 msgstr "פתקים:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "לא הוכנס כלום!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "לא נבחר כלום!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "אין מה להעביר!"
 
@@ -4856,7 +4857,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4875,7 +4876,7 @@ msgstr "מספר"
 msgid "Number Format"
 msgstr "פורמט מספר"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4913,7 +4914,7 @@ msgstr "אוק"
 msgid "October"
 msgstr "אוקטובר"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4928,7 +4929,7 @@ msgstr "סיסמא ישנה"
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4983,7 +4984,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "סדר"
 
@@ -5001,12 +5002,12 @@ msgstr "סדר #"
 msgid "Order By"
 msgstr "הזמנה על ידי"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "תאריך הזמנה"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "תאריך הזמנה חסר!"
 
@@ -5018,8 +5019,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5027,15 +5028,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "מספר הזמנה"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "מספר הזמנה חסר!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "הזמנה נמחקה!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "יצירת הזמנה נכשלה!"
 
@@ -5122,8 +5123,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5139,7 +5140,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5147,11 +5148,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "רשימת אריזה"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "תאריך רשימת אריזה חסר!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5175,7 +5176,7 @@ msgstr "שולם"
 msgid "Parent"
 msgstr "אב"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "חלק"
 
@@ -5195,8 +5196,8 @@ msgstr "קבוצת חלק"
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5217,7 +5218,7 @@ msgstr "פרטי חלק"
 msgid "Partial"
 msgstr "חלקי"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5247,7 +5248,7 @@ msgstr "קבוצתחלקים"
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "סיסמא"
 
@@ -5316,7 +5317,7 @@ msgstr "סוג תשלום"
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "תאריך תשלום חסר!"
 
@@ -5328,7 +5329,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5337,7 +5338,7 @@ msgstr ""
 msgid "Payments"
 msgstr "תשלומים"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5345,11 +5346,11 @@ msgstr ""
 msgid "Percent"
 msgstr "אחוז"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "אחוז נותר"
 
@@ -5384,7 +5385,7 @@ msgstr "טלפון"
 msgid "Physical"
 msgstr "פיזי"
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5515,8 +5516,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5533,7 +5534,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5628,9 +5629,9 @@ msgid "Primary Phone"
 msgstr "טלפון ראשי"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "הדפס"
@@ -5639,11 +5640,11 @@ msgstr "הדפס"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "הדפס ושמור"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "הדפס ושמור כחדש"
 
@@ -5695,15 +5696,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5726,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr "רווח והפסד"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "רווח/הפסד"
 
@@ -5768,8 +5769,8 @@ msgstr "תאריך רכישה:"
 msgid "Purchase History"
 msgstr "היסטוריית רכישה"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5808,7 +5809,7 @@ msgstr "נרכש"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5838,8 +5839,8 @@ msgid "Quarter"
 msgstr "רבעון"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5855,7 +5856,7 @@ msgstr "הצעת מחיר #"
 msgid "Quotation Date"
 msgstr "תאריך הצעת מחיר"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "תאריך הצעת מחיר חסר!"
 
@@ -5863,11 +5864,11 @@ msgstr "תאריך הצעת מחיר חסר!"
 msgid "Quotation Number"
 msgstr "מספר הצעת מחליר"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "מספר הצעת מחיר חסר!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5882,7 +5883,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5908,7 +5909,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5949,7 +5950,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5978,7 +5979,7 @@ msgstr "לקבל"
 msgid "Receive"
 msgstr "קבל"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "קבל סחורה"
 
@@ -6006,7 +6007,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6032,11 +6033,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6073,9 +6074,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "נותר"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6103,7 +6108,7 @@ msgstr "דוח הופק על ידי:"
 msgid "Report Name"
 msgstr "שם דוח"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "תוצאות דוח"
 
@@ -6115,7 +6120,7 @@ msgstr "דוח הוגש"
 msgid "Report Type"
 msgstr "סוג דוח"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr "דוח [_1] בתאריך [_2]"
 
@@ -6151,11 +6156,11 @@ msgstr "דוחות"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6276,11 +6281,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6309,7 +6314,7 @@ msgstr "מכירה"
 msgid "Sales"
 msgstr "מכירות"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "חשבונית מכירה"
@@ -6318,8 +6323,8 @@ msgstr "חשבונית מכירה"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6384,7 +6389,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6429,7 +6434,7 @@ msgstr "שמור טיויטא"
 msgid "Save Groups"
 msgstr "שמור קבוצה"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "שמור מיקום"
 
@@ -6437,7 +6442,7 @@ msgstr "שמור מיקום"
 msgid "Save New"
 msgstr "שמור חדש"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr "שמור מיקום חדש"
 
@@ -6454,7 +6459,7 @@ msgid "Save Translations"
 msgstr "שמור תרגום"
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "שמור כחדש"
@@ -6463,7 +6468,7 @@ msgstr "שמור כחדש"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6501,7 +6506,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6514,12 +6519,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6660,11 +6665,11 @@ msgstr "בחירת לקוח"
 msgid "Select Templates to Load"
 msgstr "בחירת תבנית לטעינה"
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "בחירת ספק"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "בחירת מדפסת!"
 
@@ -6684,12 +6689,12 @@ msgstr "בחירת חשבוניות"
 msgid "Select or Enter User"
 msgstr "בחר או הקלד משתמש"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6780,7 +6785,7 @@ msgstr "רצפים"
 msgid "Serial #"
 msgstr "סיריאלי #"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "מס. סידורי"
 
@@ -6798,11 +6803,11 @@ msgstr "מספר סיריאלי"
 msgid "Serialnumber"
 msgstr "מספרסיריאלי"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "שרות"
 
@@ -6846,13 +6851,13 @@ msgstr "בע עשרה"
 msgid "Seventy"
 msgstr "שבעים"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "משלוח"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "משלוח סחורה"
 
@@ -6882,12 +6887,12 @@ msgstr "משלוח אל:"
 msgid "Ship Via"
 msgstr "משלוח באמצעות"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "משלוח אל"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6904,23 +6909,23 @@ msgstr "משלוח באמצעות"
 msgid "Shipping"
 msgstr "משלוח"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "תאריח משלוח"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "תאריך משלוח חסר!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr "תווית משלוח"
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6996,12 +7001,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7082,11 +7087,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "מצב"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7170,7 +7175,7 @@ msgstr "הגש"
 msgid "Submitted"
 msgstr "הוגש"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7233,8 +7238,8 @@ msgstr "סך הכל"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "טג"
 
@@ -7256,7 +7261,7 @@ msgstr "מס"
 msgid "Tax Account"
 msgstr "חשבון מס"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "קוד מס"
 
@@ -7266,7 +7271,7 @@ msgstr "קוד מס"
 msgid "Tax Form"
 msgstr "ס מס"
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "טופס מס הוחל"
 
@@ -7290,7 +7295,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "טפסי מס"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "מספר עוסק"
 
@@ -7298,7 +7303,7 @@ msgstr "מספר עוסק"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "כולל מס"
@@ -7397,7 +7402,7 @@ msgstr "תבנית"
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "תבנית נשמרה!"
 
@@ -7617,7 +7622,7 @@ msgstr "זמנים"
 msgid "Timing"
 msgstr "תזמון"
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7652,7 +7657,7 @@ msgstr "עד תאריך"
 msgid "To Pay"
 msgstr "לתשלום"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "אל מחסן"
 
@@ -7698,7 +7703,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7719,7 +7724,7 @@ msgstr ""
 msgid "Total"
 msgstr "סך הכל"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,6 +7736,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr "סך הכל שולם"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7739,7 +7748,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "עסקה"
 
@@ -7772,20 +7781,20 @@ msgstr "סוג עסקה"
 msgid "Transactions"
 msgstr "עסקאות"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "העברה"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "העברה מאת"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "העברה אל"
 
@@ -7872,7 +7881,7 @@ msgstr "שתיים"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7933,7 +7942,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7949,7 +7958,7 @@ msgstr "מחיר יחידה"
 msgid "Unknown "
 msgstr "לא ידוע"
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7967,7 +7976,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "בסיס נתונים לא ידוע נמצא."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8019,20 +8028,20 @@ msgstr "לא בשימוש"
 msgid "Up"
 msgstr "למעלה"
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "עדכון"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "עודכן"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8094,7 +8103,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8180,8 +8189,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8200,7 +8209,7 @@ msgstr "בון ספק"
 msgid "Vendor History"
 msgstr "היסטוריית ספק"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "חשבונית ספק"
@@ -8216,7 +8225,7 @@ msgstr "שם ספק"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8239,7 +8248,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr "חיפוש ספק"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "ספק חסר!"
 
@@ -8276,7 +8285,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8353,7 +8362,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "אזיה סוג פריט זה?"
 
@@ -8369,7 +8378,7 @@ msgstr "כל החודש קו ישר"
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8427,7 +8436,7 @@ msgstr ""
 msgid "Years"
 msgstr "שנים"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "כן"
@@ -8446,11 +8455,11 @@ msgstr ""
 msgid "Zero"
 msgstr "אפס"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "מיקוד"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8517,7 +8526,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "עיר"
 
@@ -8561,7 +8570,7 @@ msgstr "בוצע"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/hu.po
+++ b/locale/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Hungarian (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/hu/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Hozzáférés megtagadva"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr "Teljesítés alapján"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Összesített értékcsökkenés"
 
@@ -422,7 +422,7 @@ msgstr "Új debit note"
 msgid "Add Employee"
 msgstr "Új alkalmazott"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Új átváltási árfolyam"
 
@@ -458,11 +458,11 @@ msgstr "Új cikk"
 msgid "Add Pricegroup"
 msgstr "Új árcsoport"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Új beszerzési rendelés"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Új ajánlat"
 
@@ -470,7 +470,7 @@ msgstr "Új ajánlat"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Új ajánlatkérés"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Új TEÁOR/SZJ"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Új vevőszámla"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Új vevőrendelés"
 
@@ -502,7 +502,7 @@ msgstr "Új adóűrlap"
 msgid "Add Timecard"
 msgstr "Új munkalap"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Új felhasználó"
 msgid "Add Vendor"
 msgstr "Új szállító"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Új beszerzési számla"
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Új raktár"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Címsor 1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Címsor 2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Címsor 3 "
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr "Igazítás"
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Korrigált alap"
 
@@ -682,9 +682,9 @@ msgstr "Felülírható"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr "Jóváhagyás állapota"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Jóváhagy"
@@ -826,20 +826,20 @@ msgstr "Ápr."
 msgid "April"
 msgstr "Április"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Megszerzett érték"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Biztosan törölni akarja a megrendelést"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Biztosan törölni akarja az ajánlatot"
 
@@ -912,16 +912,16 @@ msgstr "Eszköz címke"
 msgid "Assets"
 msgstr "Eszközök"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Hozzáad"
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Mellékelt"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Melléklet típusa"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Mellékelt és hivatkozott fájlok"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Mellékelve"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Mellékelte"
@@ -1009,7 +1009,7 @@ msgstr "Augusztus"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatikus"
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "Egyenleg"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Mérleg"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Alap"
 
@@ -1138,7 +1138,7 @@ msgstr "Köteg"
 msgid "Batch Class"
 msgstr "Köteg osztály"
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr "Köteg ellenőrző kódja"
 
@@ -1158,7 +1158,7 @@ msgstr "Köteg ID"
 msgid "Batch ID Missing"
 msgstr "Köteg azonosító hiányzik"
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr "Köteg neve"
 
@@ -1205,14 +1205,14 @@ msgstr "milliárd"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "VTSZ/TEÁOR"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Adószámítás"
 
@@ -1320,12 +1320,12 @@ msgstr "Adószámítás"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Érvénytelenített számlát nem lehet még egyszer érvényteleníteni!"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr "Nem lehet szolgáltatást létrehozni; nem létezik bevétel számla!"
 msgid "Cannot delete item!"
 msgstr "A tételt nem lehet törölni!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "A rendelést nem lehet törölni!"
 
@@ -1383,19 +1383,19 @@ msgstr "A rendelést nem lehet törölni!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Az ajánlatot nem lehet törölni!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Lezárt időszakban nem lehet számlát kiállítani!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Lezárt időszakban nem lehet fizetési tételt rögzíteni!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Lezárt időszakhoz nem lehet tranzakciót rögzíteni!"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "Ugyanazon számlán nem lehet tartozik és követel tranzakciót rögzíteni!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "A tranzakciót nem lehet rögzíteni!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "A rendelést nem lehet elmenteni!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Nem lehet elmenteni az ajánlatot!"
 
@@ -1432,7 +1432,8 @@ msgstr "Kártya ID"
 msgid "Cash"
 msgstr "Pénzmozgások"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Pénz számla"
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Társaság"
 
@@ -1642,7 +1643,7 @@ msgstr "Társaság telefonszáma"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr "Erősítse meg a műveletet"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Erősítse meg!"
 
@@ -1702,7 +1703,7 @@ msgstr "Erősítse meg!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Meglévő adattal való ütközés. Elképzelhető, hogy már megadta korábban?"
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr "Új névbe másol"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Költség"
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Nem sikerült elmenteni az adatokat. Kérem próbálja újra"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Nem lehet elmenteni!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Nem lehet a készletet áthelyezni!"
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr "Létrehozva"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Követel"
 
@@ -1936,7 +1937,7 @@ msgstr "Hitel számla"
 msgid "Credit Invoice"
 msgstr "Új számlakorrekció"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr "Követel"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Pénznem"
 
@@ -1969,7 +1970,7 @@ msgstr "Pénznem"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr "Vevő neve"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr "Vevő azonosító"
 msgid "Customer Search"
 msgstr "Vevő partner keresése"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "A vevő hiányzik!"
 
@@ -2065,7 +2066,7 @@ msgstr "A vevő hiányzik az adatbázisból!"
 msgid "Customer/Vendor Accounts"
 msgstr "Vevő/Szállító számlák"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr "Écs."
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Az adat nem került mentésre. Kérem próbálja újra."
 
@@ -2138,7 +2139,7 @@ msgstr "Az adatbázis nem létezik."
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "Fizetés napja"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Beérkezés dátuma"
 
@@ -2219,7 +2220,7 @@ msgstr "Mettől"
 msgid "Date of Birth"
 msgstr "Születésnap"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "A beérkezés dátuma hiányzik!"
 
@@ -2265,7 +2266,7 @@ msgstr "Napok"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Tartozik"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr "Szállítás"
 msgid "Delivery Date"
 msgstr "Szállítás dátuma"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Écs. alapja"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Écs. módja"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Écs. indul"
 
@@ -2447,11 +2448,11 @@ msgstr "Écs. indul"
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr "Értékcsökkenés"
 msgid "Depreciate Through"
 msgstr "Értékcsökkentés ezen keresztül"
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Értékcsökkenés"
@@ -2525,13 +2526,13 @@ msgstr "Értékcsökkenés kezdete"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr "Értékcsökkenés kezdete"
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr "Engedmény (%)"
 msgid "Discount:"
 msgstr "Engedmény:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Selejtezés"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Selejtezés dátuma"
 
@@ -2636,7 +2637,7 @@ msgstr "Selejtezés dátuma"
 msgid "Disposal Method"
 msgstr "Selejtezés módja"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr "Nullával osztás probléma"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr "Dokumentum típusa"
 msgid "Don't know what to do with backup"
 msgstr "Nem tudom, mit kellene tennem a biztonsági mentéssel"
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Elvégezve"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr "Dr."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "A vázlat rögzítve"
 
@@ -2722,14 +2723,14 @@ msgstr "Esedékes"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Esedékesség"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Esedékesség hiányzik!"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3044,11 +3045,11 @@ msgstr "Egyed"
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "Egység kódja"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "Egység ellenőrző kódja"
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr "Bejegyzés ID"
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Hiba: Más legördülő menü nem tartalmazhatja a gyűjtőszámlát"
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Becsült élettartam"
 
@@ -3118,20 +3119,20 @@ msgstr "Becsült élettartam"
 msgid "Every"
 msgstr "Minden"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Árf"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Átváltási árfolyam"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "A fizetett összeg átváltási árfolyama hiányzik!"
 
@@ -3139,7 +3140,7 @@ msgstr "A fizetett összeg átváltási árfolyama hiányzik!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Az átváltási árfolyam hiányzik!"
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Deviza"
 
@@ -3263,7 +3264,7 @@ msgstr "ötven"
 msgid "File"
 msgstr "Fájl"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Importált fájl"
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Fájl neve"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Fájl típusa"
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Keresztnév"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr "tizennégy"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr "Kezdő dátum"
 msgid "From File"
 msgstr "Kezdő fájl"
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Raktárból"
 
@@ -3465,7 +3466,7 @@ msgstr "Vegyes könyvelés referenciaszám"
 msgid "Gain"
 msgstr "Nyereség"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Nyereség (veszteség)"
 
@@ -3473,7 +3474,7 @@ msgstr "Nyereség (veszteség)"
 msgid "Gain Account"
 msgstr "Nyereség számla"
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr "Generálás"
 msgid "Generate Control Code"
 msgstr "Ellenőrző kód létrehozása"
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Rendelések készítése"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Beszerzési rendelés készítése"
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr "Végösszeg"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Csoport"
 
@@ -3794,8 +3795,8 @@ msgstr "Belső adatbázis hiba"
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Belső feljegyzés"
 
@@ -3857,11 +3858,11 @@ msgstr ""
 "Mielőtt ezt az anyagot/árut elévültnek nyilvánítja,a mennyiségnek nullának "
 "kell lennie!!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Készlet elmentve!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Készlet áthelyezve!"
 
@@ -3869,8 +3870,8 @@ msgstr "Készlet áthelyezve!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3888,22 +3889,22 @@ msgstr "Számla"
 msgid "Invoice #"
 msgstr "Számla #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Számla kelte"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Teljesítés dátuma"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "A teljesítés dátuma hiányzik!"
 
@@ -3919,8 +3920,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3929,7 +3930,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Számlaszám"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Számlaszám hiányzik!"
 
@@ -3987,7 +3988,7 @@ msgstr "Tétel"
 msgid "Item deleted!"
 msgstr "Tétel törölve!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "A tétel nincs az adatbázisban!"
 
@@ -4015,7 +4016,7 @@ msgstr "Jan."
 msgid "January"
 msgstr "Január"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4056,7 +4057,7 @@ msgstr "Jún."
 msgid "June"
 msgstr "Június"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4120,7 +4121,7 @@ msgstr "Utolsó módosítás"
 msgid "Last name"
 msgstr "Vezetéknév"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Átfutás"
 
@@ -4341,11 +4342,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Belépés"
 
@@ -4422,7 +4423,7 @@ msgstr "Menedzser"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Kézi"
 
@@ -4453,9 +4454,9 @@ msgid "May"
 msgstr "Máj."
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Megjegyzés"
@@ -4804,15 +4805,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4826,15 +4827,15 @@ msgstr "Megjegyzés"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Nincs bevitt adat!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nincs kiválasztva semmi!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nincs mit áthelyezni!"
 
@@ -4859,7 +4860,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4878,7 +4879,7 @@ msgstr "Azonosító"
 msgid "Number Format"
 msgstr "Számformátum"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4916,7 +4917,7 @@ msgstr "Okt."
 msgid "October"
 msgstr "Október"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr "Elenged"
 
@@ -4931,7 +4932,7 @@ msgstr "Régi jelszó"
 msgid "On Hand"
 msgstr "Készleten"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "Visszatartva"
@@ -4986,7 +4987,7 @@ msgstr "Vagy hozzáadás köteghez"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Sorrend"
 
@@ -5004,12 +5005,12 @@ msgstr "Rendelés #"
 msgid "Order By"
 msgstr "Rendezés"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Rendelés dátuma"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "A rendelés dátuma hiányzik!"
 
@@ -5021,8 +5022,8 @@ msgstr "Rendelések"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5030,15 +5031,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Rendelés azonosítója"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "A rendelés azonosítója hiányzik!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Rendelés törölve!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Sikertelen rendelés készítés!"
 
@@ -5125,8 +5126,8 @@ msgstr "BR #"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5142,7 +5143,7 @@ msgstr "RÖGZÍT"
 msgid "POST AND PRINT"
 msgstr "Rögzít és nyomtat"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5150,11 +5151,11 @@ msgstr "Rögzít és nyomtat"
 msgid "Packing List"
 msgstr "Szállítólevél"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Szállítólevél dátuma hiányzik!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Szállítólevél száma hiányzik!"
 
@@ -5178,7 +5179,7 @@ msgstr "Fizetve"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Cikk"
 
@@ -5198,8 +5199,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5220,7 +5221,7 @@ msgstr ""
 msgid "Partial"
 msgstr "Részleges"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5250,7 +5251,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Jelszó"
 
@@ -5319,7 +5320,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "A fizetés dátuma hiányzik!"
 
@@ -5331,7 +5332,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5340,7 +5341,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pénzmozgások"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 "Az érvénytelenített számlához tartozó fizetési tételeket korrigálni kell "
@@ -5350,11 +5351,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Százalék"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Selejtezés százaléka"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Maradék százalék"
 
@@ -5389,7 +5390,7 @@ msgstr "Telefon"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5520,8 +5521,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Rögzítés"
@@ -5538,7 +5539,7 @@ msgstr "Rögzítés dátuma"
 msgid "Post Yearend"
 msgstr "Évzárás rögzítése"
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Rögzítés újként"
 
@@ -5633,9 +5634,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Nyomtatás"
@@ -5644,11 +5645,11 @@ msgstr "Nyomtatás"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Nyomtat és ment"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Újként nyomtat és ment"
 
@@ -5700,15 +5701,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Bevételek"
 
@@ -5730,7 +5731,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5773,8 +5774,8 @@ msgstr "Vásárlás dátuma:"
 msgid "Purchase History"
 msgstr "Beszerzési napló"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5813,7 +5814,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5843,8 +5844,8 @@ msgid "Quarter"
 msgstr "Negyedév"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5860,7 +5861,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Ajánlat dátuma"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Az ajánlat dátuma hiányzik!"
 
@@ -5868,11 +5869,11 @@ msgstr "Az ajánlat dátuma hiányzik!"
 msgid "Quotation Number"
 msgstr "Ajánlat azonosítója"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Az ajánlat azonosítója hiányzik!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Ajánlat törölve!"
 
@@ -5887,7 +5888,7 @@ msgstr "Ajánlatok"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5913,7 +5914,7 @@ msgstr "Ajánlatkérések"
 msgid "ROP"
 msgstr "Újrarendelési pont"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5954,7 +5955,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Érkezett"
 
@@ -5983,7 +5984,7 @@ msgstr "Követelések"
 msgid "Receive"
 msgstr "Bevételezés"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Áru érkeztetés"
 
@@ -6011,7 +6012,7 @@ msgstr "Egyeztető Lista"
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Főkönyvi számla"
 
@@ -6037,11 +6038,11 @@ msgstr "Ismétlődő tranzakciók"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referencia"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6078,9 +6079,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Maradék élettartam"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Maradék"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Eredmények listája"
 
@@ -6120,7 +6125,7 @@ msgstr "Jelentés elküldve"
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6156,11 +6161,11 @@ msgstr "Jelentések"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Kérés"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6281,11 +6286,11 @@ msgstr "Osztályozókód"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6314,7 +6319,7 @@ msgstr "Eladás"
 msgid "Sales"
 msgstr "Értékesítés"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Új vevőszámla"
@@ -6323,8 +6328,8 @@ msgstr "Új vevőszámla"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Vevőszámla/tranzakció azonosító"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6389,7 +6394,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr "Csoportok mentése"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Hely mentése"
 
@@ -6442,7 +6447,7 @@ msgstr "Hely mentése"
 msgid "Save New"
 msgstr "Új mentése"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr "Új hely mentése"
 
@@ -6459,7 +6464,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Mentés újként"
@@ -6468,7 +6473,7 @@ msgstr "Mentés újként"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6506,7 +6511,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6519,12 +6524,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Beütemez"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Ütemezve"
 
@@ -6665,11 +6670,11 @@ msgstr "Vevő választás"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Szállító választás"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Válasszon egy nyomtatót!"
 
@@ -6689,12 +6694,12 @@ msgstr "Számlák kiválasztása"
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Válassza ki a postscript vagy a PDF formátumot!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Válasszon txt, postscript vagy PDF formátumot!"
 
@@ -6785,7 +6790,7 @@ msgstr "Sorszámok"
 msgid "Serial #"
 msgstr "Sorozatszám"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Sorozatszám"
 
@@ -6803,11 +6808,11 @@ msgstr "Sorszám"
 msgid "Serialnumber"
 msgstr "Sorozatszám"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Szolgáltatás"
 
@@ -6851,13 +6856,13 @@ msgstr "tizenhét"
 msgid "Seventy"
 msgstr "hetven"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Kiszállítás"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Áru kiszállítás"
 
@@ -6887,12 +6892,12 @@ msgstr "Szállítási cím:"
 msgid "Ship Via"
 msgstr "Fizetési mód"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Szállítási cím"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6909,23 +6914,23 @@ msgstr "Fizetési mód"
 msgid "Shipping"
 msgstr "Szállítás"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Szállítás dátuma"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "A szállítás dátuma hiányzik!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7001,12 +7006,12 @@ msgstr "Néhány"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7087,11 +7092,11 @@ msgstr "Kezdési dátum"
 msgid "Starting Date:"
 msgstr "Kezdő dátum:"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Megye"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7175,7 +7180,7 @@ msgstr "Elküldés"
 msgid "Submitted"
 msgstr "Elküldve"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7238,8 +7243,8 @@ msgstr "Végösszeg"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Címke"
 
@@ -7261,7 +7266,7 @@ msgstr "Adó"
 msgid "Tax Account"
 msgstr "Adó számla"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Adó kód"
 
@@ -7271,7 +7276,7 @@ msgstr "Adó kód"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Adóűrlap"
 
@@ -7295,7 +7300,7 @@ msgstr "Adóűrlap jelentések"
 msgid "Tax Forms"
 msgstr "Adóűrlapok"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "Adószám"
 
@@ -7303,7 +7308,7 @@ msgstr "Adószám"
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Adót tartalmazza"
@@ -7402,7 +7407,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7623,7 +7628,7 @@ msgstr "-szor"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7658,7 +7663,7 @@ msgstr "Végdátum"
 msgid "To Pay"
 msgstr "Fizetendő"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Raktárba"
 
@@ -7704,7 +7709,7 @@ msgstr "Legfelső szint"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7725,7 +7730,7 @@ msgstr "Legfelső szint"
 msgid "Total"
 msgstr "Végösszeg"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Összesített écs."
 
@@ -7737,6 +7742,10 @@ msgstr "Összes kintlévőség"
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Raktározott tételek"
@@ -7745,7 +7754,7 @@ msgstr "Raktározott tételek"
 msgid "Trade Discount"
 msgstr "Árengedmény"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Tranzakció"
 
@@ -7778,20 +7787,20 @@ msgstr "Tranzakció típusa"
 msgid "Transactions"
 msgstr "Számlák"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Tranzakciók"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Készlet áthelyezés"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Áthelyezés innen"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Áthelyezés ide"
 
@@ -7878,7 +7887,7 @@ msgstr "kettő"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7939,7 +7948,7 @@ msgstr "Egyedi élő cikkszám"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7955,7 +7964,7 @@ msgstr "Egységár"
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7973,7 +7982,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Ismeretlen adatbázist találtam."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8025,20 +8034,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Frissítés"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Frissítve"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8100,7 +8109,7 @@ msgstr "Vevő túlfizetés használata"
 msgid "Use Overpayment"
 msgstr "Saját túlfizetés használata"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8186,8 +8195,8 @@ msgstr "Eltérés:"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8206,7 +8215,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Szállító történet"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Új beszerzési számla"
@@ -8222,7 +8231,7 @@ msgstr "Szállító neve"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8245,7 +8254,7 @@ msgstr "Szállító referenciaszáma"
 msgid "Vendor Search"
 msgstr "Szállító partner keresése"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Hiányzik a szállító!"
 
@@ -8282,7 +8291,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Ez milyen típusú tétel?"
 
@@ -8375,7 +8384,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8433,7 +8442,7 @@ msgstr "Evzárás elvégezve"
 msgid "Years"
 msgstr "Évek"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Igen"
@@ -8452,11 +8461,11 @@ msgstr ""
 msgid "Zero"
 msgstr "Nulla"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Ir. szám."
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Irányítószám"
 
@@ -8523,7 +8532,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "város"
 
@@ -8567,7 +8576,7 @@ msgstr "elvégezve"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "db"
 

--- a/locale/po/id.po
+++ b/locale/po/id.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Indonesian (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/id/)\n"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Akses ditolak"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -195,9 +195,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -205,7 +205,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Tambah Karyawan"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Tambah Kurs"
 
@@ -461,11 +461,11 @@ msgstr "Tambah Barang"
 msgid "Add Pricegroup"
 msgstr "Tambah Kelompok Harga"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Tambah Pesanan Pembelian (PO)"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Tambah Quotation"
 
@@ -473,7 +473,7 @@ msgstr "Tambah Quotation"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Tambah Request for Quotation"
 
@@ -485,11 +485,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Tambah SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Tambah Invoice Penjualan"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Tambah Pesanan Penjualan (SO)"
 
@@ -505,7 +505,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr "Tambah User"
 msgid "Add Vendor"
 msgstr "Tambah Supplier"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Tambah Invoice Supplier"
 
@@ -539,15 +539,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Tambah Gudang"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -575,8 +575,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -685,9 +685,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -796,8 +796,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -835,20 +835,20 @@ msgstr ""
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Apakah anda yakin akan menghapus Nomor Order"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Apakah anda yakin akan menghapus Nomor Quotasi"
 
@@ -921,16 +921,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -961,31 +961,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1018,7 +1018,7 @@ msgstr "Agustus"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Otomatis"
 
@@ -1087,7 +1087,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Neraca"
@@ -1134,8 +1134,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1214,14 +1214,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Kalkulasi Pajak"
 
@@ -1329,12 +1329,12 @@ msgstr "Kalkulasi Pajak"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1384,7 +1384,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Tidak dapat menghapus Item!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Tidak dapat menghapus Pesanan!"
 
@@ -1392,19 +1392,19 @@ msgstr "Tidak dapat menghapus Pesanan!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Tidak dapat menghapus Quotation!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Tidak dapat posting invoice untuk perioda yang sudah ditutup!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Tidak dapat posting pembayaran untuk perioda yang sudah ditutup!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Tidak dapat posting transaksi untuk perioda yang sudah ditutup!"
 
@@ -1413,15 +1413,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Tidak dapat posting transaksi!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Tidak dapat menyimpan pesanan!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Tidak dapat menyimpan quotation!"
 
@@ -1441,7 +1441,8 @@ msgstr "ID Card"
 msgid "Cash"
 msgstr "Kas dan Bank"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1502,7 +1503,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1618,7 +1619,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Perusahaan"
 
@@ -1651,7 +1652,7 @@ msgstr "Telefon"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1703,7 +1704,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Konfirmasi!"
 
@@ -1711,7 +1712,7 @@ msgstr "Konfirmasi!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1754,8 +1755,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1766,7 +1767,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1815,7 +1816,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Biaya"
 
@@ -1827,19 +1828,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Tidak dapat menyimpan"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Tidak dapat mentransfer Inventory"
 
@@ -1859,8 +1860,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1924,7 +1925,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredit"
 
@@ -1945,7 +1946,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Mata Uang"
 
@@ -1978,7 +1979,7 @@ msgstr "Mata Uang"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2015,7 +2016,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2045,7 +2046,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2058,7 +2059,7 @@ msgstr "Nomor Pelanggan"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Pelanggan harap diisi!"
 
@@ -2074,7 +2075,7 @@ msgstr "Pelanggan tidak ditemukan!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2098,7 +2099,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Data tidak tersimpan. Silahkan Coba kembali"
 
@@ -2147,7 +2148,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2162,11 +2163,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2204,7 +2205,7 @@ msgstr "Tanggal Bayar"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Tanggal Diterima"
 
@@ -2228,7 +2229,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Tanggal Lahir"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Tanggal diterima harap diisi!"
 
@@ -2274,7 +2275,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2387,9 +2388,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2439,16 +2440,16 @@ msgstr "Pengiriman"
 msgid "Delivery Date"
 msgstr "Tanggal Kirim"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2456,11 +2457,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2482,7 +2483,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2534,13 +2535,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2557,7 +2558,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2628,16 +2629,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2645,7 +2646,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2653,7 +2654,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2669,7 +2670,7 @@ msgstr "Tipe Dokumen"
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Selesai"
 
@@ -2689,7 +2690,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2731,14 +2732,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Jatuh Tempo"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Tanggal Jatuh Tempo harap diisi!"
 
@@ -2750,8 +2751,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3053,11 +3054,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3073,7 +3074,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3095,7 +3096,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3119,7 +3120,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3127,20 +3128,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Kurs"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3148,7 +3149,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Kurs harap diisi!"
 
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3272,7 +3273,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3286,17 +3287,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3333,7 +3334,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3393,7 +3394,7 @@ msgstr "Empat Belas"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3425,7 +3426,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3474,7 +3475,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3482,7 +3483,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3511,11 +3512,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3560,8 +3561,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3803,8 +3804,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3862,11 +3863,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventory sudah disimpan!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventory sudah di-transfer"
 
@@ -3874,8 +3875,8 @@ msgstr "Inventory sudah di-transfer"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3893,22 +3894,22 @@ msgstr "Invoice"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Tanggal Invoice"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Tanggal Invoice harap diisi!"
 
@@ -3924,8 +3925,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3934,7 +3935,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Nomor Invoice"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Nomor Invoice harap diisi"
 
@@ -3992,7 +3993,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Barang sudah dihapus!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Item ini tidak ditemukan!"
 
@@ -4020,7 +4021,7 @@ msgstr ""
 msgid "January"
 msgstr "Januari"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4061,7 +4062,7 @@ msgstr ""
 msgid "June"
 msgstr "Juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4125,7 +4126,7 @@ msgstr ""
 msgid "Last name"
 msgstr "Nama belakang"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4346,11 +4347,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Masuk"
 
@@ -4427,7 +4428,7 @@ msgstr "Manajer"
 msgid "Manager:"
 msgstr "Manajer:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4458,9 +4459,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4807,15 +4808,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4829,15 +4830,15 @@ msgstr "Catatan"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Catatan sudah dimasukkan!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Tidak ada yang dipilih!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Tidak ada yang akan di-transfer!"
 
@@ -4862,7 +4863,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4881,7 +4882,7 @@ msgstr "Nomor"
 msgid "Number Format"
 msgstr "Format Angka"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4919,7 +4920,7 @@ msgstr ""
 msgid "October"
 msgstr "Oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4934,7 +4935,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4989,7 +4990,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "No. Pesanan"
 
@@ -5007,12 +5008,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tanggal Pesanan"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Tanggal Pesanan harap diisi!"
 
@@ -5024,8 +5025,8 @@ msgstr "Pesanan"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5033,15 +5034,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Nomor Pesanan"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Nomor Pesanan harap diisi"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Pesanan sudah dihapus!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5128,8 +5129,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5145,7 +5146,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5153,11 +5154,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Nomor Packing List harap diisi!"
 
@@ -5181,7 +5182,7 @@ msgstr "Dibayar"
 msgid "Parent"
 msgstr "Induk"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Barang"
 
@@ -5201,8 +5202,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5223,7 +5224,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5253,7 +5254,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5322,7 +5323,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Tanggal Pembayaran harap diisi!"
 
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5343,7 +5344,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pembayaran"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5351,11 +5352,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5390,7 +5391,7 @@ msgstr "Telephone"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5521,8 +5522,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Posting"
@@ -5539,7 +5540,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Posting sbg yang baru"
 
@@ -5634,9 +5635,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Cetak"
@@ -5645,11 +5646,11 @@ msgstr "Cetak"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Cetak dan Simpan"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5701,15 +5702,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5731,7 +5732,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr "Laba dan Rugi"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Laba/Rugi"
 
@@ -5774,8 +5775,8 @@ msgstr "Tanggal Pembelian:"
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5814,7 +5815,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5844,8 +5845,8 @@ msgid "Quarter"
 msgstr "Kwartal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5861,7 +5862,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Tanggal Quotation"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Tanggal Quotation harap diisi!"
 
@@ -5869,11 +5870,11 @@ msgstr "Tanggal Quotation harap diisi!"
 msgid "Quotation Number"
 msgstr "Nomor Quotation"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Nomor Quotation harap diisi!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Nomor Quotation sudah dihapus!"
 
@@ -5888,7 +5889,7 @@ msgstr "Quotation"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5914,7 +5915,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5955,7 +5956,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Terima"
 
@@ -5984,7 +5985,7 @@ msgstr "Piutang"
 msgid "Receive"
 msgstr "Penerimaan"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Penerimaan Barang"
 
@@ -6012,7 +6013,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Catat pada"
 
@@ -6038,11 +6039,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referensi"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6079,9 +6080,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Sisa"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6109,7 +6114,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6121,7 +6126,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6157,11 +6162,11 @@ msgstr "Laporan"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6282,11 +6287,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6315,7 +6320,7 @@ msgstr "Penjualan"
 msgid "Sales"
 msgstr "Penjualan"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Invoice Penjualan"
@@ -6324,8 +6329,8 @@ msgstr "Invoice Penjualan"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6390,7 +6395,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6435,7 +6440,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6443,7 +6448,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6460,7 +6465,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Simpan sbg yg baru"
@@ -6469,7 +6474,7 @@ msgstr "Simpan sbg yg baru"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6507,7 +6512,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6520,12 +6525,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6666,11 +6671,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Pilih Supplier"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Pilih Printer!"
 
@@ -6690,12 +6695,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Pilih postscript atau PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Pilih txt, postscript atau PDF!"
 
@@ -6786,7 +6791,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "No. Seri"
 
@@ -6804,11 +6809,11 @@ msgstr "Nomor Seri"
 msgid "Serialnumber"
 msgstr "Serialnumber"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Jasa"
 
@@ -6852,13 +6857,13 @@ msgstr "Tujuh belas"
 msgid "Seventy"
 msgstr "Tujuh puluh"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Kirim"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Pengiriman Barang"
 
@@ -6888,12 +6893,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Kirim kepada"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6910,23 +6915,23 @@ msgstr "Kirim melalui"
 msgid "Shipping"
 msgstr "Kirim dan Terima"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Tanggal Pengiriman"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Tanggal Pengiriman harap diisi!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7002,12 +7007,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7088,11 +7093,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Negara Bagian"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7176,7 +7181,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7239,8 +7244,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7262,7 +7267,7 @@ msgstr "Pajak"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7272,7 +7277,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7296,7 +7301,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7304,7 +7309,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Termasuk Pajak"
@@ -7403,7 +7408,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7623,7 +7628,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7658,7 +7663,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7704,7 +7709,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7725,7 +7730,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7737,6 +7742,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7745,7 +7754,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Transaksi"
 
@@ -7778,20 +7787,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transfer ke"
 
@@ -7878,7 +7887,7 @@ msgstr "Dua"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7939,7 +7948,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7955,7 +7964,7 @@ msgstr "Satuan Harga"
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7973,7 +7982,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8025,20 +8034,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Diupdate"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8100,7 +8109,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8186,8 +8195,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8206,7 +8215,7 @@ msgstr "Akun Supplier"
 msgid "Vendor History"
 msgstr "Historis Supplier"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Invoice Supplier"
@@ -8222,7 +8231,7 @@ msgstr "Nama Supplier"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8245,7 +8254,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Data Supplier harap diisi!"
 
@@ -8282,7 +8291,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Jenis item ini ?"
 
@@ -8375,7 +8384,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8433,7 +8442,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ya"
@@ -8452,11 +8461,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8523,7 +8532,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8567,7 +8576,7 @@ msgstr "selesai"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/is.po
+++ b/locale/po/is.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Icelandic (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/is/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -458,11 +458,11 @@ msgstr "Ný vara"
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Ný innkaupspöntun"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Nýr sölureikningur"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Ný sölupöntun"
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Nýr notandi"
 msgid "Add Vendor"
 msgstr "Nýr byrgir"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Nýr innkaupsreikningur"
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "apr"
 msgid "April"
 msgstr "apríl"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Ert þú viss um að þú viljir eyða pöntun númer"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "ágúst"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "Afstemming"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Staða"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Vörulager"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Get ekki eytt hlut!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Get ekki eytt pöntun!"
 
@@ -1383,19 +1383,19 @@ msgstr "Get ekki eytt pöntun!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Get ekki bókað á lokað tímabil!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Get ekki bókað greiðslu á lokað tímabil"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Get ekki bókað færslu á lokað tímabil!"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Get ekki bókað færslu!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Get ekki geymt pöntun!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Reiðufé"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Fyritæki"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Staðfesta!"
 
@@ -1702,7 +1703,7 @@ msgstr "Staðfesta!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredit"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Gjaldm"
 
@@ -1969,7 +1970,7 @@ msgstr "Gjaldm"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Viðskiptavin vantar!"
 
@@ -2065,7 +2066,7 @@ msgstr "Viðskiptavinur ekki á skrá!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "Greiðsludagur"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debit"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Afgreiðsludags."
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Búið"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Dags. lokið"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Vantar dags. lokið!"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "R-póstur"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Vx"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Vextir"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Vextir fyrir greiðslu vantar!"
 
@@ -3139,7 +3140,7 @@ msgstr "Vextir fyrir greiðslu vantar!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Vantar vexti!"
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr "Lagerbeholdning skal være nul for at du kan forælde denne sammensætni
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "Sölureikningur"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Sölureikningur dags."
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Sölureiknings dags. vantar!"
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Sölureikningur Númer"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Sölureikningsnúmer vantar!"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Hlut eytt!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Hlutur ekki á skrá!"
 
@@ -4011,7 +4012,7 @@ msgstr "jan"
 msgid "January"
 msgstr "janúar"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "jún"
 msgid "June"
 msgstr "júní"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Tengjast"
 
@@ -4418,7 +4419,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "maí"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "Upplýsinar"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Ekkert valið!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "Númer"
 msgid "Number Format"
 msgstr "Númera útlit"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "ókt"
 msgid "October"
 msgstr "óktóber"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Á lager"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Pöntun"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Pöntunar dags."
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Pöntunar dags. vantar"
 
@@ -5015,8 +5016,8 @@ msgstr "Pöntunarblað"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Pöntun númer"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Númer pöntunar vantar"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Pöntun eytt"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Fylgiseðill"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Númer fylgiseðils vantar!"
 
@@ -5172,7 +5173,7 @@ msgstr "Greitt"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Vara"
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Aðgangsorð"
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Greiðsudags. vantar!"
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Greiðslur"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Bókfæra"
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Bókfæra sem nýjan"
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Prenta"
@@ -5636,11 +5637,11 @@ msgstr "Prenta"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Mótt:"
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Bóka á"
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Fylgiskjal"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,9 +6071,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Eftir"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr "Skýrslur"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr ""
 msgid "Sales"
 msgstr "Sala"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Sölureikningur"
@@ -6315,8 +6320,8 @@ msgstr "Sölureikningur"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Geyma sem nýtt"
@@ -6460,7 +6465,7 @@ msgstr "Geyma sem nýtt"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Veljið postscript eða PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Þjónusta"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Senda"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Senda til"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr "Senda með"
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "Virðisaukaskattur"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Taka með VSK"
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr "Samtals"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Uppfærsla"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Uppfæra"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Innkaupsreikningur"
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Byrgja vantar!"
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Hvernig hlutur er þetta?"
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Já"
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "stk"
 

--- a/locale/po/it.po
+++ b/locale/po/it.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Ferruccio Zamuner <nonsolosoft@diff.org>, 2016\n"
 "Language-Team: Italian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -190,7 +190,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Accesso negato"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -198,9 +198,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -208,7 +208,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -319,7 +319,7 @@ msgstr "Rateo"
 msgid "Accrual Basis:"
 msgstr "Rateo base:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -428,7 +428,7 @@ msgstr "Nuova nota addebito"
 msgid "Add Employee"
 msgstr "Nuovo dipendente"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Nuovo tasso di cambio"
 
@@ -464,11 +464,11 @@ msgstr "Nuovo articolo"
 msgid "Add Pricegroup"
 msgstr "Nuovo gruppo prezzi"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Nuovo ordine di acquisto"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Nuova offerta"
 
@@ -476,7 +476,7 @@ msgstr "Nuova offerta"
 msgid "Add Reporting Unit"
 msgstr "Nuova unità resoconto"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Nuova richiesta offerta"
 
@@ -488,11 +488,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Nuova fattura di vendita"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Nuovo ordine di vendita"
 
@@ -508,7 +508,7 @@ msgstr "Nuova tassazione"
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Aggiungi a elenco"
 
@@ -530,7 +530,7 @@ msgstr "Nuovo Utente"
 msgid "Add Vendor"
 msgstr "Nuovo Fornitore"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Nuova fattura acquisti"
 
@@ -542,15 +542,15 @@ msgstr "Nuovo reso a fornitore"
 msgid "Add Warehouse"
 msgstr "Nuovo magazzino"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Aggiungi linea1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Nuova linea2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Nuova linea3"
 
@@ -578,8 +578,8 @@ msgstr "Aggiunto id [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -611,7 +611,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -688,9 +688,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -793,8 +793,8 @@ msgstr "Stato approvazione"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Approva"
@@ -832,20 +832,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "Aprile"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Valore acquisito"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Sei sicuro di volre cancellare l'ordine numero"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Vuoi cancellare l'offerta numero"
 
@@ -918,16 +918,16 @@ msgstr ""
 msgid "Assets"
 msgstr "Attività"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Attività a patrimonio"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr "Attività a passività"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -958,31 +958,31 @@ msgstr ""
 msgid "Attached By"
 msgstr "Collegato da"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Collegato a"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Collegato a"
@@ -1015,7 +1015,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr "Autore: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatico"
 
@@ -1084,7 +1084,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Stato Patrimoniale"
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1211,14 +1211,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Codice BIN"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1381,7 +1381,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Non puoi cancellare l'articolo"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Non puoi cancellare l'ordine"
 
@@ -1389,19 +1389,19 @@ msgstr "Non puoi cancellare l'ordine"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Non puoi registrare scritture per esercizi chiusi!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Non puoi registrare pagamenti per esercizi chiusi!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Non puoi aggiungere scritture in un esercizio chiuso!"
 
@@ -1410,15 +1410,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Non puoi salvare la scrittura!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Non puoi salvare l'ordine!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1438,7 +1438,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Cassa"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1499,7 +1500,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1615,7 +1616,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Azienda"
 
@@ -1648,7 +1649,7 @@ msgstr "Telefono azienda"
 msgid "Company Sales Tax ID"
 msgstr "Partita IVA"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1700,7 +1701,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Conferma!"
 
@@ -1708,7 +1709,7 @@ msgstr "Conferma!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1751,8 +1752,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1763,7 +1764,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1812,7 +1813,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1824,19 +1825,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1856,8 +1857,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1921,7 +1922,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Avere"
 
@@ -1942,7 +1943,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1966,7 +1967,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Valuta"
 
@@ -1975,7 +1976,7 @@ msgstr "Valuta"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2012,7 +2013,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2042,7 +2043,7 @@ msgstr "Nome cliente"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2055,7 +2056,7 @@ msgstr "Numero cliente"
 msgid "Customer Search"
 msgstr "Cerca cliente"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Cliente mancante!"
 
@@ -2071,7 +2072,7 @@ msgstr "Cliente non sul file!"
 msgid "Customer/Vendor Accounts"
 msgstr "Conti fornitori"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2095,7 +2096,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2144,7 +2145,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2159,11 +2160,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2201,7 +2202,7 @@ msgstr "Data di pagamento"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2225,7 +2226,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr "Data di nascita"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2271,7 +2272,7 @@ msgstr "Giorni"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Dare"
 
@@ -2384,9 +2385,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2436,16 +2437,16 @@ msgstr "Consegna"
 msgid "Delivery Date"
 msgstr "Data di consegna"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2453,11 +2454,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2479,7 +2480,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2531,13 +2532,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2554,7 +2555,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2625,16 +2626,16 @@ msgstr "Sconto (%)"
 msgid "Discount:"
 msgstr "Sconto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2642,7 +2643,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2650,7 +2651,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2666,7 +2667,7 @@ msgstr "Tipo documento"
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Fatto"
 
@@ -2686,7 +2687,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Prima nota scritta"
 
@@ -2728,14 +2729,14 @@ msgstr "Scadenza"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Scadenza Fattura"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Data di Scadenza mancante!"
 
@@ -2747,8 +2748,8 @@ msgstr "Trovato duplicato utente: importando utente"
 msgid "Duplicate employee numbers"
 msgstr "Numero impiegato duplicato"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3050,11 +3051,11 @@ msgstr "Entità"
 msgid "Entity Class"
 msgstr "Classe entità"
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "Codice Entità"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "Codice verifica entità"
 
@@ -3070,7 +3071,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "Busta"
@@ -3092,7 +3093,7 @@ msgstr "Attività e passività"
 msgid "Equity (Temporary)"
 msgstr "Attività (temporanea)"
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr "Attivita a Passività"
 
@@ -3116,7 +3117,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Durata stimata"
 
@@ -3124,20 +3125,20 @@ msgstr "Durata stimata"
 msgid "Every"
 msgstr "Tutti"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Cambio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Tasso di cambio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3145,7 +3146,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3190,8 +3191,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3269,7 +3270,7 @@ msgstr "cinquanta"
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3283,17 +3284,17 @@ msgstr "Nome file"
 msgid "File Type"
 msgstr "Tipo file"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nome file"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3330,7 +3331,7 @@ msgstr ""
 msgid "First Name"
 msgstr "Nome"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3390,7 +3391,7 @@ msgstr "quattrodici"
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3422,7 +3423,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3471,7 +3472,7 @@ msgstr "Riferimento libro giornale n."
 msgid "Gain"
 msgstr "Guadagno"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Guadagno (Perdita)"
 
@@ -3479,7 +3480,7 @@ msgstr "Guadagno (Perdita)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3508,11 +3509,11 @@ msgstr "Genera"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Genera ordini"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Genera ordini acquisto"
 
@@ -3557,8 +3558,8 @@ msgid "Grand Total"
 msgstr "Totale generale"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3800,8 +3801,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr "File interni"
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Note interne"
 
@@ -3861,11 +3862,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventario registrato!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3873,8 +3874,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3892,22 +3893,22 @@ msgstr "Fattura"
 msgid "Invoice #"
 msgstr "Fattura #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Creata fattura"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Data Registrazione Fattura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Manca la data della Fattura!"
 
@@ -3923,8 +3924,8 @@ msgstr "Numero Fattura"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3933,7 +3934,7 @@ msgstr "Numero Fattura"
 msgid "Invoice Number"
 msgstr "Numero fattura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Manca il numero della Fattura!"
 
@@ -3991,7 +3992,7 @@ msgstr "Articolo"
 msgid "Item deleted!"
 msgstr "Articolo Cancellato!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Articolo non in archivio!"
 
@@ -4019,7 +4020,7 @@ msgstr "Gen"
 msgid "January"
 msgstr "Gennaio"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4060,7 +4061,7 @@ msgstr "Giu"
 msgid "June"
 msgstr "Giugno"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4124,7 +4125,7 @@ msgstr "Ultimo aggiornamento"
 msgid "Last name"
 msgstr "Cognome"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4345,11 +4346,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4426,7 +4427,7 @@ msgstr "Dirigente"
 msgid "Manager:"
 msgstr "Dirigente:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Manuale"
 
@@ -4457,9 +4458,9 @@ msgid "May"
 msgstr "Mag"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4806,15 +4807,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4828,15 +4829,15 @@ msgstr "Annotazioni"
 msgid "Notes:<br />"
 msgstr "Note:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Nulla inserito!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Non hai selezionato nulla!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nulla da trasferire!"
 
@@ -4861,7 +4862,7 @@ msgid "Null model numbers"
 msgstr "Nessun numero modelli"
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4880,7 +4881,7 @@ msgstr "Partita IVA"
 msgid "Number Format"
 msgstr "Formato Numerico"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4918,7 +4919,7 @@ msgstr "Ott"
 msgid "October"
 msgstr "Ottobre"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4933,7 +4934,7 @@ msgstr "Password precedente"
 msgid "On Hand"
 msgstr "Disponibilit&agrave;"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4988,7 +4989,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Ordine"
 
@@ -5006,12 +5007,12 @@ msgstr "Ordine #"
 msgid "Order By"
 msgstr "Ordina per"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data dell'ordine"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Manca la data dell'ordine"
 
@@ -5023,8 +5024,8 @@ msgstr "Ordini"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5032,15 +5033,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Numero fattura fornitore"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Manca il numero dell'ordine!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Ordine Cancellato!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Generazione ordine fallita!"
 
@@ -5127,8 +5128,8 @@ msgstr "Ordine acquisto #"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5144,7 +5145,7 @@ msgstr "REGISTRA"
 msgid "POST AND PRINT"
 msgstr "REGISTRA e stampa"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5152,11 +5153,11 @@ msgstr "REGISTRA e stampa"
 msgid "Packing List"
 msgstr "Lista Etichette"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Manca la data della Packing List!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Manca il codice della Packing List!"
 
@@ -5180,7 +5181,7 @@ msgstr "Importo Pagato"
 msgid "Parent"
 msgstr "Padre"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Articolo"
 
@@ -5200,8 +5201,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5222,7 +5223,7 @@ msgstr ""
 msgid "Partial"
 msgstr "Parziale"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5252,7 +5253,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Password"
 
@@ -5321,7 +5322,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Manca la data del pagamento!"
 
@@ -5333,7 +5334,7 @@ msgstr "Pagamento a [_1] giorni data fattura"
 msgid "Payment due by [_1]."
 msgstr "Pagamento a [_1]"
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5342,7 +5343,7 @@ msgstr "Pagamento a [_1]"
 msgid "Payments"
 msgstr "Pagamenti"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5350,11 +5351,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Percentuale"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5389,7 +5390,7 @@ msgstr "Telefono"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5520,8 +5521,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Registra"
@@ -5538,7 +5539,7 @@ msgstr "Data registrazione"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Salva come nuovo"
 
@@ -5633,9 +5634,9 @@ msgid "Primary Phone"
 msgstr "Telefono principale"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Stampa"
@@ -5644,11 +5645,11 @@ msgstr "Stampa"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5700,15 +5701,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5731,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr "Profitti e Perdite"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Profitto/Perdita"
 
@@ -5773,8 +5774,8 @@ msgstr "Data acquisto:"
 msgid "Purchase History"
 msgstr "Storico acquisti"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5813,7 +5814,7 @@ msgstr "Comprato"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5843,8 +5844,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5860,7 +5861,7 @@ msgstr "Offerta n."
 msgid "Quotation Date"
 msgstr "Data offerta"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Manca data offerta"
 
@@ -5868,11 +5869,11 @@ msgstr "Manca data offerta"
 msgid "Quotation Number"
 msgstr "Offerta numero"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Manca numero d'offerta"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "OFferta cancellata"
 
@@ -5887,7 +5888,7 @@ msgstr "Offerte"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5913,7 +5914,7 @@ msgstr ""
 msgid "ROP"
 msgstr "Soglia di Riordino"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5954,7 +5955,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Ricevuto"
 
@@ -5983,7 +5984,7 @@ msgstr "Crediti"
 msgid "Receive"
 msgstr "Ricevuta"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6011,7 +6012,7 @@ msgstr "Resoconto di riconciliazione"
 msgid "Reconciliation Reports"
 msgstr "Resoconti riconciliazione"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registra in"
 
@@ -6037,11 +6038,11 @@ msgstr "Transazioni ricorrenti"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Riferimento"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6078,9 +6079,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Rimanente"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Nome resoconto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Resoconto risultante"
 
@@ -6120,7 +6125,7 @@ msgstr "Resoconto inviato"
 msgid "Report Type"
 msgstr "Tipo resoconto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr "Resoconto [_1] in data [_2]"
 
@@ -6156,11 +6161,11 @@ msgstr "Resoconti"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6281,11 +6286,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6314,7 +6319,7 @@ msgstr ""
 msgid "Sales"
 msgstr "Vendite"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Fattura di vendita"
@@ -6323,8 +6328,8 @@ msgstr "Fattura di vendita"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6389,7 +6394,7 @@ msgstr "Sab"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Registra sede"
 
@@ -6442,7 +6447,7 @@ msgstr "Registra sede"
 msgid "Save New"
 msgstr "Salva nuovo"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr "Registra nuova sede"
 
@@ -6459,7 +6464,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Salva come nuovo"
@@ -6468,7 +6473,7 @@ msgstr "Salva come nuovo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6506,7 +6511,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6519,12 +6524,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6665,11 +6670,11 @@ msgstr "Scegli cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Scegli fornitore"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6689,12 +6694,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr "Scegli o inserisci un utente"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Scegli tra postscript e PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6785,7 +6790,7 @@ msgstr "Sequenze"
 msgid "Serial #"
 msgstr "Serie #"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serie N."
 
@@ -6803,11 +6808,11 @@ msgstr "Numero di serie"
 msgid "Serialnumber"
 msgstr "Numero di serie"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servizio"
 
@@ -6851,13 +6856,13 @@ msgstr "diciassette"
 msgid "Seventy"
 msgstr "settanta"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Invio"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Spedire merce"
 
@@ -6887,12 +6892,12 @@ msgstr "Spedire a:"
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Spedire a"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6909,23 +6914,23 @@ msgstr "Porto"
 msgid "Shipping"
 msgstr "Logistica"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Data spedizione"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Manca data spedizione"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr "Etichetta di spedizione"
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7001,12 +7006,12 @@ msgstr "Alcuni"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7087,11 +7092,11 @@ msgstr "Data iniziale"
 msgid "Starting Date:"
 msgstr "Data iniziale:"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7175,7 +7180,7 @@ msgstr "Invia"
 msgid "Submitted"
 msgstr "Inviato"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7238,8 +7243,8 @@ msgstr "TOTALE"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7261,7 +7266,7 @@ msgstr "Tassa"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Partita IVA"
 
@@ -7271,7 +7276,7 @@ msgstr "Partita IVA"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7303,7 +7308,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr "Codice Fiscale"
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Tasse Incluse"
@@ -7402,7 +7407,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7622,7 +7627,7 @@ msgstr "Volte"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7657,7 +7662,7 @@ msgstr ""
 msgid "To Pay"
 msgstr "Da pagare"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Per magazzino"
 
@@ -7703,7 +7708,7 @@ msgstr "Cima livello"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7724,7 +7729,7 @@ msgstr "Cima livello"
 msgid "Total"
 msgstr "Totale"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7736,6 +7741,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr "Totale pagato"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7744,7 +7753,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr "Sconto"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Scrittura"
 
@@ -7777,20 +7786,20 @@ msgstr "Tipologia scrittura"
 msgid "Transactions"
 msgstr "Scritture contabili"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7877,7 +7886,7 @@ msgstr "due"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7938,7 +7947,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7954,7 +7963,7 @@ msgstr ""
 msgid "Unknown "
 msgstr "Sconosciuto "
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7972,7 +7981,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Trovato database sconosciuto."
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8024,20 +8033,20 @@ msgstr "Non usato"
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Aggiorna"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Aggiornato"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8099,7 +8108,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8185,8 +8194,8 @@ msgstr "Varianza:"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8205,7 +8214,7 @@ msgstr "Conto fornitore"
 msgid "Vendor History"
 msgstr "Storico fornitore"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Fattura fornitore"
@@ -8221,7 +8230,7 @@ msgstr "Nome fornitore"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8244,7 +8253,7 @@ msgstr "Codice riferimento fornitore"
 msgid "Vendor Search"
 msgstr "Cerca fornitore"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Manca il fornitore!"
 
@@ -8281,7 +8290,7 @@ msgstr "Stipendi e deduzioni"
 msgid "Wages/Deductions"
 msgstr "Stipendi/Deduzioni"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8358,7 +8367,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Che tipo di Articolo &egrave; questo?"
 
@@ -8374,7 +8383,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8432,7 +8441,7 @@ msgstr ""
 msgid "Years"
 msgstr "Anni"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Si"
@@ -8451,11 +8460,11 @@ msgstr "CAP"
 msgid "Zero"
 msgstr "Zero"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "CAP"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "CAP"
 
@@ -8522,7 +8531,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "città"
 
@@ -8566,7 +8575,7 @@ msgstr "fatto"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "ci"
 

--- a/locale/po/ja.po
+++ b/locale/po/ja.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Japanese (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/ja/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -458,11 +458,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr ""
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr ""
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1383,19 +1383,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1702,7 +1703,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4011,7 +4012,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4418,7 +4419,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5015,8 +5016,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5172,7 +5173,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5636,11 +5637,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,8 +6071,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6315,8 +6320,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6460,7 +6465,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/lt.po
+++ b/locale/po/lt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Lithuanian (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/lt/)\n"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -194,9 +194,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -204,7 +204,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -315,7 +315,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -460,11 +460,11 @@ msgstr "Pridėti prekę"
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Pridėti Pirkimo užsakymą"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -484,11 +484,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Pridėti Pardavimo sąskaitą-faktūrą"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Pridėti Pardavimo užsakymą"
 
@@ -504,7 +504,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr "Pridėti Vartotoją"
 msgid "Add Vendor"
 msgstr "Pridėti Tiekėja"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -538,15 +538,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -574,8 +574,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -607,7 +607,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -684,9 +684,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -789,8 +789,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -828,20 +828,20 @@ msgstr "Bal"
 msgid "April"
 msgstr "Balandis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Ar Jus tikrai norite ištrinti uzsakimas numeris:"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -914,16 +914,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -954,31 +954,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1011,7 +1011,7 @@ msgstr "Rugpjūtis"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgid "Balance"
 msgstr "Balansas"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balanso lėntelė"
@@ -1127,8 +1127,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1140,7 +1140,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1207,14 +1207,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Dėžė"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1314,7 +1314,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1322,12 +1322,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Neįmanoma ištrinti prekės!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Neįmanoma ištrinti užsakymo!"
 
@@ -1385,19 +1385,19 @@ msgstr "Neįmanoma ištrinti užsakymo!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Neįmanoma patvirtinti sąskaitos-faktūros uždarajam periodui!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Neįmanoma patvirtinti mokėjimo uždarajam periodui!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Neįmanoma patvirtinti operacijos uždarajam periodui!"
 
@@ -1406,15 +1406,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Neįmanoma patvirtinti operacijos!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Neįmanoma išsaugoti užsakymo!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1434,7 +1434,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Kasa"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1495,7 +1496,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1611,7 +1612,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firma"
 
@@ -1644,7 +1645,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1696,7 +1697,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Patvirtinti!"
 
@@ -1704,7 +1705,7 @@ msgstr "Patvirtinti!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1747,8 +1748,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1759,7 +1760,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1808,7 +1809,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1820,19 +1821,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1852,8 +1853,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1917,7 +1918,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kreditas"
 
@@ -1938,7 +1939,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1962,7 +1963,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Val."
 
@@ -1971,7 +1972,7 @@ msgstr "Val."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2008,7 +2009,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2038,7 +2039,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2051,7 +2052,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Kliento vardo nėra!"
 
@@ -2067,7 +2068,7 @@ msgstr "Tokio kliento nėra!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2140,7 +2141,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2155,11 +2156,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2197,7 +2198,7 @@ msgstr "Mokėjimo Data"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2221,7 +2222,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2267,7 +2268,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debetas"
 
@@ -2380,9 +2381,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2432,16 +2433,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Prystatimo Data"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2449,11 +2450,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2475,7 +2476,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2527,13 +2528,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2550,7 +2551,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2621,16 +2622,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2638,7 +2639,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2646,7 +2647,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2662,7 +2663,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Įvykdyta"
 
@@ -2682,7 +2683,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2724,14 +2725,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Iki Data"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Nėra Iki Datos!"
 
@@ -2743,8 +2744,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-paštas"
 
@@ -3046,11 +3047,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3088,7 +3089,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3112,7 +3113,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3120,20 +3121,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Kurs."
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Keitimo kursas"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Mokėjimo keitimo kurso nėra!"
 
@@ -3141,7 +3142,7 @@ msgstr "Mokėjimo keitimo kurso nėra!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Keitimo kurso nėra!"
 
@@ -3186,8 +3187,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3265,7 +3266,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3279,17 +3280,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3326,7 +3327,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3386,7 +3387,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3418,7 +3419,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3467,7 +3468,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3475,7 +3476,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3504,11 +3505,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3553,8 +3554,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3796,8 +3797,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3855,11 +3856,11 @@ msgstr "Prekės kiekis turi būti lygus nuliui prieš pažymint rinkinį pasenus
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3867,8 +3868,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3886,22 +3887,22 @@ msgstr "Sąskaita-faktūra"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Sąskaitos-faktūros data"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Sąskaitos-faktūros datos nėra!"
 
@@ -3917,8 +3918,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3927,7 +3928,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Sąskaitos-faktūros numeris"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Sąskaitos-faktūra numerio nėra!"
 
@@ -3985,7 +3986,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Vienetas ištrintas!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Vieneto nėra įrašuose!"
 
@@ -4013,7 +4014,7 @@ msgstr "Sau"
 msgid "January"
 msgstr "Sausis"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4054,7 +4055,7 @@ msgstr "Bir"
 msgid "June"
 msgstr "Birželis"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4118,7 +4119,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4339,11 +4340,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Prisijungimas"
 
@@ -4420,7 +4421,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4451,9 +4452,9 @@ msgid "May"
 msgstr "Geg"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4800,15 +4801,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4822,15 +4823,15 @@ msgstr "Pastaba"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nieko neišrinkta!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4855,7 +4856,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4874,7 +4875,7 @@ msgstr "Numeris"
 msgid "Number Format"
 msgstr "Skaičiaus formatas"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4912,7 +4913,7 @@ msgstr "Spa"
 msgid "October"
 msgstr "Spalis"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4927,7 +4928,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Likutis"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4982,7 +4983,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Užsakymas"
 
@@ -5000,12 +5001,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Užsakymo data"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Užsakymo datos nėra!"
 
@@ -5017,8 +5018,8 @@ msgstr "Užsakymo įrašas"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5026,15 +5027,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Užsakymo numeris"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Užsakymo numerio nėra!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Užsakymai ištrinti!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5121,8 +5122,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5138,7 +5139,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5146,11 +5147,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Įpakavimo sąrašas"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Įpakavimo sąrašo numerio nėra!"
 
@@ -5174,7 +5175,7 @@ msgstr "Apmokėta"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Prekė"
 
@@ -5194,8 +5195,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5216,7 +5217,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5246,7 +5247,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Slaptažodis"
 
@@ -5315,7 +5316,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Mokėjimo datos nėra"
 
@@ -5327,7 +5328,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5336,7 +5337,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Mokėjimai"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5344,11 +5345,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5383,7 +5384,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5514,8 +5515,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Patvirtinti"
@@ -5532,7 +5533,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Patvirtinti kaip naują"
 
@@ -5627,9 +5628,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Spausdinti"
@@ -5638,11 +5639,11 @@ msgstr "Spausdinti"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5694,15 +5695,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5724,7 +5725,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5767,8 +5768,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5807,7 +5808,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5837,8 +5838,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5854,7 +5855,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5862,11 +5863,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5881,7 +5882,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5907,7 +5908,7 @@ msgstr ""
 msgid "ROP"
 msgstr "ROP"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5948,7 +5949,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Gaut"
 
@@ -5977,7 +5978,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6005,7 +6006,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Įrašyti į"
 
@@ -6031,11 +6032,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Nuorodos"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6072,9 +6073,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Likutis"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6102,7 +6107,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6114,7 +6119,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6150,11 +6155,11 @@ msgstr "Ataskaitos"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6275,11 +6280,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6308,7 +6313,7 @@ msgstr ""
 msgid "Sales"
 msgstr "Pardavimai"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Pardavimo SF"
@@ -6317,8 +6322,8 @@ msgstr "Pardavimo SF"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6383,7 +6388,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6428,7 +6433,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6436,7 +6441,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6453,7 +6458,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Išsaugoti kaip naują"
@@ -6462,7 +6467,7 @@ msgstr "Išsaugoti kaip naują"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6500,7 +6505,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6513,12 +6518,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6659,11 +6664,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6683,12 +6688,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Išrinkite postscript arba PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6779,7 +6784,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6797,11 +6802,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Paslauga"
 
@@ -6845,13 +6850,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Pristatymas"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6881,12 +6886,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Pristatyti į"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6903,23 +6908,23 @@ msgstr "Pristatyti per"
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6995,12 +7000,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7081,11 +7086,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7169,7 +7174,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7232,8 +7237,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7255,7 +7260,7 @@ msgstr "Mokėstis"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7265,7 +7270,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7289,7 +7294,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7297,7 +7302,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "su mokesčiais"
@@ -7396,7 +7401,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7616,7 +7621,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7651,7 +7656,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7697,7 +7702,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7718,7 +7723,7 @@ msgstr ""
 msgid "Total"
 msgstr "Iš viso"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7730,6 +7735,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7738,7 +7747,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7771,20 +7780,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7871,7 +7880,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7932,7 +7941,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7948,7 +7957,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7966,7 +7975,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8018,20 +8027,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Atnaujinti"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Atnaujinta"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8093,7 +8102,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8179,8 +8188,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8199,7 +8208,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8215,7 +8224,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8238,7 +8247,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Tiekėjo Vardo nėra!"
 
@@ -8275,7 +8284,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8352,7 +8361,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Koks šio dalyko tipas?"
 
@@ -8368,7 +8377,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8426,7 +8435,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Taip"
@@ -8445,11 +8454,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8516,7 +8525,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8560,7 +8569,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "kk"
 

--- a/locale/po/lv.po
+++ b/locale/po/lv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Latvian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "lv/)\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -193,9 +193,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -203,7 +203,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Pievienot darbinieku"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Pievienot valūtas maiņas kursu"
 
@@ -459,11 +459,11 @@ msgstr "Pievienot daļu"
 msgid "Add Pricegroup"
 msgstr "Pieviento cenu grupu"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Pievienot pirkuma orderi"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Pievienot tāmi"
 
@@ -471,7 +471,7 @@ msgstr "Pievienot tāmi"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Pievienot tāmes pieprasījumu"
 
@@ -483,11 +483,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Pievienot SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Pievienot preču rēķinu"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Pievienot preču orderi"
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr "Pievienot lietotāju"
 msgid "Add Vendor"
 msgstr "Pievienot pārdevēju"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Pievienot pārdevēja rēķinu"
 
@@ -537,15 +537,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Pievienot noliktavu"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -573,8 +573,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -683,9 +683,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -788,8 +788,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "Aprīlī"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Vai jūs patiešām vēlaties dzēst ordera numuru"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Vai jūs patiešām vēlaties dzēst tāmes numuru"
 
@@ -913,16 +913,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -953,31 +953,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr "Augustā"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgid "Balance"
 msgstr "Bilance"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilances pārskats"
@@ -1126,8 +1126,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1206,14 +1206,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Bin"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1376,7 +1376,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Vienību nevar izdzēst!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Orderi nevar izdzēst!"
 
@@ -1384,19 +1384,19 @@ msgstr "Orderi nevar izdzēst!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Tāmi nevar izdzēst!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Nevar iegrāmatot rēķinu par slēgtu periodu!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Nevar iegrāmatot maksājumu par slēgtu periodu!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Nevar iegrāmatot transakciju par slēgtu periodu!"
 
@@ -1405,15 +1405,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Nevar iegrāmatot transakciju!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Maksājuma uzdevumu nevar saglabāt!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Nevar saglabāt tāmi"
 
@@ -1433,7 +1433,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Nauda"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1494,7 +1495,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1610,7 +1611,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Uzņēmums"
 
@@ -1643,7 +1644,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1695,7 +1696,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Apstiprināt!"
 
@@ -1703,7 +1704,7 @@ msgstr "Apstiprināt!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1746,8 +1747,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1758,7 +1759,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1807,7 +1808,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Izmaksas"
 
@@ -1819,19 +1820,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Nevarēja saglabāt"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Nevarēja pārsūtīt krājumu"
 
@@ -1851,8 +1852,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1916,7 +1917,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredīts"
 
@@ -1937,7 +1938,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1961,7 +1962,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Val."
 
@@ -1970,7 +1971,7 @@ msgstr "Val."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2007,7 +2008,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2037,7 +2038,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2050,7 +2051,7 @@ msgstr "Klienta numurs"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Nav norādīts klients!"
 
@@ -2066,7 +2067,7 @@ msgstr "Nav tāda klienta!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2139,7 +2140,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2154,11 +2155,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2196,7 +2197,7 @@ msgstr "Maksājuma datums"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Saņemšanas datums"
 
@@ -2220,7 +2221,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Nav norādīts saņemšanas datums"
 
@@ -2266,7 +2267,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debets"
 
@@ -2379,9 +2380,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2431,16 +2432,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Piegādes datums"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2448,11 +2449,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2474,7 +2475,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2526,13 +2527,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2549,7 +2550,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2620,16 +2621,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2637,7 +2638,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2645,7 +2646,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2661,7 +2662,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Izdarīts"
 
@@ -2681,7 +2682,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2723,14 +2724,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Apmaksas termiņš"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Nav norādīts apmaksas termiņš!"
 
@@ -2742,8 +2743,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-pasts"
 
@@ -3045,11 +3046,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3065,7 +3066,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3087,7 +3088,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3111,7 +3112,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3119,20 +3120,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Kurss"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Valūtas maiņas kurss"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Nav norādīts valūtas maiņas kurss maksājumā!"
 
@@ -3140,7 +3141,7 @@ msgstr "Nav norādīts valūtas maiņas kurss maksājumā!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Nav norādīts valūtas maiņas kurss!"
 
@@ -3185,8 +3186,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3264,7 +3265,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3278,17 +3279,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3325,7 +3326,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3385,7 +3386,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3417,7 +3418,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3466,7 +3467,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3474,7 +3475,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3503,11 +3504,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3552,8 +3553,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupa"
 
@@ -3795,8 +3796,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Iekšējās piezīmes"
 
@@ -3854,11 +3855,11 @@ msgstr "Krājuma daudzumam jābūt nullei pirms jūs varat atcelt šo komplektā
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Krājums saglabāts"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Krājums pārsūtīts"
 
@@ -3866,8 +3867,8 @@ msgstr "Krājums pārsūtīts"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3885,22 +3886,22 @@ msgstr "Rēķins"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Rēķina datums"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Nav norādīts rēķina datums!"
 
@@ -3916,8 +3917,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3926,7 +3927,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Rēķina numurs"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Nepareizs rēķina numurs"
 
@@ -3984,7 +3985,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Vienība izdzēsts!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Nav tādas vienības!"
 
@@ -4012,7 +4013,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Janvārī"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4053,7 +4054,7 @@ msgstr "Jūn"
 msgid "June"
 msgstr "Jūnijā"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4117,7 +4118,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4338,11 +4339,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Pieteikties"
 
@@ -4419,7 +4420,7 @@ msgstr "Vadītājs"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4450,9 +4451,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memorands"
@@ -4799,15 +4800,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4821,15 +4822,15 @@ msgstr "Piezīmes"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Nekas nav ievadīts"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nekas nav iezīmēts!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nav nekā pārsūtīšanai"
 
@@ -4854,7 +4855,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4873,7 +4874,7 @@ msgstr "Numurs"
 msgid "Number Format"
 msgstr "Skaitļa formāts"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4911,7 +4912,7 @@ msgstr "Okt"
 msgid "October"
 msgstr "Oktobrī"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4926,7 +4927,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Pieejams"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4981,7 +4982,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Orderis"
 
@@ -4999,12 +5000,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ordera datums"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Nav norādīts ordera datums!"
 
@@ -5016,8 +5017,8 @@ msgstr "Ordera ieraksts"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5025,15 +5026,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Ordera Nr."
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Nav norādīts ordera numurs!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Orderis izdzēsts"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5120,8 +5121,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5137,7 +5138,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5145,11 +5146,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Iesaiņojumu saraksts"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Nav norādīts iesaiņojumu datums!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Nav norādīts iesaiņojumu numurs!"
 
@@ -5173,7 +5174,7 @@ msgstr "Apmaksāts"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Prece"
 
@@ -5193,8 +5194,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5215,7 +5216,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5245,7 +5246,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Parole"
 
@@ -5314,7 +5315,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Nav norādīts maksājuma datums"
 
@@ -5326,7 +5327,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5335,7 +5336,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Maksājumi"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5343,11 +5344,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5382,7 +5383,7 @@ msgstr "Tel."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5513,8 +5514,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Iegrāmatot"
@@ -5531,7 +5532,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Iegrāmatot kā jaunu"
 
@@ -5626,9 +5627,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Drukāt"
@@ -5637,11 +5638,11 @@ msgstr "Drukāt"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5693,15 +5694,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5723,7 +5724,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5766,8 +5767,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5806,7 +5807,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5836,8 +5837,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5853,7 +5854,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Tāmes datums"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Nav norādīts tāmes datums"
 
@@ -5861,11 +5862,11 @@ msgstr "Nav norādīts tāmes datums"
 msgid "Quotation Number"
 msgstr "Tāmes numurs"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Nav norādīts tāmes numurs"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Tāme izdzēsta"
 
@@ -5880,7 +5881,7 @@ msgstr "Tāmes"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5906,7 +5907,7 @@ msgstr "Tāmes pieprasījumu"
 msgid "ROP"
 msgstr "Pasūtīšanas limits"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5947,7 +5948,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Saņemts"
 
@@ -5976,7 +5977,7 @@ msgstr "Ienākošie maksājumi"
 msgid "Receive"
 msgstr "Saņemt"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Saņemt preces"
 
@@ -6004,7 +6005,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Ierakstīt"
 
@@ -6030,11 +6031,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Norāde"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6071,9 +6072,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Atlikums"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6101,7 +6106,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6113,7 +6118,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6149,11 +6154,11 @@ msgstr "Atskaites"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6274,11 +6279,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6307,7 +6312,7 @@ msgstr "Pārdošana"
 msgid "Sales"
 msgstr "Pārdošanas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Pārdošanas rēķins"
@@ -6316,8 +6321,8 @@ msgstr "Pārdošanas rēķins"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6382,7 +6387,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6427,7 +6432,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6435,7 +6440,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6452,7 +6457,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Saglabāt kā jaunu"
@@ -6461,7 +6466,7 @@ msgstr "Saglabāt kā jaunu"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6499,7 +6504,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6512,12 +6517,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6658,11 +6663,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6682,12 +6687,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Izvēlēties postscript vai PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6778,7 +6783,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Seriālais Nr."
 
@@ -6796,11 +6801,11 @@ msgstr "Seriālais numurs"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Pakalpojums"
 
@@ -6844,13 +6849,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Piegādāt"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Piegādāt preces"
 
@@ -6880,12 +6885,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Piegādes adrese"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6902,23 +6907,23 @@ msgstr "Piegādāt caur"
 msgid "Shipping"
 msgstr "Piegāde"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Nosūtīšanas datums"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Nav norādīts nosūtīšanas datums"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6994,12 +6999,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7080,11 +7085,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7168,7 +7173,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7231,8 +7236,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7254,7 +7259,7 @@ msgstr "Nodokļi"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7264,7 +7269,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7288,7 +7293,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7296,7 +7301,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Kopā ar nodokļiem"
@@ -7395,7 +7400,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7615,7 +7620,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7650,7 +7655,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7696,7 +7701,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7717,7 +7722,7 @@ msgstr ""
 msgid "Total"
 msgstr "Pavisam Kopā"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7729,6 +7734,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7737,7 +7746,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr "Vairumtirgotāja atlaide"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7770,20 +7779,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Transakcijas"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Pārsūtīšana"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Krājuma pārsūtīšana"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Pārsūtīt uz"
 
@@ -7870,7 +7879,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7931,7 +7940,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7947,7 +7956,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7965,7 +7974,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8017,20 +8026,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Atjaunināt"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Atjaunināts"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8092,7 +8101,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8178,8 +8187,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8198,7 +8207,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Pārdevēja vēsture"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Pārdevēja rēķins"
@@ -8214,7 +8223,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8237,7 +8246,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Pārdevējs nav norādīts!"
 
@@ -8274,7 +8283,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8351,7 +8360,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Kāda veida vienība tā ir?"
 
@@ -8367,7 +8376,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8425,7 +8434,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Jā"
@@ -8444,11 +8453,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8515,7 +8524,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8559,7 +8568,7 @@ msgstr "izdarīts"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "gb"
 

--- a/locale/po/ms_MY.po
+++ b/locale/po/ms_MY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Malay (Malaysia) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/ms_MY/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr "Akses Dinafikan"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Tambah Pekerja"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Tambah kadar pertukaran"
 
@@ -458,11 +458,11 @@ msgstr "Tambah Bahagian"
 msgid "Add Pricegroup"
 msgstr "Tambah Kumpulan Harga"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Tambah Pesanan Belian"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Tambah Sebut Harga"
 
@@ -470,7 +470,7 @@ msgstr "Tambah Sebut Harga"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Tambah Permintaan untuk Sebut Harga"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Tambah SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Tambah Jualan Invois"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Tambah Pesanan Jualan"
 
@@ -502,7 +502,7 @@ msgstr "Tambah Borang Cukai"
 msgid "Add Timecard"
 msgstr "Tambah Kad Masa "
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Tambah pengguna"
 msgid "Add Vendor"
 msgstr "Tambah Pembekal"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Penambahan Invois Pembekal"
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Tambah Gudang"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Tambah barisan1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Tambah barisan2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Tambah barisan3"
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Basis Yang Diubah"
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Diluluskan"
@@ -826,20 +826,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Nilai Diperlukan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Dapatan Nilai Yang Tinggal"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Adakah anda pasti mahu memadam nombor pesanan"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Adakah anda pasti ingin memadam Nombor Sebut Harga"
 
@@ -912,16 +912,16 @@ msgstr "Tanda Aset"
 msgid "Assets"
 msgstr "Aset"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Lampiran"
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Dilampirkan Kepada"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Dilampirkan Untuk Menaip"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Dilampirkan dan Fail Berkaitan"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Dilampirkan pada"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Dilampirkan oleh"
@@ -1009,7 +1009,7 @@ msgstr "Ogos"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatik"
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "Baki"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Helaian Kira-kira"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Asas"
 
@@ -1138,7 +1138,7 @@ msgstr "Kumpulan"
 msgid "Batch Class"
 msgstr "Kelas Kumpulan"
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr "Kod kawalan batch"
 
@@ -1158,7 +1158,7 @@ msgstr "ID Kumpulan"
 msgid "Batch ID Missing"
 msgstr "Kumpulan ID hilang"
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr "Nama Batch"
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Tong"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Kira Cukai"
 
@@ -1320,12 +1320,12 @@ msgstr "Kira Cukai"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Tidak boleh membatalkan invois yang telah dibatalkan"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr "Perkhidmatan tidak boleh dihasilkan; Akaun pendapatan tidak wujud!"
 msgid "Cannot delete item!"
 msgstr "Barang tidak boleh dipadam"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Tidak boleh memadam pesanan"
 
@@ -1383,19 +1383,19 @@ msgstr "Tidak boleh memadam pesanan"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Tidak boleh memadam sebut harga!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Tidak boleh simpan invois untuk jangka masa yang terdekat!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Tidak boleh simpan bayaran untuk jangka masa yang terdekat!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Tidak boleh menyimpan transaksi untuk tempoh tertutup"
 
@@ -1406,15 +1406,15 @@ msgstr ""
 "Tidak boleh menyimpan transaksi dengan kemasukan debit dan kredit untuk akaun "
 "yang sama"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Transaksi gagal dihantar!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Tidak Boleh Menyimpan Pesanan"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Tidah Boleh Menyimpan Sebut Harga!"
 
@@ -1434,7 +1434,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Tunai"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1495,7 +1496,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1611,7 +1612,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Syarikat"
 
@@ -1644,7 +1645,7 @@ msgstr "Nombor Telefon Syarikat"
 msgid "Company Sales Tax ID"
 msgstr "ID Cukai Jualan Syarikat"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1696,7 +1697,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Sah!"
 
@@ -1704,7 +1705,7 @@ msgstr "Sah!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1747,8 +1748,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1759,7 +1760,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1808,7 +1809,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "kos"
 
@@ -1820,19 +1821,19 @@ msgstr "Kos Barangan Yang Dijual"
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Data tidak boleh disimpan. Sila cuba lagi"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Tidak boleh disimpan"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Tidak dapat memindahkan Inventori!"
 
@@ -1852,8 +1853,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1917,7 +1918,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredit"
 
@@ -1938,7 +1939,7 @@ msgstr "Akaun Kredit"
 msgid "Credit Invoice"
 msgstr "Invois kredit"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1962,7 +1963,7 @@ msgstr "Kredit"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1971,7 +1972,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2008,7 +2009,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2038,7 +2039,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2051,7 +2052,7 @@ msgstr "Nombor Pelanggan"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Pelanggan hilang"
 
@@ -2067,7 +2068,7 @@ msgstr "Pelangan tiada dalam fail!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Data gagal disimpan. Sila cuba lagi"
 
@@ -2140,7 +2141,7 @@ msgstr "Pengkalan data tidak wujud"
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2155,11 +2156,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2197,7 +2198,7 @@ msgstr "Tarikh Dibayar"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Tarikh diterima"
 
@@ -2221,7 +2222,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Tarikh diterima hilang"
 
@@ -2267,7 +2268,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debit"
 
@@ -2380,9 +2381,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2432,16 +2433,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Tarikh Penghantaran"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2449,11 +2450,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2475,7 +2476,7 @@ msgstr "Penyusutan"
 msgid "Depreciate Through"
 msgstr "Melalui Penyusutan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Susut Nilai"
@@ -2527,13 +2528,13 @@ msgstr "Permulaan Susut Nilai"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2550,7 +2551,7 @@ msgstr "Permulaan Susut Nilai"
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2621,16 +2622,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Pembuangan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Tarikh Pembuangan"
 
@@ -2638,7 +2639,7 @@ msgstr "Tarikh Pembuangan"
 msgid "Disposal Method"
 msgstr "Cara Pembuangan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2646,7 +2647,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr "Kesalahan bahagian 0"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2662,7 +2663,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr "Tidak mengetahui apa yang perlu dibuat dengan backup "
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Selesai"
 
@@ -2682,7 +2683,7 @@ msgstr ""
 msgid "Dr."
 msgstr "Dr."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Draf yang tercatat"
 
@@ -2724,14 +2725,14 @@ msgstr "Tarikh Akhir"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Tarikh Akhir"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Tarikh akhir hilang!"
 
@@ -2743,8 +2744,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr "Salinan nombor pekerja"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3046,11 +3047,11 @@ msgstr "Entiti"
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "Kod Entiti"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "Kod Kawalan entiti"
 
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr "Masukkan ID"
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3088,7 +3089,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3112,7 +3113,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Ralat: Tidak boleh termasuk ringkasan akaun selain menu dropdown"
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3120,20 +3121,20 @@ msgstr ""
 msgid "Every"
 msgstr "Setiap"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Tukar"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Kadar Pertukaran"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Kadar pertukaran pembayaran hilang!"
 
@@ -3141,7 +3142,7 @@ msgstr "Kadar pertukaran pembayaran hilang!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Kadar pertukaran hilang!"
 
@@ -3186,8 +3187,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3265,7 +3266,7 @@ msgstr ""
 msgid "File"
 msgstr "Fail"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Fail Masukkan"
 
@@ -3279,17 +3280,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Nama Fail"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Jenis Fail"
@@ -3326,7 +3327,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3386,7 +3387,7 @@ msgstr ""
 msgid "Fri"
 msgstr "Jumaat"
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3418,7 +3419,7 @@ msgstr "Tarikh Mula"
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Daripada gudang"
 
@@ -3467,7 +3468,7 @@ msgstr "Nombor rujukan GL"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Dapat (Kerugian)"
 
@@ -3475,7 +3476,7 @@ msgstr "Dapat (Kerugian)"
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3504,11 +3505,11 @@ msgstr "Hasilkan"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Menjana pesanan"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Menjana Pesanan Pembelian"
 
@@ -3553,8 +3554,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Kumpulan"
 
@@ -3796,8 +3797,8 @@ msgstr "Kesalahan Dalaman Pangkalan Data"
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Nota Dalaman"
 
@@ -3855,11 +3856,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventori disimpan"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventori di hantar"
 
@@ -3867,8 +3868,8 @@ msgstr "Inventori di hantar"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3886,22 +3887,22 @@ msgstr "Invois"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Tarikh Invois"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Tarikh Invois hilang!"
 
@@ -3917,8 +3918,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3927,7 +3928,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Nombor Invois"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3985,7 +3986,7 @@ msgstr "Barang"
 msgid "Item deleted!"
 msgstr "Barang dipadam"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Item tiada di dalam fail!"
 
@@ -4013,7 +4014,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Januari"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4054,7 +4055,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Jun"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4118,7 +4119,7 @@ msgstr "Kemaskini Terakhir"
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Utama"
 
@@ -4339,11 +4340,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Daftar masuk"
 
@@ -4420,7 +4421,7 @@ msgstr "Pengurus"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Manual"
 
@@ -4451,9 +4452,9 @@ msgid "May"
 msgstr "Mei"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4802,15 +4803,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4824,15 +4825,15 @@ msgstr "Nota"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Tiada apa-apa yang dimasukan"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Anda tidak memilih apa-apa!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "TIada apa-apa untuk dihantar"
 
@@ -4857,7 +4858,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4876,7 +4877,7 @@ msgstr "Nombor"
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4914,7 +4915,7 @@ msgstr "Okt"
 msgid "October"
 msgstr "Oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr "Teruskan"
 
@@ -4929,7 +4930,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Dalam Tangan"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "Ditahan"
@@ -4984,7 +4985,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Pesanan"
 
@@ -5002,12 +5003,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tarikh Pesanan"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Tarikh Pesanan Hilang!"
 
@@ -5019,8 +5020,8 @@ msgstr "Entri pesanan"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5028,15 +5029,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Nombor Pesanan"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Nombor Pesanan Hilang!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Pesanan dipadam"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Penjanaan Pesanan gagal!"
 
@@ -5123,8 +5124,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5140,7 +5141,7 @@ msgstr "SIMPAN"
 msgid "POST AND PRINT"
 msgstr "SIMPAN dan Cetak"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5148,11 +5149,11 @@ msgstr "SIMPAN dan Cetak"
 msgid "Packing List"
 msgstr "Senarai Bungkusan"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5176,7 +5177,7 @@ msgstr "Dibaya"
 msgid "Parent"
 msgstr "Waris"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Bahagian"
 
@@ -5196,8 +5197,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5218,7 +5219,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5248,7 +5249,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5317,7 +5318,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Tarikh pembayaran hilang!"
 
@@ -5329,7 +5330,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5338,7 +5339,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Bayaran"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 "Bayaran berkaitan dengan invois yang dibatalkan mungkin perlu diterbalikkan"
@@ -5347,11 +5348,11 @@ msgstr ""
 msgid "Percent"
 msgstr "Peratus"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Peratusan Pembuangan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Peratusan Yang Tinggal"
 
@@ -5386,7 +5387,7 @@ msgstr ""
 msgid "Physical"
 msgstr "Fizikal"
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5517,8 +5518,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Simpan"
@@ -5535,7 +5536,7 @@ msgstr "Tarikh disimpan"
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Simpan Sebagai Baru"
 
@@ -5630,9 +5631,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Cetak"
@@ -5641,11 +5642,11 @@ msgstr "Cetak"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Cetak dan Simpan"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Cetak dan Simpan sebagai yang baru"
 
@@ -5697,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Teruskan"
 
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Keuntungan/Kerugian"
 
@@ -5770,8 +5771,8 @@ msgstr "Tarikh Pembelian"
 msgid "Purchase History"
 msgstr "Rekod Pembelian"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5810,7 +5811,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5840,8 +5841,8 @@ msgid "Quarter"
 msgstr "Suku"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5857,7 +5858,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Tarikh Sebut Harga"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Tarikh Sebut Harga Hilang!"
 
@@ -5865,11 +5866,11 @@ msgstr "Tarikh Sebut Harga Hilang!"
 msgid "Quotation Number"
 msgstr "Bilangan Sebut Harga"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Nombor sebut harga hilang!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Sebut Harga dipadam!"
 
@@ -5884,7 +5885,7 @@ msgstr "Sebutan Harga"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5910,7 +5911,7 @@ msgstr "RFQs"
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5951,7 +5952,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr "Menbina semula/menaik taraf"
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Terima"
 
@@ -5980,7 +5981,7 @@ msgstr ""
 msgid "Receive"
 msgstr "Diterima"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Penerimaan barang dagangan"
 
@@ -6008,7 +6009,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr "Laporan Pendamaian"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Rekod Kemasukan"
 
@@ -6034,11 +6035,11 @@ msgstr "Perulangan Input Transaksi"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Rujukan"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6075,9 +6076,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Baki"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Hasil Laporan"
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,11 +6158,11 @@ msgstr "Laporan"
 msgid "Reposting Not Allowed"
 msgstr "Ulangan pesanan tidak dibenarkan"
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6278,11 +6283,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6311,7 +6316,7 @@ msgstr ""
 msgid "Sales"
 msgstr "Jualan"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Jualan Invois"
@@ -6320,8 +6325,8 @@ msgstr "Jualan Invois"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "jualan invois/nombor urus niaga AR"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6386,7 +6391,7 @@ msgstr "Sabtu"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6431,7 +6436,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6456,7 +6461,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Simpan sebagai baru"
@@ -6465,7 +6470,7 @@ msgstr "Simpan sebagai baru"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6503,7 +6508,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Jadual"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Sudah Dijadualkan"
 
@@ -6662,11 +6667,11 @@ msgstr "Pilih Pelanggan"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Pilih Pembekal"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Pilih Mesin Pencetak!"
 
@@ -6686,12 +6691,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Pilih postscript atau PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Pilih txt, postscript atau PDF!"
 
@@ -6782,7 +6787,7 @@ msgstr "Turutan"
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "No. Siri"
 
@@ -6800,11 +6805,11 @@ msgstr "Nombor Siri"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Servis"
 
@@ -6848,13 +6853,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Hantar"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Barang dagangan kapal"
 
@@ -6884,12 +6889,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr "Hantar Melalui"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Hantar kepada"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6906,23 +6911,23 @@ msgstr "Penghantaran melalui"
 msgid "Shipping"
 msgstr "Penghantaran"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Tarikh penghantaran"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Tarikh penghantaran hilang!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6998,12 +7003,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7084,11 +7089,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Negeri"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7172,7 +7177,7 @@ msgstr ""
 msgid "Submitted"
 msgstr "Dihantar"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7235,8 +7240,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Tanda"
 
@@ -7258,7 +7263,7 @@ msgstr "Cukai"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "Kod Cukai"
 
@@ -7268,7 +7273,7 @@ msgstr "Kod Cukai"
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Bentuk cukai digunakan"
 
@@ -7292,7 +7297,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr "Borang cukai"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Disertakan dengan Cukai"
@@ -7399,7 +7404,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "templat Disimppan!"
 
@@ -7619,7 +7624,7 @@ msgstr "Masa"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7654,7 +7659,7 @@ msgstr "Kepada tarikh"
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Ke gudang"
 
@@ -7700,7 +7705,7 @@ msgstr "Tahap Tertinggi"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7721,7 +7726,7 @@ msgstr "Tahap Tertinggi"
 msgid "Total"
 msgstr "Jumlah"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7733,6 +7738,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr "Jumlah Dibayar"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7741,7 +7750,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr "Diskaun Perniagaan "
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Transaksi"
 
@@ -7774,20 +7783,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Hantar"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Hantar Inventori"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Hantar daripada"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Hantar ke"
 
@@ -7874,7 +7883,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7935,7 +7944,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7951,7 +7960,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7969,7 +7978,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr "Pangkalan data tidak dikenali dijumpai"
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8021,20 +8030,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Terbaru"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Dikemaskini"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8096,7 +8105,7 @@ msgstr "Menggunakan Bayaran Lebih AR"
 msgid "Use Overpayment"
 msgstr "Menggunakan Bayaran Lebih"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8182,8 +8191,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8202,7 +8211,7 @@ msgstr "Akaun Pembekal"
 msgid "Vendor History"
 msgstr "Rekod Pembekal"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Pembekal Senarai Bekalan"
@@ -8218,7 +8227,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8241,7 +8250,7 @@ msgstr "Nombor Rujukan Pembekal"
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Pembekal hilang!"
 
@@ -8278,7 +8287,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr "Gaji/Potongan"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8355,7 +8364,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Apakah jenis item ini?"
 
@@ -8371,7 +8380,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8429,7 +8438,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ya"
@@ -8448,11 +8457,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Kod Pos"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8519,7 +8528,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "Bandar"
 
@@ -8563,7 +8572,7 @@ msgstr "selesai"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/nb.po
+++ b/locale/po/nb.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Håvard Sørli <havard@sorli.no>, 2018,2021\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -193,7 +193,7 @@ msgstr "Skrinlagt"
 msgid "Access Denied"
 msgstr "Nektet Adgang"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -201,9 +201,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -211,7 +211,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -322,7 +322,7 @@ msgstr "Kostnad"
 msgid "Accrual Basis:"
 msgstr "Kostnadsbase"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Akkumulert Nedskrivning"
 
@@ -431,7 +431,7 @@ msgstr "Ny Regning"
 msgid "Add Employee"
 msgstr "Ny ansatt"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Ny vekslingskurs"
 
@@ -467,11 +467,11 @@ msgstr "Ny vare"
 msgid "Add Pricegroup"
 msgstr "Ny prisgruppe"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Ny innkjøpsordre"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Nytt tilbud"
 
@@ -479,7 +479,7 @@ msgstr "Nytt tilbud"
 msgid "Add Reporting Unit"
 msgstr "Ny rapport enhet"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Ny tilbudsforespørsel"
 
@@ -491,11 +491,11 @@ msgstr "Legg til retur"
 msgid "Add SIC"
 msgstr "Ny SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Ny Utgående Faktura"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Ny salgsordre"
 
@@ -511,7 +511,7 @@ msgstr "Legg til MVA skjema"
 msgid "Add Timecard"
 msgstr "Legg til timekort"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Legg til i liste"
 
@@ -533,7 +533,7 @@ msgstr "Ny bruker"
 msgid "Add Vendor"
 msgstr "Ny leverandør"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Ny Inngående Faktura"
 
@@ -545,15 +545,15 @@ msgstr "Ny leverandør retur"
 msgid "Add Warehouse"
 msgstr "Nytt lager"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Legg til linje1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Legg til linje2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Legg til linje3"
 
@@ -581,8 +581,8 @@ msgstr "Lagt til nr [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -614,7 +614,7 @@ msgstr "Just"
 msgid "Adjusted"
 msgstr "justert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Juster grunnlag"
 
@@ -691,9 +691,9 @@ msgstr "Tillat Innlegg"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -802,8 +802,8 @@ msgstr "Godkjennings  status"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Godkjenne"
@@ -841,20 +841,20 @@ msgstr "apr"
 msgid "April"
 msgstr "april"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Ervervet verdi"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Ervervet verdi gjennstår"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Er du sikker på at du vil fjerne ordrenummer"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Er du sikker på at du vil fjerne tilbudsnummer"
 
@@ -927,16 +927,16 @@ msgstr "Eiendel Merkelapp"
 msgid "Assets"
 msgstr "Eiendel"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Eiendel til Egenkapital"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr "Eiendel til Gjeld"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Tillegg"
@@ -967,31 +967,31 @@ msgstr "Vedlegg til"
 msgid "Attached By"
 msgstr "Tillagt av"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Koblett til"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Festet til type"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Festet og linket filer"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Festet til"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Festet av"
@@ -1024,7 +1024,7 @@ msgstr "august"
 msgid "Author: [_1]"
 msgstr "Revisor: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatisk"
 
@@ -1093,7 +1093,7 @@ msgid "Balance"
 msgstr "Balanse"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balanse"
@@ -1140,8 +1140,8 @@ msgstr "Basis valuta"
 msgid "Base system"
 msgstr "Grunn systemet"
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basis"
 
@@ -1153,7 +1153,7 @@ msgstr "Gruppe"
 msgid "Batch Class"
 msgstr "Gruppe Klasse"
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr "Gruppe kontrollkode"
 
@@ -1173,7 +1173,7 @@ msgstr "Gruppe ID"
 msgid "Batch ID Missing"
 msgstr "Gruppe ID mangler"
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr "Gruppe navn"
 
@@ -1220,14 +1220,14 @@ msgstr "Milliard "
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Boks"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1327,7 +1327,7 @@ msgstr "Varekostnad Rapport"
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Kalkuler MVA/Avgifter"
 
@@ -1335,12 +1335,12 @@ msgstr "Kalkuler MVA/Avgifter"
 msgid "Can't post credits and debits on one line."
 msgstr "Kan ikke spesifisere både debet og kreditt på en linje"
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Kan ikke annullere en annullert Faktura"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1390,7 +1390,7 @@ msgstr "Kan ikke lage Tjenester; Inntekts konto eksisterer ikke!"
 msgid "Cannot delete item!"
 msgstr "Kan ikke slette enkeltdel!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Kan ikke slette ordre!"
 
@@ -1398,19 +1398,19 @@ msgstr "Kan ikke slette ordre!"
 msgid "Cannot delete posted transaction"
 msgstr "Kan ikke slette bokførte Posteringer"
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Kan ikke slette tilbud!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Kan ikke bokføre faktura for en avsluttet periode!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Kan ikke bokføre betaling for en avsluttet periode!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Kan ikke bokføre Postering for en avsluttet periode!"
 
@@ -1419,15 +1419,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "Kan ikke bokføre Postering med debet og kredit på samme konto!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Kan ikke bokføre Postering!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Kan ikke lagre ordre!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Kan ikke lagre tilbud!"
 
@@ -1447,7 +1447,8 @@ msgstr "Kort ID"
 msgid "Cash"
 msgstr "Kontant"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Kontant konto"
 
@@ -1508,7 +1509,7 @@ msgid "Chord"
 msgstr "Streng"
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1624,7 +1625,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firma"
 
@@ -1657,7 +1658,7 @@ msgstr "Firmatelefon"
 msgid "Company Sales Tax ID"
 msgstr "Firmaets MVA nummer"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr "Bekreft handling"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Bekreft!"
 
@@ -1717,7 +1718,7 @@ msgstr "Bekreft!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Konflikt med eksisterende data, kanskje ar det lagt inn før?"
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1760,8 +1761,8 @@ msgstr "Innhold"
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1772,7 +1773,7 @@ msgstr "Innhold"
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1824,7 +1825,7 @@ msgid "Copy to New Name"
 msgstr "Kopier til Nytt Navn"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Kostpris"
 
@@ -1836,19 +1837,19 @@ msgstr "Kostnader for solgte varer"
 msgid "Could Not Load Template from DB"
 msgstr "Kunne ikke laste Mal fra DB"
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Kunne ikke lagre data. Prøv igjen."
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Kunne ikke lagre"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Kunne ikke overføre varebeholdning!"
 
@@ -1868,8 +1869,8 @@ msgstr "Motpartsnummer"
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1933,7 +1934,7 @@ msgstr "Laget på"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredit"
 
@@ -1954,7 +1955,7 @@ msgstr "Kredittkontoer"
 msgid "Credit Invoice"
 msgstr "Kreditfaktura"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1978,7 +1979,7 @@ msgstr "Kreditt"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Val"
 
@@ -1987,7 +1988,7 @@ msgstr "Val"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2024,7 +2025,7 @@ msgstr "Tilpassede flagg"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2054,7 +2055,7 @@ msgstr "Kundenavn"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2067,7 +2068,7 @@ msgstr "Kundenummer"
 msgid "Customer Search"
 msgstr "Kunde søk"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Kunde mangler!"
 
@@ -2083,7 +2084,7 @@ msgstr "Kunde mangler i databasen!"
 msgid "Customer/Vendor Accounts"
 msgstr "Kunde/Leverandør Kontoer"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr "D M"
 
@@ -2107,7 +2108,7 @@ msgstr "Data fra kontoutskriften"
 msgid "Data from your ledger"
 msgstr "Data fra hovedbok"
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Data ikke lagret. Prøv igjen."
 
@@ -2156,7 +2157,7 @@ msgstr "Databasen eksisterer ikke"
 msgid "Database exists."
 msgstr "Databasen eksisterer."
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2171,11 +2172,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2213,7 +2214,7 @@ msgstr "Betalingsdato"
 msgid "Date Range"
 msgstr "Datointervall"
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Mottaksdato"
 
@@ -2237,7 +2238,7 @@ msgstr "Fra Dato"
 msgid "Date of Birth"
 msgstr "Fødselsdag"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Mangler mottaksdato"
 
@@ -2283,7 +2284,7 @@ msgstr "Dager"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debet"
 
@@ -2396,9 +2397,9 @@ msgstr "Definerte valutakurstyper"
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2448,16 +2449,16 @@ msgstr "Levering"
 msgid "Delivery Date"
 msgstr "Leveringsdato"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Avdeling Basis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Avdeling Metode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Avdeling Start"
 
@@ -2465,11 +2466,11 @@ msgstr "Avdeling Start"
 msgid "Dep. Through"
 msgstr "Nedskrevet gjennom"
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Avdeling YTD"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Avdeling denne kjøring"
 
@@ -2491,7 +2492,7 @@ msgstr "Avskrive"
 msgid "Depreciate Through"
 msgstr "Avskrive igjennom"
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Avskrivning"
@@ -2543,13 +2544,13 @@ msgstr "Avskrivnings Start"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2566,7 +2567,7 @@ msgstr "Avskrivnings Start"
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2637,16 +2638,16 @@ msgstr "Rabatt (%)"
 msgid "Discount:"
 msgstr "Rabatt:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Vis Aktivert Verdi"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Deponert"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Deponert Dato"
 
@@ -2654,7 +2655,7 @@ msgstr "Deponert Dato"
 msgid "Disposal Method"
 msgstr "Deponert Metode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Deponert Rapport [_1] på dato [_2]"
 
@@ -2662,7 +2663,7 @@ msgstr "Deponert Rapport [_1] på dato [_2]"
 msgid "Division by 0 error"
 msgstr "Feil, dividert på 0"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr "Doble kundenummer"
 
@@ -2678,7 +2679,7 @@ msgstr "Dokumenttype"
 msgid "Don't know what to do with backup"
 msgstr "Vei ikke hvordan å bruke backup"
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Ferdig"
 
@@ -2698,7 +2699,7 @@ msgstr ""
 msgid "Dr."
 msgstr "Dr."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Kladd Sendt"
 
@@ -2740,14 +2741,14 @@ msgstr "Forfall"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Forfallsdato"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Forfallsdato mangler!"
 
@@ -2759,8 +2760,8 @@ msgstr "Dublikat bruker funnet: Import bruker"
 msgid "Duplicate employee numbers"
 msgstr "Ansattnummer finnes fra før"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Epost"
 
@@ -3064,11 +3065,11 @@ msgstr "Eksisterende"
 msgid "Entity Class"
 msgstr "Eksisterende Klasse"
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "Eksisterende Kode"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "Eksisterende Kontollkode"
 
@@ -3084,7 +3085,7 @@ msgstr "Navn på enhet"
 msgid "Entry ID"
 msgstr "Eksisterende ID"
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "Konvulutt"
@@ -3106,7 +3107,7 @@ msgstr "Egenkapital & Gjeld"
 msgid "Equity (Temporary)"
 msgstr "Egenkapital (midlertidig)"
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr "Egenkapital til Gjeld"
 
@@ -3130,7 +3131,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Feil: Kan ikke inkludere sumkonto i andre nedtrekksmenyer"
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Est. Levetid"
 
@@ -3138,20 +3139,20 @@ msgstr "Est. Levetid"
 msgid "Every"
 msgstr "Hver"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Vxl"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Vekslingskurs"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Vekslingskurs for betaling mangler!"
 
@@ -3159,7 +3160,7 @@ msgstr "Vekslingskurs for betaling mangler!"
 msgid "Exchange rate hasn't been defined!"
 msgstr "Vekslingskurs er ikke definert!"
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Vekslingskurs mangler!"
 
@@ -3204,8 +3205,8 @@ msgstr "Ekstra Brukt"
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Faks"
 
@@ -3283,7 +3284,7 @@ msgstr "Femti"
 msgid "File"
 msgstr "Fil"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Importert Fil"
 
@@ -3297,17 +3298,17 @@ msgstr "Filnavn"
 msgid "File Type"
 msgstr "Filtype"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Filnavn"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Filtype"
@@ -3344,7 +3345,7 @@ msgstr "Første"
 msgid "First Name"
 msgstr "Fornavn"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr "Bare første kolonne"
 
@@ -3404,7 +3405,7 @@ msgstr "Fjorten"
 msgid "Fri"
 msgstr "Fri"
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3436,7 +3437,7 @@ msgstr "Fra Dato"
 msgid "From File"
 msgstr "Fra Fil"
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Fra Lager"
 
@@ -3485,7 +3486,7 @@ msgstr "GL Referansenummer"
 msgid "Gain"
 msgstr "Overskudd"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Overskudd (Tap)"
 
@@ -3493,7 +3494,7 @@ msgstr "Overskudd (Tap)"
 msgid "Gain Account"
 msgstr "Oversuddskonto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr "Overskudd/Tap"
 
@@ -3522,11 +3523,11 @@ msgstr "Generer"
 msgid "Generate Control Code"
 msgstr "Generer Kontrollkode"
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Generer orderere"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Generer innkjøpsorderere"
 
@@ -3571,8 +3572,8 @@ msgid "Grand Total"
 msgstr "Grand Total"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Gruppe"
 
@@ -3815,8 +3816,8 @@ msgstr "Intern Database Error"
 msgid "Internal Files"
 msgstr "Interne Filer"
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Interne notater"
 
@@ -3878,11 +3879,11 @@ msgstr ""
 "Varebeholdning må være null for at du kan sette denne sammensetningen som "
 "foreldet!"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Varebeholdning lagret"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Varebeholdning overført"
 
@@ -3890,8 +3891,8 @@ msgstr "Varebeholdning overført"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3909,22 +3910,22 @@ msgstr "Faktura"
 msgid "Invoice #"
 msgstr "Faktura nummer"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Faktura Opprettet"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Faktura Opprettet Dato mangler!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fakturadato"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Fakturadato mangler!"
 
@@ -3940,8 +3941,8 @@ msgstr "Fakturanummer."
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3950,7 +3951,7 @@ msgstr "Fakturanummer."
 msgid "Invoice Number"
 msgstr "Fakturanummer"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Fakturanummer mangler!"
 
@@ -4008,7 +4009,7 @@ msgstr "Artikkel"
 msgid "Item deleted!"
 msgstr "Elementet slettet!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Elementet mangler i databasen!"
 
@@ -4039,7 +4040,7 @@ msgstr "jan"
 msgid "January"
 msgstr "januar"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4080,7 +4081,7 @@ msgstr "jun"
 msgid "June"
 msgstr "juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr "Likviditetsgrad"
 
@@ -4144,7 +4145,7 @@ msgstr "Siste Oppdatering"
 msgid "Last name"
 msgstr "Etternavn"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Lede"
 
@@ -4369,11 +4370,11 @@ msgstr "Låst av [_1]"
 msgid "Logged out due to inactivity"
 msgstr "Logget ut på grunn av ikke aktivitet"
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4452,7 +4453,7 @@ msgstr "Behandler"
 msgid "Manager:"
 msgstr "Behandler:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Bruksanvisning"
 
@@ -4483,9 +4484,9 @@ msgid "May"
 msgstr "mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Notat"
@@ -4834,15 +4835,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4856,15 +4857,15 @@ msgstr "Merknader"
 msgid "Notes:<br />"
 msgstr "Merknader:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Ingenting lagt inn!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Ingenting valgt!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Ingenting å overføre!"
 
@@ -4889,7 +4890,7 @@ msgid "Null model numbers"
 msgstr "Null modell nummer"
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4908,7 +4909,7 @@ msgstr "Nummer"
 msgid "Number Format"
 msgstr "Numerisk format"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr "Nummer mangler i rad [_1]"
 
@@ -4946,7 +4947,7 @@ msgstr "okt"
 msgid "October"
 msgstr "oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr "Av vent"
 
@@ -4961,7 +4962,7 @@ msgstr "Gammelt Passord"
 msgid "On Hand"
 msgstr "På lager"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "På vent"
@@ -5016,7 +5017,7 @@ msgstr "Eller legg til parti"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Ordre"
 
@@ -5034,12 +5035,12 @@ msgstr "Ordre #"
 msgid "Order By"
 msgstr "Ordre av"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ordredato"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Ordredato mangler!"
 
@@ -5051,8 +5052,8 @@ msgstr "Ordrer"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5060,15 +5061,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Ordrenummer"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Ordrenummer mangler!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Ordre slettet!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Ordre opprettelse feilet"
 
@@ -5155,8 +5156,8 @@ msgstr "PO #"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5172,7 +5173,7 @@ msgstr "Post"
 msgid "POST AND PRINT"
 msgstr "Post og Skriv"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5180,11 +5181,11 @@ msgstr "Post og Skriv"
 msgid "Packing List"
 msgstr "Følgeseddel"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Dato for følgeseddel mangler!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Nummer for følgeseddel mangler!"
 
@@ -5208,7 +5209,7 @@ msgstr "Betalt"
 msgid "Parent"
 msgstr "Forelder"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Varegruppe"
 
@@ -5228,8 +5229,8 @@ msgstr "Varegruppe"
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5250,7 +5251,7 @@ msgstr "Vare detaljer"
 msgid "Partial"
 msgstr "Begrensett"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Begrenset Salgs Rapport [_1] på dato [_2]"
 
@@ -5280,7 +5281,7 @@ msgstr "Varegruppe"
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Passord"
 
@@ -5349,7 +5350,7 @@ msgstr "Betalingstype"
 msgid "Payment batch"
 msgstr "Betalings bunt"
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Betalingsdato mangler!"
 
@@ -5361,7 +5362,7 @@ msgstr "Betalingsforfall NET [_1] dager fra Faktura dato."
 msgid "Payment due by [_1]."
 msgstr "Betalingsforfall på [_1]."
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5370,7 +5371,7 @@ msgstr "Betalingsforfall på [_1]."
 msgid "Payments"
 msgstr "Betalinger"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr "Betalinger koblet ti annullerte fakturaer trenge å bli reversert. "
 
@@ -5378,11 +5379,11 @@ msgstr "Betalinger koblet ti annullerte fakturaer trenge å bli reversert. "
 msgid "Percent"
 msgstr "Prosent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Prosent Fordelt"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Prosent gjenværende"
 
@@ -5417,7 +5418,7 @@ msgstr "Tlf"
 msgid "Physical"
 msgstr "Fysisk"
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5558,8 +5559,8 @@ msgstr "Bruk v. 1.2 UI for å legge til SRU kontoer."
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Bokfør"
@@ -5576,7 +5577,7 @@ msgstr "Bokfør Dato"
 msgid "Post Yearend"
 msgstr "Bokfør Årsavslutning"
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Bokfør som ny"
 
@@ -5682,9 +5683,9 @@ msgid "Primary Phone"
 msgstr "Sentralbord tlf"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Skriv ut"
@@ -5693,11 +5694,11 @@ msgstr "Skriv ut"
 msgid "Print Batch"
 msgstr "Skriv Batch"
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Skriv ut og lagre"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Skriv ut og lagre som ny"
 
@@ -5749,15 +5750,15 @@ msgstr "Skriver Postering [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Skrive Arbeidsordre [_1]"
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Prioritert Dep."
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Prioritert gjennom"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "Fortsettelser"
 
@@ -5779,7 +5780,7 @@ msgstr "Produkt kvittering"
 msgid "Profit and Loss"
 msgstr "Fortjeneste og Tap"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Fortjeneste/tap"
 
@@ -5822,8 +5823,8 @@ msgstr "Innkjøpsdato:"
 msgid "Purchase History"
 msgstr "Innkjøpshistorikk"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5862,7 +5863,7 @@ msgstr "Kjøpt"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5892,8 +5893,8 @@ msgid "Quarter"
 msgstr "Kvartal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5909,7 +5910,7 @@ msgstr "Tilbud #"
 msgid "Quotation Date"
 msgstr "Tilbudsdato"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Mangler tilbudsdato"
 
@@ -5917,11 +5918,11 @@ msgstr "Mangler tilbudsdato"
 msgid "Quotation Number"
 msgstr "Tilbudsnummer"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Mangler tilbudsnummer"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Tilbud slettet!"
 
@@ -5936,7 +5937,7 @@ msgstr "Tilbud"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5962,7 +5963,7 @@ msgstr "Tilbudsforespørsler"
 msgid "ROP"
 msgstr "Etterbestill ved"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -6003,7 +6004,7 @@ msgstr "Se kvittering"
 msgid "Rebuild/Upgrade?"
 msgstr "Rebygg/Oppgrader?"
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Mottatt"
 
@@ -6032,7 +6033,7 @@ msgstr "Innbetalinger"
 msgid "Receive"
 msgstr "Motta"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Motta varer"
 
@@ -6060,7 +6061,7 @@ msgstr "Avstemnings Rapport"
 msgid "Reconciliation Reports"
 msgstr "Avstemningsrapporter"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Bokfør på"
 
@@ -6086,11 +6087,11 @@ msgstr "Gjentagende Posteringer"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referanse"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr "Referansenummer mangler"
 
@@ -6127,9 +6128,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Resterende Levetid"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resterende"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6157,7 +6162,7 @@ msgstr "Raport generert av:"
 msgid "Report Name"
 msgstr "Rapportnavn"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Rapportresultat"
 
@@ -6169,7 +6174,7 @@ msgstr "Innsendt Rapport"
 msgid "Report Type"
 msgstr "Rapport Type"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr "Rapport [_1] på dato [_2]"
 
@@ -6205,11 +6210,11 @@ msgstr "Rapporter"
 msgid "Reposting Not Allowed"
 msgstr "Reføring ikke lov"
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Be om"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6330,11 +6335,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr "SIC:"
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr "SO Number"
 
@@ -6363,7 +6368,7 @@ msgstr "Salg"
 msgid "Sales"
 msgstr "Salg"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Utgående Faktura"
@@ -6372,8 +6377,8 @@ msgstr "Utgående Faktura"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Utgående Faktura Posterings nummer"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6438,7 +6443,7 @@ msgstr "Lør"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6483,7 +6488,7 @@ msgstr "Lagre Kladd"
 msgid "Save Groups"
 msgstr "Lagre Grupper"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Lagre Sted"
 
@@ -6491,7 +6496,7 @@ msgstr "Lagre Sted"
 msgid "Save New"
 msgstr "Lagre Ny"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr "Lagre nytt Sted"
 
@@ -6508,7 +6513,7 @@ msgid "Save Translations"
 msgstr "Lagre oversettelser"
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Lagre som ny"
@@ -6517,7 +6522,7 @@ msgstr "Lagre som ny"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr "Lagre de gitte endringene og forsøk å fortsette overføringen."
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6555,7 +6560,7 @@ msgstr "Lagre [_1] [_2]"
 msgid "Saving over an existing document.  Continue?"
 msgstr "Lagre over et eksisterende dokument. Fortsett?"
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6568,12 +6573,12 @@ msgstr "Lagre over et eksisterende dokument. Fortsett?"
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Planlagt"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Planlagt"
 
@@ -6714,11 +6719,11 @@ msgstr "Velg kunde"
 msgid "Select Templates to Load"
 msgstr "Velg Maler for å vise"
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Velg leverandør"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Velg en skriver!"
 
@@ -6738,12 +6743,12 @@ msgstr "Velg Fakturaer"
 msgid "Select or Enter User"
 msgstr "Velg eller skriv inn bruker"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Velg postscript eller PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Velg txt, postscript eller PDF!"
 
@@ -6834,7 +6839,7 @@ msgstr "Sekvenser"
 msgid "Serial #"
 msgstr "Serie #"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serienummer"
 
@@ -6852,11 +6857,11 @@ msgstr "Serienummer"
 msgid "Serialnumber"
 msgstr "Serienummer"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Tjeneste"
 
@@ -6900,13 +6905,13 @@ msgstr "Sytten"
 msgid "Seventy"
 msgstr "Sytti"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Send"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Send varer"
 
@@ -6936,12 +6941,12 @@ msgstr "Send til:"
 msgid "Ship Via"
 msgstr "Send via"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Send til"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6958,23 +6963,23 @@ msgstr "Send via"
 msgid "Shipping"
 msgstr "Frakt"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Leveringsdato"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Mangler leveringsdato"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr "Sendings Etikett"
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7050,12 +7055,12 @@ msgstr "Noen"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7136,11 +7141,11 @@ msgstr "Start Dato"
 msgid "Starting Date:"
 msgstr "Start Dato:"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Start"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7224,7 +7229,7 @@ msgstr "Avgi"
 msgid "Submitted"
 msgstr "Avgitt"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7287,8 +7292,8 @@ msgstr "TOTAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Merkelappapp"
 
@@ -7310,7 +7315,7 @@ msgstr "MVA/Avgift"
 msgid "Tax Account"
 msgstr "MVA konto"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "MVA kode"
 
@@ -7320,7 +7325,7 @@ msgstr "MVA kode"
 msgid "Tax Form"
 msgstr "MVA Skjema"
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "MVA Skjema Brukt"
 
@@ -7344,7 +7349,7 @@ msgstr "MVA Skjema Rapporter"
 msgid "Tax Forms"
 msgstr "MVA Skjemaer"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "MVA ID"
 
@@ -7352,7 +7357,7 @@ msgstr "MVA ID"
 msgid "Tax ID/SSN"
 msgstr "MVA ID/SSN"
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Inkl. MVA/Avgifter"
@@ -7453,7 +7458,7 @@ msgstr "Mal"
 msgid "Template Listing"
 msgstr "Mal  Oversikt"
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Mal  lagret"
 
@@ -7685,7 +7690,7 @@ msgstr "Ganger"
 msgid "Timing"
 msgstr "Timing"
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7720,7 +7725,7 @@ msgstr "Til Dato"
 msgid "To Pay"
 msgstr "Til Betaling"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Til lager"
 
@@ -7766,7 +7771,7 @@ msgstr "Topplan"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7787,7 +7792,7 @@ msgstr "Topplan"
 msgid "Total"
 msgstr "I alt"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Total akkumulert  inskudd"
 
@@ -7799,6 +7804,10 @@ msgstr "Totalt Utestående"
 msgid "Total Paid"
 msgstr "Totalt Betalt"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Spore Artikler"
@@ -7807,7 +7816,7 @@ msgstr "Spore Artikler"
 msgid "Trade Discount"
 msgstr "Handelsrabatt"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Postering"
 
@@ -7840,20 +7849,20 @@ msgstr "Posterings type"
 msgid "Transactions"
 msgstr "Posteringer"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Overføre"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Overfør varebeholdning"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Overfør fra"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Overfør til"
 
@@ -7940,7 +7949,7 @@ msgstr "To"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -8004,7 +8013,7 @@ msgstr "Unike ikke foreldete varenummer"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -8020,7 +8029,7 @@ msgstr "Enhets Pris"
 msgid "Unknown "
 msgstr "Ukjent"
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -8040,7 +8049,7 @@ msgstr "Ukjent diagram type; skulle være H(Overskrift)/A(Konto)"
 msgid "Unknown database found."
 msgstr "Ukjent database funnet"
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8092,20 +8101,20 @@ msgstr "Ikke i bruk"
 msgid "Up"
 msgstr "Opp"
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Oppdatér"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Oppdatert"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8167,7 +8176,7 @@ msgstr "Bruk Kunde Overbetaling"
 msgid "Use Overpayment"
 msgstr "Bruk Overbetaling"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr "Bruk send til"
 
@@ -8253,8 +8262,8 @@ msgstr "Forandring:"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8273,7 +8282,7 @@ msgstr "Leverandørkonto"
 msgid "Vendor History"
 msgstr "Leverandørhistorikk"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Inngående Faktura"
@@ -8289,7 +8298,7 @@ msgstr "Leverandør Navn"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8312,7 +8321,7 @@ msgstr "Leverandørens Referansenummer"
 msgid "Vendor Search"
 msgstr "Leverandør søk"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Leverandør mangler!"
 
@@ -8349,7 +8358,7 @@ msgstr "Lønninger og Skattekort"
 msgid "Wages/Deductions"
 msgstr "Lønninger/Skatt"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8426,7 +8435,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Hvilken type ting er dette?"
 
@@ -8442,7 +8451,7 @@ msgstr "Hele Måneden i rett linje"
 msgid "Widgit Themes"
 msgstr "Widgit Themes"
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8500,7 +8509,7 @@ msgstr "Årsavslutning avsluttet"
 msgid "Years"
 msgstr "År"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
@@ -8519,11 +8528,11 @@ msgstr "Postnummer"
 msgid "Zero"
 msgstr "Null"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Postnummer"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Postnummer"
 
@@ -8592,7 +8601,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "by"
 
@@ -8636,7 +8645,7 @@ msgstr "gjort"
 msgid "e"
 msgstr "e"
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "stk"
 

--- a/locale/po/nl.po
+++ b/locale/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Jos <j.verdoold@gmail.com>, 2016\n"
 "Language-Team: Dutch (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -192,7 +192,7 @@ msgstr "Afschrijving"
 msgid "Access Denied"
 msgstr "Toegang geweigerd"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -200,9 +200,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -210,7 +210,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -321,7 +321,7 @@ msgstr "Aangegroeid"
 msgid "Accrual Basis:"
 msgstr "Aangroeibasis:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Cum. Afschrijving"
 
@@ -430,7 +430,7 @@ msgstr "Debetmemo Toevoegen"
 msgid "Add Employee"
 msgstr "Werknemer Toevoegen"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Wisselkoers Toevoegen"
 
@@ -466,11 +466,11 @@ msgstr "Artikel Toevoegen"
 msgid "Add Pricegroup"
 msgstr "Prijsgroep Toevoegen"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Inkooporder Toevoegen"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Offerte Toevoegen"
 
@@ -478,7 +478,7 @@ msgstr "Offerte Toevoegen"
 msgid "Add Reporting Unit"
 msgstr "Rapportage-eenheid Toevoegen"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Prijsaanvraag Toevoegen"
 
@@ -490,11 +490,11 @@ msgstr "Retour Toevoegen"
 msgid "Add SIC"
 msgstr "SIC Toevoegen"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Verkoopfactuur Toevoegen"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Verkooporder Toevoegen"
 
@@ -510,7 +510,7 @@ msgstr "Belastingformulier Toevoegen"
 msgid "Add Timecard"
 msgstr "Tijdregistratie Toevoegen"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Aan lijst Toevoegen"
 
@@ -532,7 +532,7 @@ msgstr "Gebruiker Toevoegen"
 msgid "Add Vendor"
 msgstr "Leverancier Toevoegen"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Inkoopfactuur Toevoegen"
 
@@ -544,15 +544,15 @@ msgstr "Inkoopretour Toevoegen"
 msgid "Add Warehouse"
 msgstr "Magazijn Toevoegen"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Regel 1 Toevoegen"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Regel 2 Toevoegen"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Regel 3 Toevoegen"
 
@@ -580,8 +580,8 @@ msgstr "Toegevoegde id [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -613,7 +613,7 @@ msgstr "Aanp."
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Aangepaste basis"
 
@@ -690,9 +690,9 @@ msgstr "Invoer toestaan"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -795,8 +795,8 @@ msgstr "Goedkeuringsstatus"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Goedkeuren"
@@ -834,20 +834,20 @@ msgstr "apr"
 msgid "April"
 msgstr "april"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Verkregen prijs bij verkoop"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Verkregen restwaarde"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Weet u zeker dat u dit ordernummer wilt verwijderen?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Weet u zeker dat u dit offertenummer wilt verwijderen?"
 
@@ -920,16 +920,16 @@ msgstr "Activa code"
 msgid "Assets"
 msgstr "Activa"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Activa naar Eigen vermogen"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr "Activa naar Passiva"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Bijvoegen"
@@ -960,31 +960,31 @@ msgstr "Bijgevoegd op"
 msgid "Attached By"
 msgstr "Bijgevoegd door"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Gevoegd bij"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Bijgevoegd type"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Bijgevoegde en gekoppelde bestanden"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Bijgevoegd op"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Bijgevoegd door"
@@ -1017,7 +1017,7 @@ msgstr "augustus"
 msgid "Author: [_1]"
 msgstr "Auteur: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatisch"
 
@@ -1086,7 +1086,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balans"
@@ -1133,8 +1133,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basis"
 
@@ -1146,7 +1146,7 @@ msgstr "Groep"
 msgid "Batch Class"
 msgstr "Groep soort"
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr "Groep nummer"
 
@@ -1166,7 +1166,7 @@ msgstr "Groep ID"
 msgid "Batch ID Missing"
 msgstr "Groep ID ontbreekt"
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr "Groep naam"
 
@@ -1213,14 +1213,14 @@ msgstr "miljard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Vak"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Bereken BTW"
 
@@ -1328,12 +1328,12 @@ msgstr "Bereken BTW"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Teruggedraaide factuur niet terugdraaibaar!"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1383,7 +1383,7 @@ msgstr "Kan geen diensten aanmaken; Inkomstenrekening bestaat niet!"
 msgid "Cannot delete item!"
 msgstr "Kan onderdeel niet verwijderen!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Kan order niet verwijderen!"
 
@@ -1391,19 +1391,19 @@ msgstr "Kan order niet verwijderen!"
 msgid "Cannot delete posted transaction"
 msgstr "Geboekte transactie niet verwijderbaar"
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Kan offerte niet verwijderen!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Kan geen factuur boeken in afgesloten periode!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Kan geen betaling boeken voor afgesloten periode!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Kan geen boeking maken in afgesloten periode"
 
@@ -1414,15 +1414,15 @@ msgstr ""
 "Kan geen transactie boeken met een debit- en creditregel voor dezelfde "
 "rekening!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Kan transactie niet boeken!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Kan order niet opslaan!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Kan offerte niet opslaan!"
 
@@ -1442,7 +1442,8 @@ msgstr "Kaart ID"
 msgid "Cash"
 msgstr "Kas"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Kasrekening"
 
@@ -1503,7 +1504,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1619,7 +1620,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Bedrijf"
 
@@ -1652,7 +1653,7 @@ msgstr "Bedrijfstelefoon"
 msgid "Company Sales Tax ID"
 msgstr "Firma BTW Nummer"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1704,7 +1705,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr "Bevestig bewerking"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Bevestig!"
 
@@ -1712,7 +1713,7 @@ msgstr "Bevestig!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Conflicteert met bestaande gegevens. Misschien heeft u het al ingevoerd"
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1755,8 +1756,8 @@ msgstr "Inhoud"
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1767,7 +1768,7 @@ msgstr "Inhoud"
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1816,7 +1817,7 @@ msgid "Copy to New Name"
 msgstr "Kopiëer naar nieuwe naam"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Kostprijs"
 
@@ -1828,19 +1829,19 @@ msgstr "Kostprijs van verkochte goederen"
 msgid "Could Not Load Template from DB"
 msgstr "Kon sjabloon niet uit DB ophalen"
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Kan gegevens niet opslaan Probeer opnieuw"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Kon niet opslaan!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Kon geen Inventaris overboeken!"
 
@@ -1860,8 +1861,8 @@ msgstr "Tegenpartij code"
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1925,7 +1926,7 @@ msgstr "Gemaakt op"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Credit"
 
@@ -1946,7 +1947,7 @@ msgstr "Crediteurenrekeningen"
 msgid "Credit Invoice"
 msgstr "Creditfactuur"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1970,7 +1971,7 @@ msgstr "Credit"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Val."
 
@@ -1979,7 +1980,7 @@ msgstr "Val."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2016,7 +2017,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2046,7 +2047,7 @@ msgstr "Klantnaam"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2059,7 +2060,7 @@ msgstr "Klant Nummer"
 msgid "Customer Search"
 msgstr "Klant zoeken"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Klant ontbreekt!"
 
@@ -2075,7 +2076,7 @@ msgstr "Klant bestaat niet!"
 msgid "Customer/Vendor Accounts"
 msgstr "Klanten-/leveranciersrekeningen"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr "Dag Maand"
 
@@ -2099,7 +2100,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Gegevens niet opgeslagen Probeer opnieuw"
 
@@ -2148,7 +2149,7 @@ msgstr "Database bestaat niet."
 msgid "Database exists."
 msgstr "Database bestaat al."
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2163,11 +2164,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2205,7 +2206,7 @@ msgstr "Betaaldatum"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Datum ontvangen"
 
@@ -2229,7 +2230,7 @@ msgstr "Datum vanaf"
 msgid "Date of Birth"
 msgstr "Geboortedatum"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Ontvangstdatum ontbreekt!"
 
@@ -2275,7 +2276,7 @@ msgstr "Dagen"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debet"
 
@@ -2388,9 +2389,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2440,16 +2441,16 @@ msgstr "Bezorging"
 msgid "Delivery Date"
 msgstr "Leverdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Afschr. Basis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Afschr. methode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Afschr. begint"
 
@@ -2457,11 +2458,11 @@ msgstr "Afschr. begint"
 msgid "Dep. Through"
 msgstr "Afschr. tot"
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Afschr. dit jr"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Afschr. dit rapport"
 
@@ -2483,7 +2484,7 @@ msgstr "Afschrijven"
 msgid "Depreciate Through"
 msgstr "Afschrijvingen door"
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Afschrijving"
@@ -2535,13 +2536,13 @@ msgstr "Afschrijving begint"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2558,7 +2559,7 @@ msgstr "Afschrijving begint"
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2629,16 +2630,16 @@ msgstr "Korting (%)"
 msgid "Discount:"
 msgstr "Korting:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Verkregen restwaarde afschrijving"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Verwijdering"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Verwijderingsdatum"
 
@@ -2646,7 +2647,7 @@ msgstr "Verwijderingsdatum"
 msgid "Disposal Method"
 msgstr "Verwijderingsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Verwijderingsrapport [_1] op datum [_2]"
 
@@ -2654,7 +2655,7 @@ msgstr "Verwijderingsrapport [_1] op datum [_2]"
 msgid "Division by 0 error"
 msgstr "Delen door 0 kan niet! Onmodelijk!"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr "Laat dit veld niet leeg [_1]"
 
@@ -2670,7 +2671,7 @@ msgstr "Document Type"
 msgid "Don't know what to do with backup"
 msgstr "Onbekend welke aktie met backup"
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Klaar"
 
@@ -2690,7 +2691,7 @@ msgstr ""
 msgid "Dr."
 msgstr "Dr."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Concept geboekt"
 
@@ -2732,14 +2733,14 @@ msgstr "Verschuldigd op"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Vervaldatum"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Vervaldatum ontbreekt!"
 
@@ -2751,8 +2752,8 @@ msgstr "Dubbele gebruiker gevonden: gebruiker geïmporteerd"
 msgid "Duplicate employee numbers"
 msgstr "Werknemer Nummer"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3056,11 +3057,11 @@ msgstr "Bedrijfseenheid"
 msgid "Entity Class"
 msgstr "Entiteitsoort"
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "Bedrijfseenheid code"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "Bedrijfseenheid Control Code"
 
@@ -3076,7 +3077,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr "Invoer ID"
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "Enveloppe"
@@ -3098,7 +3099,7 @@ msgstr "Eigenvermogen & passiva"
 msgid "Equity (Temporary)"
 msgstr "Eigenvermogen (Tijdelijk)"
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr "Eigen vermogen naar passiva"
 
@@ -3122,7 +3123,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Fout: Samenvattingsrekening niet combineerbaar met selectielijsten"
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Verw. Levensduur"
 
@@ -3130,20 +3131,20 @@ msgstr "Verw. Levensduur"
 msgid "Every"
 msgstr "Elke"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Wissel"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Wisselkoers"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Wisselkoers voor betaling ontbreekt!"
 
@@ -3151,7 +3152,7 @@ msgstr "Wisselkoers voor betaling ontbreekt!"
 msgid "Exchange rate hasn't been defined!"
 msgstr "Wisselkoers is niet gedefinieerd!"
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Wisselkoers ontbreekt!"
 
@@ -3196,8 +3197,8 @@ msgstr "Extra gebruikt"
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3275,7 +3276,7 @@ msgstr "Vijftig"
 msgid "File"
 msgstr "Bestand"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Bestand geimporteerd"
 
@@ -3289,17 +3290,17 @@ msgstr "Bestandsnaam"
 msgid "File Type"
 msgstr "Bestandstype"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Bestandsnaam"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Bestandstype"
@@ -3336,7 +3337,7 @@ msgstr "Eerste"
 msgid "First Name"
 msgstr "Voornaam"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr "Alleen eerste kolom"
 
@@ -3396,7 +3397,7 @@ msgstr "Veertien"
 msgid "Fri"
 msgstr "Vrij"
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3428,7 +3429,7 @@ msgstr "Vanaf datum"
 msgid "From File"
 msgstr "Vanuit bestand"
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Van Magazijn"
 
@@ -3477,7 +3478,7 @@ msgstr "Memoriaal Referentiecode"
 msgid "Gain"
 msgstr "Winst"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Winst  (Verlies)"
 
@@ -3485,7 +3486,7 @@ msgstr "Winst  (Verlies)"
 msgid "Gain Account"
 msgstr "Winstrekening"
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3514,11 +3515,11 @@ msgstr "Genereer"
 msgid "Generate Control Code"
 msgstr "Genereer controlecode"
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Genereer Orders"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Genereer Aankooporders"
 
@@ -3563,8 +3564,8 @@ msgid "Grand Total"
 msgstr "Totaal generaal"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Productgroep"
 
@@ -3806,8 +3807,8 @@ msgstr "Interne database fout"
 msgid "Internal Files"
 msgstr "Interne bestanden"
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Interne Opmerkingen"
 
@@ -3869,11 +3870,11 @@ msgstr ""
 "Voorraadhoeveelheid moet nul zijn voordat dit artikel incourant aangemerkt "
 "kan worden"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Voorraad opgeslagen!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Voorraad overgeheveld!"
 
@@ -3881,8 +3882,8 @@ msgstr "Voorraad overgeheveld!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3900,22 +3901,22 @@ msgstr "Factuur"
 msgid "Invoice #"
 msgstr "Factuur #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Factuur aangemaakt"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Factuur aanmaakdatum mist!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Factuurdatum"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Factuurdatum ontbreekt!"
 
@@ -3931,8 +3932,8 @@ msgstr "Factuurnr"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3941,7 +3942,7 @@ msgstr "Factuurnr"
 msgid "Invoice Number"
 msgstr "Factuurcode"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Factuurcode ontbreekt!"
 
@@ -3999,7 +4000,7 @@ msgstr "Regel"
 msgid "Item deleted!"
 msgstr "Onderdeel verwijderd!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Dit onderdeel is niet in de database gevonden!"
 
@@ -4032,7 +4033,7 @@ msgstr "jan"
 msgid "January"
 msgstr "januari"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4073,7 +4074,7 @@ msgstr "jun"
 msgid "June"
 msgstr "juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr "KPI's"
 
@@ -4137,7 +4138,7 @@ msgstr "Laatst bijgewerkt"
 msgid "Last name"
 msgstr "Achternaam"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Prospect Klant"
 
@@ -4358,11 +4359,11 @@ msgstr "Vergrendeld door [_1]"
 msgid "Logged out due to inactivity"
 msgstr "Uitgelogd door inactiviteit"
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Aanmelden"
 
@@ -4441,7 +4442,7 @@ msgstr "Manager"
 msgid "Manager:"
 msgstr "Manager:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Handmatig"
 
@@ -4472,9 +4473,9 @@ msgid "May"
 msgstr "mei"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4827,15 +4828,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4849,15 +4850,15 @@ msgstr "Opmerkingen"
 msgid "Notes:<br />"
 msgstr "Notities:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Niets ingevuld!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Niets geselecteerd!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Niets over te boeken!"
 
@@ -4882,7 +4883,7 @@ msgid "Null model numbers"
 msgstr "NULL modelnummers"
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4901,7 +4902,7 @@ msgstr "Nummer"
 msgid "Number Format"
 msgstr "Nummeraanduiding"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr "Getal mist in regel [_1]"
 
@@ -4939,7 +4940,7 @@ msgstr "okt"
 msgid "October"
 msgstr "oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr "Uit de wacht"
 
@@ -4954,7 +4955,7 @@ msgstr "Oud wachtwoord"
 msgid "On Hand"
 msgstr "Op voorraad"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "Wacht"
@@ -5009,7 +5010,7 @@ msgstr "Of Voeg toe aan Groep"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Bestelling"
 
@@ -5027,12 +5028,12 @@ msgstr "Order #"
 msgid "Order By"
 msgstr "Order door"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Orderdatum"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Orderdatum ontbreekt!"
 
@@ -5044,8 +5045,8 @@ msgstr "Orderinvoer"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5053,15 +5054,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Referentie"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Ordernummer ontbreekt!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Order verwijderd!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Genereren order mislukt!"
 
@@ -5148,8 +5149,8 @@ msgstr "PO #"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5165,7 +5166,7 @@ msgstr "accorderen"
 msgid "POST AND PRINT"
 msgstr "accorderen en afdrukken"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5173,11 +5174,11 @@ msgstr "accorderen en afdrukken"
 msgid "Packing List"
 msgstr "Pakbon"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Datum ontbreekt op de pakbon!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Nummer ontbreekt op de pakbon!"
 
@@ -5201,7 +5202,7 @@ msgstr "Betaald"
 msgid "Parent"
 msgstr "Parent"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artikel"
 
@@ -5221,8 +5222,8 @@ msgstr "Artikelgroep"
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5243,7 +5244,7 @@ msgstr ""
 msgid "Partial"
 msgstr "Gedeeltelijk"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Gedeeltelijk afschrijvingsrapportage [_1] op datum [_2]"
 
@@ -5273,7 +5274,7 @@ msgstr "Artikelgroep"
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -5342,7 +5343,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Geen betalingsdatum aanwezig!"
 
@@ -5354,7 +5355,7 @@ msgstr "Betaling verschuldigd NET [_1] dagen vanaf factuurdatum"
 msgid "Payment due by [_1]."
 msgstr "Betaling verschuldigd op [_1]."
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5363,7 +5364,7 @@ msgstr "Betaling verschuldigd op [_1]."
 msgid "Payments"
 msgstr "Betalingen"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr "Betalingen m.b.t. niet geldige facturen moeten worden teruggeboekt"
 
@@ -5371,11 +5372,11 @@ msgstr "Betalingen m.b.t. niet geldige facturen moeten worden teruggeboekt"
 msgid "Percent"
 msgstr "procent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Percentage verwijderd"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Resterend Percentage"
 
@@ -5410,7 +5411,7 @@ msgstr "Telefoon"
 msgid "Physical"
 msgstr "Fysiek"
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5550,8 +5551,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Inboeken"
@@ -5568,7 +5569,7 @@ msgstr "Boekdatum"
 msgid "Post Yearend"
 msgstr "Boek jaarafsluiting"
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Inboeken als nieuw"
 
@@ -5663,9 +5664,9 @@ msgid "Primary Phone"
 msgstr "Eerste telefoonnummer"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Afdrukken"
@@ -5674,11 +5675,11 @@ msgstr "Afdrukken"
 msgid "Print Batch"
 msgstr "Print groep"
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Afdrukken en Opslaan"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Afdrukken en Sla op als nieuw"
 
@@ -5730,15 +5731,15 @@ msgstr "Afdrukken transactie [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Afdrukken werkbon [_1]"
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Eerdere Afschr."
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Voorafgaand aan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "vervolgt"
 
@@ -5760,7 +5761,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr "Winst en verlies"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Verlies/Winst"
 
@@ -5803,8 +5804,8 @@ msgstr "Datum Inkoop"
 msgid "Purchase History"
 msgstr "Inkoophistorie"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5843,7 +5844,7 @@ msgstr "Gekocht"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5873,8 +5874,8 @@ msgid "Quarter"
 msgstr "Kwartaal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5890,7 +5891,7 @@ msgstr "Offerte #"
 msgid "Quotation Date"
 msgstr "Offertedatum"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Offertedatum ontbreekt!"
 
@@ -5898,11 +5899,11 @@ msgstr "Offertedatum ontbreekt!"
 msgid "Quotation Number"
 msgstr "Offertecode"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Offertecode ontbreekt!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Offerte verwijderd!"
 
@@ -5917,7 +5918,7 @@ msgstr "Offertes"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5943,7 +5944,7 @@ msgstr "Prijsaanvragen"
 msgid "ROP"
 msgstr "Minimum voorraad"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5984,7 +5985,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr "Herbouwen/upgraden?"
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Ontvangen"
 
@@ -6013,7 +6014,7 @@ msgstr "Vorderingen"
 msgid "Receive"
 msgstr "Ontvangen"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Goederen Ontvangen"
 
@@ -6041,7 +6042,7 @@ msgstr "Aansluitrapport"
 msgid "Reconciliation Reports"
 msgstr "Aansluitrapporten"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Boeken op"
 
@@ -6067,11 +6068,11 @@ msgstr "Geplande Transacties"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referentie"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr "Referentienummer mist"
 
@@ -6108,9 +6109,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Verwachte resterende levensduur"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resterend"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6138,7 +6143,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Rapportnaam"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Rapportresultaat"
 
@@ -6150,7 +6155,7 @@ msgstr "Rapport ingediend"
 msgid "Report Type"
 msgstr "Rapportsoort"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr "Rapport [_1] op datum [_2]"
 
@@ -6186,11 +6191,11 @@ msgstr "Rapporten"
 msgid "Reposting Not Allowed"
 msgstr "Heraccordering niet toegestaan"
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Gevr"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6311,11 +6316,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr "SIC:"
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6344,7 +6349,7 @@ msgstr "Verkoopfactuur"
 msgid "Sales"
 msgstr "Verkoop"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Verkoopfactuur"
@@ -6353,8 +6358,8 @@ msgstr "Verkoopfactuur"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Verkoopfactuur/Transactienummer Debiteuren"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6419,7 +6424,7 @@ msgstr "Zater"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6464,7 +6469,7 @@ msgstr "Opslaan"
 msgid "Save Groups"
 msgstr "Groepen opslaan"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Locatie opslaan"
 
@@ -6472,7 +6477,7 @@ msgstr "Locatie opslaan"
 msgid "Save New"
 msgstr "Nieuw opslaan"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr "Nieuwe locatie opslaan"
 
@@ -6489,7 +6494,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Opslaan als nieuw"
@@ -6498,7 +6503,7 @@ msgstr "Opslaan als nieuw"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6536,7 +6541,7 @@ msgstr "Opslaan [_1] [_2]"
 msgid "Saving over an existing document.  Continue?"
 msgstr "Opslaan en bestaand document vervangen?"
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6549,12 +6554,12 @@ msgstr "Opslaan en bestaand document vervangen?"
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Inplannen"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Ingepland"
 
@@ -6695,11 +6700,11 @@ msgstr "Selecteer Klant"
 msgid "Select Templates to Load"
 msgstr "Kies sjablonen om te laden"
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Selecteer Leverancier"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecteer een Printer"
 
@@ -6719,12 +6724,12 @@ msgstr "Kies facturen"
 msgid "Select or Enter User"
 msgstr "Selecteer gebruiker of voer een gebruiker in"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Kies postscript of PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Kiest txt, postscript of PDF!"
 
@@ -6815,7 +6820,7 @@ msgstr "Volgnummers"
 msgid "Serial #"
 msgstr "Serie#"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serienr"
 
@@ -6833,11 +6838,11 @@ msgstr "Serienummer"
 msgid "Serialnumber"
 msgstr "Serienummer"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Dienst"
 
@@ -6881,13 +6886,13 @@ msgstr "Zeventien"
 msgid "Seventy"
 msgstr "Zeventig"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Verzenden"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Goederen Verzenden"
 
@@ -6917,12 +6922,12 @@ msgstr "Verzenden aan:"
 msgid "Ship Via"
 msgstr "Verzenden met"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Verzenden aan"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6939,23 +6944,23 @@ msgstr "Verzenden via"
 msgid "Shipping"
 msgstr "Zendingen"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Verzenddatum"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Verzenddatum ontbreekt!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr "Verzendlabel"
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7031,12 +7036,12 @@ msgstr "Sommige"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7118,11 +7123,11 @@ msgstr "Startdatum"
 msgid "Starting Date:"
 msgstr "Startdatum:"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Provincie"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7206,7 +7211,7 @@ msgstr "Indienen"
 msgid "Submitted"
 msgstr "Verstuurd"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7269,8 +7274,8 @@ msgstr "TOTAAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Label"
 
@@ -7292,7 +7297,7 @@ msgstr "BTW"
 msgid "Tax Account"
 msgstr "Belastingrekening"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "BTW Code"
 
@@ -7302,7 +7307,7 @@ msgstr "BTW Code"
 msgid "Tax Form"
 msgstr "Belastingformulier"
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Belasting formulier toegepast"
 
@@ -7326,7 +7331,7 @@ msgstr "Belastingformulierrapporten"
 msgid "Tax Forms"
 msgstr "Belasting formulieren"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "BTW#"
 
@@ -7334,7 +7339,7 @@ msgstr "BTW#"
 msgid "Tax ID/SSN"
 msgstr "BTW/BSN#"
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Belasting Inbegrepen"
@@ -7433,7 +7438,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr "Sjablonenlijst"
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Sjabloon opgeslagen!"
 
@@ -7655,7 +7660,7 @@ msgstr "Keren"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7690,7 +7695,7 @@ msgstr "tot Datum"
 msgid "To Pay"
 msgstr "Betalen"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Naar Magazijn"
 
@@ -7736,7 +7741,7 @@ msgstr "Hoogste Niveau"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7757,7 +7762,7 @@ msgstr "Hoogste Niveau"
 msgid "Total"
 msgstr "Totaal"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Totaal afschrijvingen"
 
@@ -7769,6 +7774,10 @@ msgstr "Totaal openstaand"
 msgid "Total Paid"
 msgstr "Totaal betaald"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Magazijngoederen"
@@ -7777,7 +7786,7 @@ msgstr "Magazijngoederen"
 msgid "Trade Discount"
 msgstr "Handelskorting"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Boeking"
 
@@ -7810,20 +7819,20 @@ msgstr "Boekingtype"
 msgid "Transactions"
 msgstr "Boekingen"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Overboeking"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Inventaris overboeken"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Overdragen van"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Overboeken naar"
 
@@ -7910,7 +7919,7 @@ msgstr "Twee"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7971,7 +7980,7 @@ msgstr "Unieke geldige artikelnummers"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7987,7 +7996,7 @@ msgstr "Eenheidsprijs"
 msgid "Unknown "
 msgstr "Onbekend"
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -8007,7 +8016,7 @@ msgstr "Onbekend rekeningtype; moet een header (H) of rekening (A) zijn"
 msgid "Unknown database found."
 msgstr "Onbekende database aangetroffen"
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8059,20 +8068,20 @@ msgstr "Ongebruikt"
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Bijwerken"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Bijgewerkt"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8134,7 +8143,7 @@ msgstr "Gebruik voorschot Debiteuren factuur"
 msgid "Use Overpayment"
 msgstr "Gebruik voorschot"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr "Gebruik verzendadres"
 
@@ -8220,8 +8229,8 @@ msgstr "Afwijking:"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8240,7 +8249,7 @@ msgstr "Leveranciers Rekening "
 msgid "Vendor History"
 msgstr "Leverancierhistorie"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Inkoopfactuur"
@@ -8256,7 +8265,7 @@ msgstr "Leveranciernaam"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8279,7 +8288,7 @@ msgstr "Leveranciernummer"
 msgid "Vendor Search"
 msgstr "Leverancier zoeken"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Leverancier ontbreekt!"
 
@@ -8316,7 +8325,7 @@ msgstr "Lonen en inhoudingen"
 msgid "Wages/Deductions"
 msgstr "Lonen/Inhoudingen"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8393,7 +8402,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Wat voor soort artikel is dit?"
 
@@ -8409,7 +8418,7 @@ msgstr "Maandelijks lineair"
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8467,7 +8476,7 @@ msgstr "Jaarafsluiting afgerond"
 msgid "Years"
 msgstr "jaren"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
@@ -8486,11 +8495,11 @@ msgstr "Postcode"
 msgid "Zero"
 msgstr "nul"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Postcode"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Postcode"
 
@@ -8559,7 +8568,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "(Woon)plaats"
 
@@ -8603,7 +8612,7 @@ msgstr "gebeurd"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "p.st."
 

--- a/locale/po/nl_BE.po
+++ b/locale/po/nl_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Dutch (Belgium) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/nl_BE/)\n"
@@ -188,7 +188,7 @@ msgstr "Afschrijving"
 msgid "Access Denied"
 msgstr "Toegang geweigerd"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -196,9 +196,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -206,7 +206,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -317,7 +317,7 @@ msgstr "Aangegroeid"
 msgid "Accrual Basis:"
 msgstr "Aangroeibasis:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Cum. Afschrijving"
 
@@ -426,7 +426,7 @@ msgstr "Debetmemo toevoegen"
 msgid "Add Employee"
 msgstr "Werknemer toevoegen"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Wisselkoers toevoegen"
 
@@ -462,11 +462,11 @@ msgstr "Artikel toevoegen"
 msgid "Add Pricegroup"
 msgstr "Prijsgroep toevoegen"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Inkooporder toevoegen"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Offerte toevoegen"
 
@@ -474,7 +474,7 @@ msgstr "Offerte toevoegen"
 msgid "Add Reporting Unit"
 msgstr "Rapportage-eenheid Toevoegen"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Offerteaanvraag toevoegen"
 
@@ -486,11 +486,11 @@ msgstr "Retour Toevoegen"
 msgid "Add SIC"
 msgstr "SIC toevoegen"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Verkoopfactuur toevoegen"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Verkooporder toevoegen"
 
@@ -506,7 +506,7 @@ msgstr "Belastingformulier Toevoegen"
 msgid "Add Timecard"
 msgstr "Tijdregistratie Toevoegen"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Aan lijst Toevoegen"
 
@@ -528,7 +528,7 @@ msgstr "Gebruiker toevoegen"
 msgid "Add Vendor"
 msgstr "Leverancier toevoegen"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Inkoop factuur toevoegen"
 
@@ -540,15 +540,15 @@ msgstr "Inkoopretour Toevoegen"
 msgid "Add Warehouse"
 msgstr "Magazijn toevoegen"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Regel 1 Toevoegen"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Regel 2 Toevoegen"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Regel 3 Toevoegen"
 
@@ -576,8 +576,8 @@ msgstr "Toegevoegde id [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -609,7 +609,7 @@ msgstr "Aanp."
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "Aangepaste basis"
 
@@ -686,9 +686,9 @@ msgstr "Invoer toestaan"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -791,8 +791,8 @@ msgstr "Goedkeuringsstatus"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Goedkeuren"
@@ -830,20 +830,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr "Verkregen prijs bij verkoop"
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr "Verkregen restwaarde"
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Weet u zeker dat u dit ordernummer wilt verwijderen?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Weet u zeker dat u dit offertenummer wilt verwijderen?"
 
@@ -916,16 +916,16 @@ msgstr "Activa code"
 msgid "Assets"
 msgstr "Activa"
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr "Activa naar Eigen vermogen"
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr "Activa naar Passiva"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Bijvoegen"
@@ -956,31 +956,31 @@ msgstr "Bijgevoegd op"
 msgid "Attached By"
 msgstr "Bijgevoegd door"
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr "Bijgevoegd aan"
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Bijgevoegd bestandstype"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr "Bijgevoegde bestanden en link naar bestanden"
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr "Bijgevoegd op"
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr "Bijgevoegd door"
@@ -1013,7 +1013,7 @@ msgstr "Augustus"
 msgid "Author: [_1]"
 msgstr "Auteur: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Automatisch"
 
@@ -1082,7 +1082,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balans"
@@ -1129,8 +1129,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr "Basis"
 
@@ -1142,7 +1142,7 @@ msgstr "Groep"
 msgid "Batch Class"
 msgstr "Groep soort"
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr "Batch Control Code"
 
@@ -1162,7 +1162,7 @@ msgstr "Groep ID"
 msgid "Batch ID Missing"
 msgstr "Gegroepeerd Afdrukken ID ontbreekt"
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr "Groep naam"
 
@@ -1209,14 +1209,14 @@ msgstr "miljard"
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Locatie"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "CSV"
 msgstr "CSV"
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr "Bereken BTW"
 
@@ -1324,12 +1324,12 @@ msgstr "Bereken BTW"
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "Teruggedraaide factuur niet terugdraaibaar!"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1379,7 +1379,7 @@ msgstr "Kan geen diensten aanmaken; Inkomstenrekening bestaat niet!"
 msgid "Cannot delete item!"
 msgstr "Kan onderdeel niet verwijderen!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Kan order niet verwijderen!"
 
@@ -1387,19 +1387,19 @@ msgstr "Kan order niet verwijderen!"
 msgid "Cannot delete posted transaction"
 msgstr "Geboekte transactie niet verwijderbaar"
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Kan offerte niet verwijderen!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Kan geen factuur boeken in afgesloten periode!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Kan geen betaling boeken voor afgesloten periode!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Kan geen boeking maken in afgesloten periode"
 
@@ -1410,15 +1410,15 @@ msgstr ""
 "Kan geen transactie boeken met een debit- en creditregel voor dezelfde "
 "rekening!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Kan transactie niet boeken!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Kan order niet opslaan!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Kan offerte niet opslaan!"
 
@@ -1438,7 +1438,8 @@ msgstr "Kaart ID"
 msgid "Cash"
 msgstr "Kas (contant)"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Kasrekening"
 
@@ -1499,7 +1500,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1615,7 +1616,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Bedrijf"
 
@@ -1648,7 +1649,7 @@ msgstr "Firma Telefoon"
 msgid "Company Sales Tax ID"
 msgstr "Firma BTW Nummer"
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1700,7 +1701,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr "Bevestig bewerking"
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Bevestig!"
 
@@ -1708,7 +1709,7 @@ msgstr "Bevestig!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr "Conflicteert met bestaande gegevens. Misschien heeft u het al ingevoerd"
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1751,8 +1752,8 @@ msgstr "Inhoud"
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1763,7 +1764,7 @@ msgstr "Inhoud"
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1812,7 +1813,7 @@ msgid "Copy to New Name"
 msgstr "Kopiëer naar nieuwe naam"
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Kost"
 
@@ -1824,19 +1825,19 @@ msgstr "Kostprijs van verkochte goederen"
 msgid "Could Not Load Template from DB"
 msgstr "Kon sjabloon niet uit DB ophalen"
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr "Kan gegevens niet opslaan Probeer opnieuw"
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Kon niet opslaan!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Kon geen inventaris overboeken!"
 
@@ -1856,8 +1857,8 @@ msgstr "Tegenpartij code"
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1921,7 +1922,7 @@ msgstr "Gemaakt op"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Credit"
 
@@ -1942,7 +1943,7 @@ msgstr "Crediteurenrekeningen"
 msgid "Credit Invoice"
 msgstr "Creditfactuur"
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1966,7 +1967,7 @@ msgstr "Credit"
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Val."
 
@@ -1975,7 +1976,7 @@ msgstr "Val."
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2012,7 +2013,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2042,7 +2043,7 @@ msgstr "Klantnaam"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2055,7 +2056,7 @@ msgstr "Klantnummer"
 msgid "Customer Search"
 msgstr "Klant zoeken"
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Klant ontbreekt!"
 
@@ -2071,7 +2072,7 @@ msgstr "Klant bestaat niet!"
 msgid "Customer/Vendor Accounts"
 msgstr "Klanten-/leveranciersrekeningen"
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr "Dag Maand"
 
@@ -2095,7 +2096,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr "Gegevens niet opgeslagen Probeer opnieuw"
 
@@ -2144,7 +2145,7 @@ msgstr "Database bestaat niet."
 msgid "Database exists."
 msgstr "Database bestaat al."
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2159,11 +2160,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2201,7 +2202,7 @@ msgstr "Betaaldatum"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Ontvangstdatum"
 
@@ -2225,7 +2226,7 @@ msgstr "Datum vanaf"
 msgid "Date of Birth"
 msgstr "Geboortedatum"
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Ontvangstdatum ontbreekt!"
 
@@ -2271,7 +2272,7 @@ msgstr "Dagen"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debet"
 
@@ -2384,9 +2385,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2436,16 +2437,16 @@ msgstr "Bezorging"
 msgid "Delivery Date"
 msgstr "Leverdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr "Afschr. Basis"
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr "Afschr. methode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr "Afschr. begint"
 
@@ -2453,11 +2454,11 @@ msgstr "Afschr. begint"
 msgid "Dep. Through"
 msgstr "Afschr. tot"
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr "Afschr. dit jr"
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr "Afschr. dit rapport"
 
@@ -2479,7 +2480,7 @@ msgstr "Afschrijven"
 msgid "Depreciate Through"
 msgstr "Afschrijvingen door"
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr "Afschrijving"
@@ -2531,13 +2532,13 @@ msgstr "Afschrijving begint"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2554,7 +2555,7 @@ msgstr "Afschrijving begint"
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2625,16 +2626,16 @@ msgstr "Korting (%)"
 msgid "Discount:"
 msgstr "Korting:"
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr "Verkregen restwaarde afschrijving"
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr "Verwijdering"
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr "Verwijderingsdatum"
 
@@ -2642,7 +2643,7 @@ msgstr "Verwijderingsdatum"
 msgid "Disposal Method"
 msgstr "Verwijderingsmethode"
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr "Verwijderingsrapport [_1] op datum [_2]"
 
@@ -2650,7 +2651,7 @@ msgstr "Verwijderingsrapport [_1] op datum [_2]"
 msgid "Division by 0 error"
 msgstr "Delen door 0 kan niet! Onmodelijk!"
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr "Laat dit veld niet leeg [_1]"
 
@@ -2666,7 +2667,7 @@ msgstr "Document Type"
 msgid "Don't know what to do with backup"
 msgstr "Onbekend welke aktie met backup"
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Klaar"
 
@@ -2686,7 +2687,7 @@ msgstr ""
 msgid "Dr."
 msgstr "Dr."
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr "Concept geboekt"
 
@@ -2728,14 +2729,14 @@ msgstr "Verschuldigd op"
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Vervaldatum"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Vervaldatum ontbreekt!"
 
@@ -2747,8 +2748,8 @@ msgstr "Dubbele gebruiker gevonden: gebruiker geïmporteerd"
 msgid "Duplicate employee numbers"
 msgstr "Werknemer Nummer"
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3052,11 +3053,11 @@ msgstr "Bedrijfseenheid"
 msgid "Entity Class"
 msgstr "Entiteitsoort"
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr "Bedrijfseenheid code"
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr "Bedrijfseenheid Control Code"
 
@@ -3072,7 +3073,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr "Invoer ID"
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr "Enveloppe"
@@ -3094,7 +3095,7 @@ msgstr "Eigenvermogen & passiva"
 msgid "Equity (Temporary)"
 msgstr "Eigenvermogen (Tijdelijk)"
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr "Eigen vermogen naar passiva"
 
@@ -3118,7 +3119,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr "Fout: Samenvattingsrekening niet combineerbaar met selectielijsten"
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr "Verw. Levensduur"
 
@@ -3126,20 +3127,20 @@ msgstr "Verw. Levensduur"
 msgid "Every"
 msgstr "Elke"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Wisselkoers"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Wisselkoers"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Wisselkoers voor Betaling ontbreekt!"
 
@@ -3147,7 +3148,7 @@ msgstr "Wisselkoers voor Betaling ontbreekt!"
 msgid "Exchange rate hasn't been defined!"
 msgstr "Wisselkoers is niet gedefinieerd!"
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Wisselkoers ontbreekt!"
 
@@ -3192,8 +3193,8 @@ msgstr "Extra gebruikt"
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3271,7 +3272,7 @@ msgstr "vijftig"
 msgid "File"
 msgstr "Bestand"
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr "Bestand geimporteerd"
 
@@ -3285,17 +3286,17 @@ msgstr "Bestandsnaam"
 msgid "File Type"
 msgstr "Bestandstype"
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr "Bestandsnaam"
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr "Bestandstype"
@@ -3332,7 +3333,7 @@ msgstr "Eerste"
 msgid "First Name"
 msgstr "Voornaam"
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr "Alleen eerste kolom"
 
@@ -3392,7 +3393,7 @@ msgstr "veertien"
 msgid "Fri"
 msgstr "Vrij"
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3424,7 +3425,7 @@ msgstr "Vanaf datum"
 msgid "From File"
 msgstr "Vanuit bestand"
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Van magazijn"
 
@@ -3473,7 +3474,7 @@ msgstr "Memoriaal referentiecode"
 msgid "Gain"
 msgstr "Winst"
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr "Winst  (Verlies)"
 
@@ -3481,7 +3482,7 @@ msgstr "Winst  (Verlies)"
 msgid "Gain Account"
 msgstr "Winstrekening"
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3510,11 +3511,11 @@ msgstr "Genereer"
 msgid "Generate Control Code"
 msgstr "Genereer controlecode"
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Genereer orders"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Genereer aankooporders"
 
@@ -3559,8 +3560,8 @@ msgid "Grand Total"
 msgstr "Totaal generaal"
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Groep"
 
@@ -3802,8 +3803,8 @@ msgstr "Interne databasefout"
 msgid "Internal Files"
 msgstr "Interne bestanden"
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Interne notities"
 
@@ -3865,11 +3866,11 @@ msgstr ""
 "Voorraadhoeveelheid moet nul zijn voordat dit artikel incourant aangemerkt "
 "kan worden"
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Voorraad opgeslagen"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Voorraad overgeheveld"
 
@@ -3877,8 +3878,8 @@ msgstr "Voorraad overgeheveld"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3896,22 +3897,22 @@ msgstr "Factuur"
 msgid "Invoice #"
 msgstr "Factuur #"
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr "Factuur aangemaakt"
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr "Factuur aanmaakdatum mist!"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Factuurdatum"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Factuurdatum ontbreekt!"
 
@@ -3927,8 +3928,8 @@ msgstr "Factuurnr"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3937,7 +3938,7 @@ msgstr "Factuurnr"
 msgid "Invoice Number"
 msgstr "Factuurnummer"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Factuurnummer ontbreekt!"
 
@@ -3995,7 +3996,7 @@ msgstr "Regel"
 msgid "Item deleted!"
 msgstr "Onderdeel verwijderd!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Dit onderdeel is niet in de database gevonden!"
 
@@ -4028,7 +4029,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Januari"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4069,7 +4070,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr "KPI's"
 
@@ -4133,7 +4134,7 @@ msgstr "Laatst bijgewerkt"
 msgid "Last name"
 msgstr "Achternaam"
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Prospect Klant"
 
@@ -4354,11 +4355,11 @@ msgstr "Vergrendeld door [_1]"
 msgid "Logged out due to inactivity"
 msgstr "Uitgelogd door inactiviteit"
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4437,7 +4438,7 @@ msgstr "Manager"
 msgid "Manager:"
 msgstr "Manager:"
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr "Handmatig"
 
@@ -4468,9 +4469,9 @@ msgid "May"
 msgstr "Mei"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memo"
@@ -4823,15 +4824,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4845,15 +4846,15 @@ msgstr "Opmerkingen"
 msgid "Notes:<br />"
 msgstr "Notities:<br />"
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Niets ingevuld!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Niets geselecteerd!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Niets over te boeken!"
 
@@ -4878,7 +4879,7 @@ msgid "Null model numbers"
 msgstr "NULL modelnummers"
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4897,7 +4898,7 @@ msgstr "Nummer"
 msgid "Number Format"
 msgstr "Nummeraanduiding"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr "Getal mist in regel [_1]"
 
@@ -4935,7 +4936,7 @@ msgstr "Okt"
 msgid "October"
 msgstr "Oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr "Uit de wacht"
 
@@ -4950,7 +4951,7 @@ msgstr "Oud wachtwoord"
 msgid "On Hand"
 msgstr "Op voorraad"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr "Wacht"
@@ -5005,7 +5006,7 @@ msgstr "Of Voeg toe aan Groep"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Bestelling"
 
@@ -5023,12 +5024,12 @@ msgstr "Order #"
 msgid "Order By"
 msgstr "Order door"
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Orderdatum"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Geen order datum aanwezig"
 
@@ -5040,8 +5041,8 @@ msgstr "Order invoer"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5049,15 +5050,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Referentie"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Geen ordernummer aanwezig"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Order verwijderd!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Genereren order mislukt!"
 
@@ -5144,8 +5145,8 @@ msgstr "PO #"
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5161,7 +5162,7 @@ msgstr "accorderen"
 msgid "POST AND PRINT"
 msgstr "accorderen en afdrukken"
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5169,11 +5170,11 @@ msgstr "accorderen en afdrukken"
 msgid "Packing List"
 msgstr "Pakbon"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Pakbon datum ontbreekt!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Pakbon nummer ontbreekt!"
 
@@ -5197,7 +5198,7 @@ msgstr "Betaald"
 msgid "Parent"
 msgstr "Parent"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artikel"
 
@@ -5217,8 +5218,8 @@ msgstr "Artikelgroep"
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5239,7 +5240,7 @@ msgstr ""
 msgid "Partial"
 msgstr "Gedeeltelijk"
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr "Gedeeltelijk afschrijvingsrapportage [_1] op datum [_2]"
 
@@ -5269,7 +5270,7 @@ msgstr "Artikelgroep"
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -5338,7 +5339,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Geen betalingsdatum aanwezig!"
 
@@ -5350,7 +5351,7 @@ msgstr "Betaling verschuldigd NET [_1] dagen vanaf factuurdatum"
 msgid "Payment due by [_1]."
 msgstr "Betaling verschuldigd op [_1]."
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5359,7 +5360,7 @@ msgstr "Betaling verschuldigd op [_1]."
 msgid "Payments"
 msgstr "Betalingen"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr "Betalingen m.b.t. niet geldige facturen moeten worden teruggeboekt"
 
@@ -5367,11 +5368,11 @@ msgstr "Betalingen m.b.t. niet geldige facturen moeten worden teruggeboekt"
 msgid "Percent"
 msgstr "procent"
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr "Percentage verwijderd"
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr "Resterend Percentage"
 
@@ -5406,7 +5407,7 @@ msgstr "Tel."
 msgid "Physical"
 msgstr "Fysiek"
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5546,8 +5547,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Boek"
@@ -5564,7 +5565,7 @@ msgstr "Boekdatum"
 msgid "Post Yearend"
 msgstr "Boek jaarafsluiting"
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Boek als nieuw"
 
@@ -5659,9 +5660,9 @@ msgid "Primary Phone"
 msgstr "Eerste telefoonnummer"
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Afdrukken"
@@ -5670,11 +5671,11 @@ msgstr "Afdrukken"
 msgid "Print Batch"
 msgstr "Print groep"
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Afdrukken en Opslaan"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Afdrukken en Sla op als nieuw"
 
@@ -5726,15 +5727,15 @@ msgstr "Afdrukken transactie [_1]"
 msgid "Printing Work Order [_1]"
 msgstr "Afdrukken werkbon [_1]"
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr "Eerdere afschr."
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr "Voorafgaand aan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr "vervolgt"
 
@@ -5756,7 +5757,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr "Winst en verlies"
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr "Verlies/Winst"
 
@@ -5799,8 +5800,8 @@ msgstr "Inkoopdatum:"
 msgid "Purchase History"
 msgstr "Inkoophistorie"
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5839,7 +5840,7 @@ msgstr "Gekocht"
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5869,8 +5870,8 @@ msgid "Quarter"
 msgstr "Kwartaal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5886,7 +5887,7 @@ msgstr "Offerte #"
 msgid "Quotation Date"
 msgstr "Offertedatum"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Offertedatum ontbreekt!"
 
@@ -5894,11 +5895,11 @@ msgstr "Offertedatum ontbreekt!"
 msgid "Quotation Number"
 msgstr "Offertenummer"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Offertenummer ontbreekt!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Offerte verwijderd!"
 
@@ -5913,7 +5914,7 @@ msgstr "Offertes"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5939,7 +5940,7 @@ msgstr "Offerteaanvragen"
 msgid "ROP"
 msgstr "Minimum voorraad"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5980,7 +5981,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr "Herbouwen/upgraden?"
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Ontvangen"
 
@@ -6009,7 +6010,7 @@ msgstr "Vorderingen"
 msgid "Receive"
 msgstr "Inkomende zending"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Goederen Ontvangen"
 
@@ -6037,7 +6038,7 @@ msgstr "Aansluitrapport"
 msgid "Reconciliation Reports"
 msgstr "Aansluitrapporten"
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Boeken op"
 
@@ -6063,11 +6064,11 @@ msgstr "Geplande Transacties"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referentie"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr "Referentienummer mist"
 
@@ -6104,9 +6105,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr "Verwachte resterende levensduur"
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resterend"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6134,7 +6139,7 @@ msgstr ""
 msgid "Report Name"
 msgstr "Rapportnaam"
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr "Rapportresultaat"
 
@@ -6146,7 +6151,7 @@ msgstr "Rapport ingediend"
 msgid "Report Type"
 msgstr "Rapportsoort"
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr "Rapport [_1] op datum [_2]"
 
@@ -6182,11 +6187,11 @@ msgstr "Rapporten"
 msgid "Reposting Not Allowed"
 msgstr "Heraccordering niet toegestaan"
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Gevr"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6307,11 +6312,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr "SIC:"
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6340,7 +6345,7 @@ msgstr "Verkoopfactuur"
 msgid "Sales"
 msgstr "Verkoop"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Verkoopfactuur"
@@ -6349,8 +6354,8 @@ msgstr "Verkoopfactuur"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Verkoopfactuur/Transactienummer Debiteuren"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6415,7 +6420,7 @@ msgstr "Zater"
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6460,7 +6465,7 @@ msgstr "Opslaan"
 msgid "Save Groups"
 msgstr "Groepen opslaan"
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr "Locatie opslaan"
 
@@ -6468,7 +6473,7 @@ msgstr "Locatie opslaan"
 msgid "Save New"
 msgstr "Nieuw opslaan"
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr "Nieuwe locatie opslaan"
 
@@ -6485,7 +6490,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Opslaan als nieuw"
@@ -6494,7 +6499,7 @@ msgstr "Opslaan als nieuw"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6532,7 +6537,7 @@ msgstr "Opslaan [_1] [_2]"
 msgid "Saving over an existing document.  Continue?"
 msgstr "Opslaan en bestaand document vervangen?"
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6545,12 +6550,12 @@ msgstr "Opslaan en bestaand document vervangen?"
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Inplannen"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Ingepland"
 
@@ -6691,11 +6696,11 @@ msgstr "Selecteer Klant"
 msgid "Select Templates to Load"
 msgstr "Kies sjablonen om te laden"
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Selecteer Leverancier"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecteer een Printer"
 
@@ -6715,12 +6720,12 @@ msgstr "Kies facturen"
 msgid "Select or Enter User"
 msgstr "Selecteer gebruiker of voer een gebruiker in"
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Kies postscript of PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Kiest txt, postscript of PDF!"
 
@@ -6811,7 +6816,7 @@ msgstr "Volgnummers"
 msgid "Serial #"
 msgstr "Serie#"
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serienr"
 
@@ -6829,11 +6834,11 @@ msgstr "Serienummer"
 msgid "Serialnumber"
 msgstr "Serienummer"
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Dienst"
 
@@ -6877,13 +6882,13 @@ msgstr "zeventien"
 msgid "Seventy"
 msgstr "zeventig"
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Verzenden"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Goederen Verzenden"
 
@@ -6913,12 +6918,12 @@ msgstr "Verzenden aan:"
 msgid "Ship Via"
 msgstr "Verzenden met"
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Verzenden aan"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6935,23 +6940,23 @@ msgstr "Verzenden via"
 msgid "Shipping"
 msgstr "Zendingen"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Verzenddatum"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Verzenddatum ontbreekt!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr "Verzendlabel"
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7027,12 +7032,12 @@ msgstr "Sommige"
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7114,11 +7119,11 @@ msgstr "Startdatum"
 msgid "Starting Date:"
 msgstr "Startdatum:"
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Provincie"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7202,7 +7207,7 @@ msgstr "Indienen"
 msgid "Submitted"
 msgstr "Verstuurd"
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7265,8 +7270,8 @@ msgstr "TOTAAL"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Label"
 
@@ -7288,7 +7293,7 @@ msgstr "Belasting"
 msgid "Tax Account"
 msgstr "Belastingrekening"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr "BTW Code"
 
@@ -7298,7 +7303,7 @@ msgstr "BTW Code"
 msgid "Tax Form"
 msgstr "Belastingformulier"
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr "Belasting formulier toegepast"
 
@@ -7322,7 +7327,7 @@ msgstr "Belastingformulierrapporten"
 msgid "Tax Forms"
 msgstr "Belasting formulieren"
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr "BTW#"
 
@@ -7330,7 +7335,7 @@ msgstr "BTW#"
 msgid "Tax ID/SSN"
 msgstr "BTW/BSN#"
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Inclusief Belasting"
@@ -7429,7 +7434,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr "Sjablonenlijst"
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr "Sjabloon opgeslagen!"
 
@@ -7651,7 +7656,7 @@ msgstr "Keren"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7686,7 +7691,7 @@ msgstr "tot Datum"
 msgid "To Pay"
 msgstr "Betalen"
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Naar Magazijn"
 
@@ -7732,7 +7737,7 @@ msgstr "Hoogste Niveau"
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7753,7 +7758,7 @@ msgstr "Hoogste Niveau"
 msgid "Total"
 msgstr "Totaal"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr "Totaal afschrijvingen"
 
@@ -7765,6 +7770,10 @@ msgstr "Totaal openstaand"
 msgid "Total Paid"
 msgstr "Totaal betaald"
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Magazijngoederen"
@@ -7773,7 +7782,7 @@ msgstr "Magazijngoederen"
 msgid "Trade Discount"
 msgstr "Handelskorting"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Boeking"
 
@@ -7806,20 +7815,20 @@ msgstr "Boekingtype"
 msgid "Transactions"
 msgstr "Boekingen"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Overboeking"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Inventaris overboeken"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Overdragen van"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Overboeken naar"
 
@@ -7906,7 +7915,7 @@ msgstr "twee"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7967,7 +7976,7 @@ msgstr "Unieke geldige artikelnummers"
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7983,7 +7992,7 @@ msgstr "Eenheidsprijs"
 msgid "Unknown "
 msgstr "Onbekend"
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -8003,7 +8012,7 @@ msgstr "Onbekend rekeningtype; moet een header (H) of rekening (A) zijn"
 msgid "Unknown database found."
 msgstr "Onbekende database aangetroffen"
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8055,20 +8064,20 @@ msgstr "Ongebruikt"
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Bijwerken"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Bijgewerkt"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8130,7 +8139,7 @@ msgstr "Gebruik voorschot Debiteuren factuur"
 msgid "Use Overpayment"
 msgstr "Gebruik voorschot"
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr "Gebruik verzendadres"
 
@@ -8216,8 +8225,8 @@ msgstr "Afwijking:"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8236,7 +8245,7 @@ msgstr "Leveranciers Rekening "
 msgid "Vendor History"
 msgstr "Leverancier Historie"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Inkoopfaktuur"
@@ -8252,7 +8261,7 @@ msgstr "Leveranciernaam"
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8275,7 +8284,7 @@ msgstr "Leveranciernummer"
 msgid "Vendor Search"
 msgstr "Leverancier zoeken"
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Leverancier ontbreekt!"
 
@@ -8312,7 +8321,7 @@ msgstr "Lonen en inhoudingen"
 msgid "Wages/Deductions"
 msgstr "Lonen/Inhoudingen"
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8389,7 +8398,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Wat voor soort artikel is dit?"
 
@@ -8405,7 +8414,7 @@ msgstr "Maandelijks lineair"
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8463,7 +8472,7 @@ msgstr "Jaarafsluiting afgerond"
 msgid "Years"
 msgstr "jaren"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
@@ -8482,11 +8491,11 @@ msgstr "Postcode"
 msgid "Zero"
 msgstr "nul"
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr "Postcode"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr "Postcode"
 
@@ -8555,7 +8564,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr "(Woon)plaats"
 
@@ -8599,7 +8608,7 @@ msgstr "gebeurd"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "voor"
 

--- a/locale/po/pl.po
+++ b/locale/po/pl.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Polish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "pl/)\n"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -194,9 +194,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -204,7 +204,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -315,7 +315,7 @@ msgstr "Narzut"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Dodaj Pracownika"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Dodaj Kurs Walut"
 
@@ -460,11 +460,11 @@ msgstr "Dodaj Produkt"
 msgid "Add Pricegroup"
 msgstr "Dodaj Grupę Cenową"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Dodaj Zamówienie Zakupu"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Dodaj Ofertę"
 
@@ -472,7 +472,7 @@ msgstr "Dodaj Ofertę"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Dodaj Prośbę o Ofertę"
 
@@ -484,11 +484,11 @@ msgstr "Dodaj zwrot"
 msgid "Add SIC"
 msgstr "Dodaj EKD"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Zarejestrój Fakturę VAT Sprzedaży"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Dodaj Zlecenie Sprzedaży"
 
@@ -504,7 +504,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr "Dodaj Użytkownika"
 msgid "Add Vendor"
 msgstr "Dodaj Dostawcę"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Zarejestrój Fakturę VAT Zakupu"
 
@@ -538,15 +538,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Dodaj Magazyn"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -574,8 +574,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -607,7 +607,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -684,9 +684,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -789,8 +789,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -828,20 +828,20 @@ msgstr "Kwiecień"
 msgid "April"
 msgstr "Kwiecień"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Czy chcesz usunąć Numer Zamówienia?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Czy chcesz usunąć Numer Oferty?"
 
@@ -914,16 +914,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -954,31 +954,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1011,7 +1011,7 @@ msgstr "Sierpień"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilans"
@@ -1127,8 +1127,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1140,7 +1140,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1207,14 +1207,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Kosz"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1314,7 +1314,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1322,12 +1322,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Nie możesz usunąć pozycji!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Nie możesz usunąć zamówienia!"
 
@@ -1385,19 +1385,19 @@ msgstr "Nie możesz usunąć zamówienia!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Nie możesz usunąć oferty"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Nie można zksięgować faktury po zamknięciu okresu!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Nie można zaksięgować płatności po zamknięciu okresu!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Nie można zaksięgować transakcji po zamknięciu okresu!"
 
@@ -1406,15 +1406,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Nie możesz zatwierdzić transakcji!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Nie można zapisać zamowienia!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Nie można zapisać oferty!"
 
@@ -1434,7 +1434,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Kasa"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1495,7 +1496,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1611,7 +1612,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Firma"
 
@@ -1644,7 +1645,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1696,7 +1697,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Potwierdż!"
 
@@ -1704,7 +1705,7 @@ msgstr "Potwierdż!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1747,8 +1748,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1759,7 +1760,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1808,7 +1809,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Koszt"
 
@@ -1820,19 +1821,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Nie może zapisać!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Nie może przesunąć Inwentarza"
 
@@ -1852,8 +1853,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1917,7 +1918,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredyt"
 
@@ -1938,7 +1939,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1962,7 +1963,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Waluta"
 
@@ -1971,7 +1972,7 @@ msgstr "Waluta"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2008,7 +2009,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2038,7 +2039,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2051,7 +2052,7 @@ msgstr "Numer Odbiorcy"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Brak Odbiorcy"
 
@@ -2067,7 +2068,7 @@ msgstr "Brak Odbiorcy w bazie danych"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2140,7 +2141,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2155,11 +2156,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2197,7 +2198,7 @@ msgstr "Data Zapłaty"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Data Wpłaty"
 
@@ -2221,7 +2222,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Brak Daty Wpłaty"
 
@@ -2267,7 +2268,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debet"
 
@@ -2380,9 +2381,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2432,16 +2433,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Data Dostawy"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2449,11 +2450,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2475,7 +2476,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2527,13 +2528,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2550,7 +2551,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2621,16 +2622,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2638,7 +2639,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2646,7 +2647,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2662,7 +2663,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Zrobione"
 
@@ -2682,7 +2683,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2724,14 +2725,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Termin Płatności"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Brak Terminu Płatności!"
 
@@ -2743,8 +2744,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3046,11 +3047,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3088,7 +3089,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3112,7 +3113,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3120,20 +3121,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Kurs Walut"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Kurs Walut"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Brakuje Kursu Walut dla płatności!"
 
@@ -3141,7 +3142,7 @@ msgstr "Brakuje Kursu Walut dla płatności!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Brakuje Kursu Walut"
 
@@ -3186,8 +3187,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Kurs Walut"
 
@@ -3265,7 +3266,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3279,17 +3280,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3326,7 +3327,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3386,7 +3387,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3418,7 +3419,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3467,7 +3468,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3475,7 +3476,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3504,11 +3505,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3553,8 +3554,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupa"
 
@@ -3796,8 +3797,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Noty Wewnętrzne"
 
@@ -3857,11 +3858,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inwentarz zapisany!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inwentarz przeniesiony!"
 
@@ -3869,8 +3870,8 @@ msgstr "Inwentarz przeniesiony!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3888,22 +3889,22 @@ msgstr "Faktura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Data Wystawienia"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Brak Daty Wystawienia"
 
@@ -3919,8 +3920,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3929,7 +3930,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Numer Faktury"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Brak Numeru Faktury"
 
@@ -3987,7 +3988,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Pozycja usunięta"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Produkt nie jest w zbiorze!"
 
@@ -4015,7 +4016,7 @@ msgstr "Styczeń"
 msgid "January"
 msgstr "Styczeń"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4056,7 +4057,7 @@ msgstr "Czerwiec"
 msgid "June"
 msgstr "Czerwiec"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4120,7 +4121,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4341,11 +4342,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Zarejestrój się"
 
@@ -4422,7 +4423,7 @@ msgstr "Kierownik"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4453,9 +4454,9 @@ msgid "May"
 msgstr "Maj"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Notatka"
@@ -4802,15 +4803,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4824,15 +4825,15 @@ msgstr "Noty"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Nic nie wprowadzono!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nic nie zaznaczone!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nie ma nic do przeniesienia!"
 
@@ -4857,7 +4858,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4876,7 +4877,7 @@ msgstr "Numer Katalogu"
 msgid "Number Format"
 msgstr "Format Numeru"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4914,7 +4915,7 @@ msgstr "Pażdziernik"
 msgid "October"
 msgstr "Pażdziernik"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4929,7 +4930,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Stan Zapasu Podręcznego"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4984,7 +4985,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Zlecenie"
 
@@ -5002,12 +5003,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data Zlecenia"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Brak Daty Zlecenia"
 
@@ -5019,8 +5020,8 @@ msgstr "Wystawianie Zleceń"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5028,15 +5029,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Numer ZLecenia"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Brak Numeru Zlecenia"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Zlecenie usunięte"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5123,8 +5124,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5140,7 +5141,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5148,11 +5149,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista Pakunkowa"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Brak Daty Listy Pakunkowej"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Brak Numeru Listy Pakunkowej"
 
@@ -5176,7 +5177,7 @@ msgstr "Zapłacono"
 msgid "Parent"
 msgstr "Rodzic"
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Produkt"
 
@@ -5196,8 +5197,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5218,7 +5219,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5248,7 +5249,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Hasło"
 
@@ -5317,7 +5318,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Brak Daty Wypłaty"
 
@@ -5329,7 +5330,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5338,7 +5339,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Wypłaty"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5346,11 +5347,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5385,7 +5386,7 @@ msgstr "Tel."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5516,8 +5517,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Zatwierdż"
@@ -5534,7 +5535,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Zatwierdż jako nowe"
 
@@ -5629,9 +5630,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Wydrukuj"
@@ -5640,11 +5641,11 @@ msgstr "Wydrukuj"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Wydrukuj i Zapisz"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5696,15 +5697,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5726,7 +5727,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5769,8 +5770,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5809,7 +5810,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5839,8 +5840,8 @@ msgid "Quarter"
 msgstr "Kwartał"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5856,7 +5857,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Data Oferty"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Brak Daty Oferty"
 
@@ -5864,11 +5865,11 @@ msgstr "Brak Daty Oferty"
 msgid "Quotation Number"
 msgstr "Numer Oferty"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Brak Numeru Oferty"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Oferta usunięta"
 
@@ -5883,7 +5884,7 @@ msgstr "Oferty"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5909,7 +5910,7 @@ msgstr "Prośby o Ofertę"
 msgid "ROP"
 msgstr "PPZ"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5950,7 +5951,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Otrzymano"
 
@@ -5979,7 +5980,7 @@ msgstr "Należności"
 msgid "Receive"
 msgstr "Dostawy"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Dostawy Towarów"
 
@@ -6007,7 +6008,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Zapisz w"
 
@@ -6033,11 +6034,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Odnośnik"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6074,9 +6075,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Pozostałe"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6104,7 +6109,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6152,11 +6157,11 @@ msgstr "Sprawozdania"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6277,11 +6282,11 @@ msgstr "EKD"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SWW"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6310,7 +6315,7 @@ msgstr "Sprzedaż"
 msgid "Sales"
 msgstr "Sprzedaż"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Faktura VAT Sprzedaży"
@@ -6319,8 +6324,8 @@ msgstr "Faktura VAT Sprzedaży"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6385,7 +6390,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6430,7 +6435,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6438,7 +6443,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6455,7 +6460,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Zapisz jako nowe"
@@ -6464,7 +6469,7 @@ msgstr "Zapisz jako nowe"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6502,7 +6507,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6515,12 +6520,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6661,11 +6666,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6685,12 +6690,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Wybierz postscript lub PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6781,7 +6786,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Nr. Sr."
 
@@ -6799,11 +6804,11 @@ msgstr "Numer Seryjny"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Usługi"
 
@@ -6847,13 +6852,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Wysyłka"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Wysyłka Produktów"
 
@@ -6883,12 +6888,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Wyślij do"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6905,23 +6910,23 @@ msgstr "Wyślij przez"
 msgid "Shipping"
 msgstr "Spedycja"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Dzień Dostawy"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Brak Dnia Dostawy!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6997,12 +7002,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7083,11 +7088,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Rejon"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7171,7 +7176,7 @@ msgstr "Wyślij"
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7234,8 +7239,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7257,7 +7262,7 @@ msgstr "Podatek"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7267,7 +7272,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7291,7 +7296,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7299,7 +7304,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Podatek Wliczony"
@@ -7398,7 +7403,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7618,7 +7623,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7653,7 +7658,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7699,7 +7704,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7720,7 +7725,7 @@ msgstr ""
 msgid "Total"
 msgstr "Wartość Brutto"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7732,6 +7737,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7740,7 +7749,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr "Rabat Handlowy"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Transakcja"
 
@@ -7773,20 +7782,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Zestawienia Transakcji"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Przelewy"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Przeniesienie Inventarza"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Przenieś z"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Przenieś do"
 
@@ -7873,7 +7882,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7934,7 +7943,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7950,7 +7959,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7968,7 +7977,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8020,20 +8029,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Uzupełnij"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Uzupełnione"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8095,7 +8104,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8181,8 +8190,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8201,7 +8210,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Statystyka Dostaw"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Faktura VAT Zakupu"
@@ -8217,7 +8226,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8240,7 +8249,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Brak Dostawcy"
 
@@ -8277,7 +8286,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8354,7 +8363,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Co to za rodzaj artykułu"
 
@@ -8370,7 +8379,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8428,7 +8437,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Tak"
@@ -8447,11 +8456,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8518,7 +8527,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8562,7 +8571,7 @@ msgstr "wykonane"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "szt"
 

--- a/locale/po/pt.po
+++ b/locale/po/pt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Portuguese (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/pt/)\n"
@@ -188,7 +188,7 @@ msgstr "Abandono"
 msgid "Access Denied"
 msgstr "Acesso não-permitido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -196,9 +196,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -206,7 +206,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -317,7 +317,7 @@ msgstr "Resultado final"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -426,7 +426,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Adicionar Empregado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Adicionar Taxa de Câmbio"
 
@@ -462,11 +462,11 @@ msgstr "Novo Produto"
 msgid "Add Pricegroup"
 msgstr "Adicionar Grupo de Preços"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Nova Ordem de Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Adicionar Cotação"
 
@@ -474,7 +474,7 @@ msgstr "Adicionar Cotação"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Adicionar Requisição de Cotação"
 
@@ -486,11 +486,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Adicionar SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Nova Factura de Venda"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Nova Encomenda de Cliente"
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr "Novo Utilizador"
 msgid "Add Vendor"
 msgstr "Novo Fornecedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Nova Factura de Compra"
 
@@ -540,15 +540,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Adicionar Almoxarifado"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -576,8 +576,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -609,7 +609,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -686,9 +686,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -791,8 +791,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -830,20 +830,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Confirma a remoção da Encomenda?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Tem certeza que quer APAGAR tal número de Cotação?"
 
@@ -916,16 +916,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -956,31 +956,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1013,7 +1013,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Folha de Balanço"
@@ -1129,8 +1129,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1209,14 +1209,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Bin"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Não é possivel apagar o item!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Não é possivel apagar a encomenda!"
 
@@ -1387,19 +1387,19 @@ msgstr "Não é possivel apagar a encomenda!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Não é possível apagar a cotação"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Não pode lançar factura em período fechado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Não pode lançar pagamento em período fechado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Não é possivel lançar transacção para um periodo fechado!"
 
@@ -1410,15 +1410,15 @@ msgstr ""
 "Não é possível lançar a transação com o mesmo valor para a conta de débito e "
 "de crédito"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Não é possivel lançar transacção"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Não é possível guardar encomenda!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Não é possível salvar a cotação!"
 
@@ -1438,7 +1438,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Dinheiro"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1499,7 +1500,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1615,7 +1616,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Companhia"
 
@@ -1648,7 +1649,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1700,7 +1701,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar!"
 
@@ -1708,7 +1709,7 @@ msgstr "Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1751,8 +1752,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1763,7 +1764,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1812,7 +1813,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Custo"
 
@@ -1824,19 +1825,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Não é possível salvar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Não é possível transferir inventário!"
 
@@ -1856,8 +1857,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1921,7 +1922,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1942,7 +1943,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1966,7 +1967,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Moeda"
 
@@ -1975,7 +1976,7 @@ msgstr "Moeda"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2012,7 +2013,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2042,7 +2043,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2055,7 +2056,7 @@ msgstr "Número do Cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Falta cliente!"
 
@@ -2071,7 +2072,7 @@ msgstr "Cliente inexistente!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2095,7 +2096,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2144,7 +2145,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2159,11 +2160,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2201,7 +2202,7 @@ msgstr "Data de pagamento"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Data de recebimento"
 
@@ -2225,7 +2226,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Data de recebimento faltando!"
 
@@ -2271,7 +2272,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2384,9 +2385,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2436,16 +2437,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Data de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2453,11 +2454,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2479,7 +2480,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2531,13 +2532,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2554,7 +2555,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2625,16 +2626,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2642,7 +2643,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2650,7 +2651,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2666,7 +2667,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Pronto"
 
@@ -2686,7 +2687,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2728,14 +2729,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Data de Vencimento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Falta Data de Vencimento!"
 
@@ -2747,8 +2748,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-Mail"
 
@@ -3050,11 +3051,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3070,7 +3071,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3092,7 +3093,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3116,7 +3117,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3124,20 +3125,20 @@ msgstr ""
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Câmbio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Taxa de Câmbio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Falta a taxa de câmbio para o pagamento!"
 
@@ -3145,7 +3146,7 @@ msgstr "Falta a taxa de câmbio para o pagamento!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Falta a taxa de câmbio!"
 
@@ -3190,8 +3191,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3269,7 +3270,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3283,17 +3284,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3330,7 +3331,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3390,7 +3391,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3422,7 +3423,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Do Almoxarifado"
 
@@ -3471,7 +3472,7 @@ msgstr "Número de Referência da Conta"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3479,7 +3480,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3508,11 +3509,11 @@ msgstr "Gerar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Gerar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Gerar Ordens de Compra"
 
@@ -3557,8 +3558,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3800,8 +3801,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas internas"
 
@@ -3861,11 +3862,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventário salvo!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventário transferido!"
 
@@ -3873,8 +3874,8 @@ msgstr "Inventário transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3892,22 +3893,22 @@ msgstr "Factura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Data de Factura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Data de Factura não encontrada!"
 
@@ -3923,8 +3924,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3933,7 +3934,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número de Factura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Número de Factura não encontrado!"
 
@@ -3991,7 +3992,7 @@ msgstr "Item"
 msgid "Item deleted!"
 msgstr "Item apagado"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Item não está no arquivo!"
 
@@ -4019,7 +4020,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Janeiro"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4060,7 +4061,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junho"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4124,7 +4125,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Lead"
 
@@ -4345,11 +4346,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Login"
 
@@ -4426,7 +4427,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4457,9 +4458,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memorando"
@@ -4806,15 +4807,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4828,15 +4829,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Nada entrou!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nada seleccionado"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nada a transferir!"
 
@@ -4861,7 +4862,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4880,7 +4881,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato numérico"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4918,7 +4919,7 @@ msgstr "Out"
 msgid "October"
 msgstr "Outubro"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4933,7 +4934,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Em Stock"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4988,7 +4989,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Encomenda"
 
@@ -5006,12 +5007,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data da Encomenda"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Falta data da Encomenda"
 
@@ -5023,8 +5024,8 @@ msgstr "Encomendas de Clientes"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5032,15 +5033,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Encomenda Número"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Falta numero da Encomenda!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Encomenda apagada"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "A geração de pedidos falhou!"
 
@@ -5127,8 +5128,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5144,7 +5145,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5152,11 +5153,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Expedição"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Data da lista de conteúdo faltando!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Falta Numero de Lista de Expedição"
 
@@ -5180,7 +5181,7 @@ msgstr "Total Pago"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Produto"
 
@@ -5200,8 +5201,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5222,7 +5223,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5252,7 +5253,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Password"
 
@@ -5321,7 +5322,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Falta Data de Pagamento!"
 
@@ -5333,7 +5334,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5342,7 +5343,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagamentos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5350,11 +5351,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5389,7 +5390,7 @@ msgstr "Fone"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5520,8 +5521,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Processar"
@@ -5538,7 +5539,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Processar como novo"
 
@@ -5633,9 +5634,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5644,11 +5645,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir e Salvar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir e Salvar como Novo"
 
@@ -5700,15 +5701,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5730,7 +5731,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5773,8 +5774,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5813,7 +5814,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5843,8 +5844,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5860,7 +5861,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Data da Cotação"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Data da Cotação faltando!"
 
@@ -5868,11 +5869,11 @@ msgstr "Data da Cotação faltando!"
 msgid "Quotation Number"
 msgstr "Número da Cotação"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Número da Cotação faltando!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Cotação apagada!"
 
@@ -5887,7 +5888,7 @@ msgstr "Cotações"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5913,7 +5914,7 @@ msgstr "RDCs"
 msgid "ROP"
 msgstr "Nível mínimo de stock"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5954,7 +5955,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Recebido"
 
@@ -5983,7 +5984,7 @@ msgstr "A Receber"
 msgid "Receive"
 msgstr "Receber"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Receber Mercadoria"
 
@@ -6011,7 +6012,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registar em"
 
@@ -6037,11 +6038,11 @@ msgstr "Transações Recorrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referência"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6078,9 +6079,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Sobram"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6120,7 +6125,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6156,11 +6161,11 @@ msgstr "Relatórios"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Req"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6281,11 +6286,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6314,7 +6319,7 @@ msgstr "Venda"
 msgid "Sales"
 msgstr "Vendas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Factura de Venda"
@@ -6323,8 +6328,8 @@ msgstr "Factura de Venda"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Fatura de Venda/Númenro da Transação de CR"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6389,7 +6394,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6442,7 +6447,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6459,7 +6464,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Guardar como novo"
@@ -6468,7 +6473,7 @@ msgstr "Guardar como novo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6506,7 +6511,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6519,12 +6524,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programação"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6665,11 +6670,11 @@ msgstr "Selecionar Cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Selecionar Fornecedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecione uma Impressora!"
 
@@ -6689,12 +6694,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Seleccione PostScript ou PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Selecionar txt, Postscript ou PDF!"
 
@@ -6785,7 +6790,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Nº Série"
 
@@ -6803,11 +6808,11 @@ msgstr "Número de Série"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Serviço"
 
@@ -6851,13 +6856,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Expedir"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Despachar mercadoria"
 
@@ -6887,12 +6892,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Expedir para"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6909,23 +6914,23 @@ msgstr "Expedir via"
 msgid "Shipping"
 msgstr "Despacho de Mercadorias"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Data do Despacho"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Data do Despacho faltando!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7001,12 +7006,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7087,11 +7092,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7175,7 +7180,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7238,8 +7243,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7261,7 +7266,7 @@ msgstr "Imposto"
 msgid "Tax Account"
 msgstr "Conts de Imposto"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7271,7 +7276,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7303,7 +7308,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impostos incluídos"
@@ -7402,7 +7407,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7622,7 +7627,7 @@ msgstr "Vêzes"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7657,7 +7662,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Para o Almoxarifado"
 
@@ -7703,7 +7708,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7724,7 +7729,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7736,6 +7741,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Itens Rastreáveis"
@@ -7744,7 +7753,7 @@ msgstr "Itens Rastreáveis"
 msgid "Trade Discount"
 msgstr "Desconto de comércio"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Transação"
 
@@ -7777,20 +7786,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Tansações"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferir"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferência de Inventário"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Trasnferir de"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir para"
 
@@ -7877,7 +7886,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7938,7 +7947,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7954,7 +7963,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7972,7 +7981,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8024,20 +8033,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Actualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Actualizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8099,7 +8108,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8185,8 +8194,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8205,7 +8214,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Histórico do Fornecedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Factura de Compra"
@@ -8221,7 +8230,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8244,7 +8253,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Falta fornecedor"
 
@@ -8281,7 +8290,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8358,7 +8367,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Que tipo de Item é este?"
 
@@ -8374,7 +8383,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8432,7 +8441,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sim"
@@ -8451,11 +8460,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8522,7 +8531,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8566,7 +8575,7 @@ msgstr "feito"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "cd"
 

--- a/locale/po/pt_BR.po
+++ b/locale/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Rodrigo de Almeida Sottomaior Macedo "
 "<rmsolucoeseminformatica@protonmail.com>, 2016\n"
@@ -191,7 +191,7 @@ msgstr "Abandono"
 msgid "Access Denied"
 msgstr "Acesso não-permitido"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -199,9 +199,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -209,7 +209,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -320,7 +320,7 @@ msgstr "Resultado final"
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Adicionar Empregado"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Adicionar Taxa de Câmbio"
 
@@ -465,11 +465,11 @@ msgstr "Adicionar Item"
 msgid "Add Pricegroup"
 msgstr "Adicionar Grupo de Preços"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Adicionar Ordem de Compra"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Adicionar Cotação"
 
@@ -477,7 +477,7 @@ msgstr "Adicionar Cotação"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Adicionar Requisição de Cotação"
 
@@ -489,11 +489,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Adicionar SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Adicionar Fatura de Venda"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Adicionar Pedido de Venda"
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr "Adicionar Usuário"
 msgid "Add Vendor"
 msgstr "Adicionar Fornecedor"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Adicionar Fatura de Compra"
 
@@ -543,15 +543,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Adicionar Almoxarifado"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -579,8 +579,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -689,9 +689,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -794,8 +794,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -833,20 +833,20 @@ msgstr "Abr"
 msgid "April"
 msgstr "Abril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Tem certeza que quer APAGAR tal número de Pedido?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Tem certeza que quer APAGAR tal número de Cotação?"
 
@@ -919,16 +919,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -959,31 +959,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1016,7 +1016,7 @@ msgstr "Agosto"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgid "Balance"
 msgstr "Balanço"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Folha de Balanço"
@@ -1132,8 +1132,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1165,7 +1165,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1212,14 +1212,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Preteleira"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1327,12 +1327,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Não é possível apagar o item!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Não é possível apagar o pedido!"
 
@@ -1390,19 +1390,19 @@ msgstr "Não é possível apagar o pedido!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Não é possível apagar a cotação"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Não é possível lançar a fatura em período fechado!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Não é possível lançar o pagamento em período fechado!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Não é possível lançar a transação para um período já encerrado!"
 
@@ -1413,15 +1413,15 @@ msgstr ""
 "Não é possível lançar a transação com o mesmo valor para a conta de débito e "
 "de crédito"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Não é possível lançar a transação!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Não é possível salvar o pedido!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Não é possível salvar a cotação!"
 
@@ -1441,7 +1441,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Caixa"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1502,7 +1503,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1618,7 +1619,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Empresa"
 
@@ -1651,7 +1652,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1703,7 +1704,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Confirmar!"
 
@@ -1711,7 +1712,7 @@ msgstr "Confirmar!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1754,8 +1755,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1766,7 +1767,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1815,7 +1816,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Custo"
 
@@ -1827,19 +1828,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Não é possível salvar!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Não é possível transferir inventário!"
 
@@ -1859,8 +1860,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1924,7 +1925,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Crédito"
 
@@ -1945,7 +1946,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Moeda"
 
@@ -1978,7 +1979,7 @@ msgstr "Moeda"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2015,7 +2016,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2045,7 +2046,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2058,7 +2059,7 @@ msgstr "Número do Cliente"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Cliente faltando!"
 
@@ -2074,7 +2075,7 @@ msgstr "Cliente não está no arquivo!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2098,7 +2099,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2147,7 +2148,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2162,11 +2163,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2204,7 +2205,7 @@ msgstr "Data de pagamento"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Data de recebimento"
 
@@ -2228,7 +2229,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Data de recebimento faltando!"
 
@@ -2274,7 +2275,7 @@ msgstr "Dias"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Débito"
 
@@ -2387,9 +2388,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2439,16 +2440,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Data de entrega"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2456,11 +2457,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2482,7 +2483,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2534,13 +2535,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2557,7 +2558,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2628,16 +2629,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2645,7 +2646,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2653,7 +2654,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2669,7 +2670,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Feito"
 
@@ -2689,7 +2690,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2731,14 +2732,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Data de Vencimento"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Data de Vencimento faltando!"
 
@@ -2750,8 +2751,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3053,11 +3054,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3073,7 +3074,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3095,7 +3096,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3119,7 +3120,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3127,20 +3128,20 @@ msgstr ""
 msgid "Every"
 msgstr "Cada"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Câmbio"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Taxa de câmbio"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Falta a taxa de câmbio para o pagamento!"
 
@@ -3148,7 +3149,7 @@ msgstr "Falta a taxa de câmbio para o pagamento!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Falta a taxa de câmbio!"
 
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3272,7 +3273,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3286,17 +3287,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3333,7 +3334,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3393,7 +3394,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3425,7 +3426,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Do Almoxarifado"
 
@@ -3474,7 +3475,7 @@ msgstr "Número de Referência da Conta"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3482,7 +3483,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3511,11 +3512,11 @@ msgstr "Gerar"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Gerar Pedidos"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Gerar Ordens de Compra"
 
@@ -3560,8 +3561,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupo"
 
@@ -3803,8 +3804,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Notas internas"
 
@@ -3864,11 +3865,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Inventário salvo!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Inventário transferido!"
 
@@ -3876,8 +3877,8 @@ msgstr "Inventário transferido!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3895,22 +3896,22 @@ msgstr "Fatura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Data da Fatura"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Data da Fatura não encontrada!"
 
@@ -3926,8 +3927,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3936,7 +3937,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Número da Fatura"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Número da Fatura não encontrado!"
 
@@ -3994,7 +3995,7 @@ msgstr "Item"
 msgid "Item deleted!"
 msgstr "Item apagado!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Item não está no arquivo!"
 
@@ -4022,7 +4023,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Janeiro"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4063,7 +4064,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Junho"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4127,7 +4128,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Lead"
 
@@ -4348,11 +4349,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Entrar"
 
@@ -4429,7 +4430,7 @@ msgstr "Gerente"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4460,9 +4461,9 @@ msgid "May"
 msgstr "Mai"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Memorando"
@@ -4809,15 +4810,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4831,15 +4832,15 @@ msgstr "Notas"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Nada entrou!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Nada foi selecionado!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Nada a transferir!"
 
@@ -4864,7 +4865,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4883,7 +4884,7 @@ msgstr "Número"
 msgid "Number Format"
 msgstr "Formato de números"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4921,7 +4922,7 @@ msgstr "Out"
 msgid "October"
 msgstr "Outubro"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4936,7 +4937,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Em Estoque"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4991,7 +4992,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Pedido"
 
@@ -5009,12 +5010,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data do Pedido"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Data do Pedido Faltando"
 
@@ -5026,8 +5027,8 @@ msgstr "Entrada de Pedido"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5035,15 +5036,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Número do Pedido"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Número do pedido faltando!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Pedido apagado!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "A geração de pedidos falhou!"
 
@@ -5130,8 +5131,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5147,7 +5148,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5155,11 +5156,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Lista de Conteúdo"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Data da lista de conteúdo faltando!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Número da lista de conteúdo faltando!"
 
@@ -5183,7 +5184,7 @@ msgstr "Total Efetuado"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Item"
 
@@ -5203,8 +5204,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5225,7 +5226,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5255,7 +5256,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Senha"
 
@@ -5324,7 +5325,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Data de pagamento faltando!"
 
@@ -5336,7 +5337,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5345,7 +5346,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Pagamentos"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5353,11 +5354,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5392,7 +5393,7 @@ msgstr "Fone"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5523,8 +5524,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Lançar"
@@ -5541,7 +5542,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Lançar como novo"
 
@@ -5636,9 +5637,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Imprimir"
@@ -5647,11 +5648,11 @@ msgstr "Imprimir"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Imprimir e Salvar"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Imprimir e Salvar como Novo"
 
@@ -5703,15 +5704,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5733,7 +5734,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5776,8 +5777,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5816,7 +5817,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5846,8 +5847,8 @@ msgid "Quarter"
 msgstr "Trimestre"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5863,7 +5864,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Data da Cotação"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Data da Cotação faltando!"
 
@@ -5871,11 +5872,11 @@ msgstr "Data da Cotação faltando!"
 msgid "Quotation Number"
 msgstr "Número da Cotação"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Número da Cotação faltando!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Cotação apagada!"
 
@@ -5890,7 +5891,7 @@ msgstr "Cotações"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5916,7 +5917,7 @@ msgstr "RDCs"
 msgid "ROP"
 msgstr "PDR"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5957,7 +5958,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Recebidos"
 
@@ -5986,7 +5987,7 @@ msgstr "A Receber"
 msgid "Receive"
 msgstr "Receber"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Receber Mercadoria"
 
@@ -6014,7 +6015,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Registrar em"
 
@@ -6040,11 +6041,11 @@ msgstr "Transações Recorrentes"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referência"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6081,9 +6082,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Restante"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6111,7 +6116,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6123,7 +6128,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6159,11 +6164,11 @@ msgstr "Relatórios"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Req"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6284,11 +6289,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6317,7 +6322,7 @@ msgstr "Venda"
 msgid "Sales"
 msgstr "Vendas"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Fatura de Venda"
@@ -6326,8 +6331,8 @@ msgstr "Fatura de Venda"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Fatura de Venda/Númenro da Transação de CR"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6392,7 +6397,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6437,7 +6442,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6445,7 +6450,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6462,7 +6467,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Salvar como novo"
@@ -6471,7 +6476,7 @@ msgstr "Salvar como novo"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6509,7 +6514,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6522,12 +6527,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Programação"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Programado"
 
@@ -6668,11 +6673,11 @@ msgstr "Selecionar Cliente"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Selecionar Fornecedor"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Selecione uma Impressora!"
 
@@ -6692,12 +6697,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Selecionar Postscript ou PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Selecionar txt, Postscript ou PDF!"
 
@@ -6788,7 +6793,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Nº Série"
 
@@ -6806,11 +6811,11 @@ msgstr "Número de Série"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Serviço"
 
@@ -6854,13 +6859,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Despachar"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Despachar mercadoria"
 
@@ -6890,12 +6895,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Enviar para"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6912,23 +6917,23 @@ msgstr "Enivar por"
 msgid "Shipping"
 msgstr "Despacho de Mercadorias"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Data do Despacho"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Data do Despacho faltando!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7004,12 +7009,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7090,11 +7095,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Estado"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7178,7 +7183,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7241,8 +7246,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7264,7 +7269,7 @@ msgstr "Imposto"
 msgid "Tax Account"
 msgstr "Conts de Imposto"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7274,7 +7279,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7298,7 +7303,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7306,7 +7311,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Impostos incluídos"
@@ -7405,7 +7410,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7625,7 +7630,7 @@ msgstr "Vêzes"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7660,7 +7665,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Para o Almoxarifado"
 
@@ -7706,7 +7711,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7727,7 +7732,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7739,6 +7744,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Itens Rastreáveis"
@@ -7747,7 +7756,7 @@ msgstr "Itens Rastreáveis"
 msgid "Trade Discount"
 msgstr "Desconto de comércio"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Transação"
 
@@ -7780,20 +7789,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Tansações"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Transferir"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Transferência de Inventário"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Trasnferir de"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Transferir para"
 
@@ -7880,7 +7889,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7941,7 +7950,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7957,7 +7966,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7975,7 +7984,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8027,20 +8036,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Atualizar"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Atualizado"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8102,7 +8111,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8188,8 +8197,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8208,7 +8217,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Histórico do Fornecedor"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Fatura de Compra"
@@ -8224,7 +8233,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8247,7 +8256,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Fornecedor faltando!"
 
@@ -8284,7 +8293,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8361,7 +8370,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Que tipo de Item é este?"
 
@@ -8377,7 +8386,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8435,7 +8444,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Sim"
@@ -8454,11 +8463,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8525,7 +8534,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8569,7 +8578,7 @@ msgstr "feito"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "cada"
 

--- a/locale/po/ru.po
+++ b/locale/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Ann Madz <annamadzigon@gmail.com>, 2020\n"
 "Language-Team: Russian (http://www.transifex.com/ledgersmb/ledgersmb/language/"
@@ -194,7 +194,7 @@ msgstr "Отказ"
 msgid "Access Denied"
 msgstr "Доступ невозможен"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -202,9 +202,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -212,7 +212,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -323,7 +323,7 @@ msgstr "Начисление"
 msgid "Accrual Basis:"
 msgstr "База начисления"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "Накопленный износ"
 
@@ -432,7 +432,7 @@ msgstr "Добавить дебит-ноту"
 msgid "Add Employee"
 msgstr "Новый сотрудник"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Новый курс"
 
@@ -468,11 +468,11 @@ msgstr "Новый продукт"
 msgid "Add Pricegroup"
 msgstr "Новый тип цен"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Новый заказ поставщика"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Новое резервирование"
 
@@ -480,7 +480,7 @@ msgstr "Новое резервирование"
 msgid "Add Reporting Unit"
 msgstr "Добавить отчетную единицу"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Новый запрос на резервирование"
 
@@ -492,11 +492,11 @@ msgstr "Добавить возврат"
 msgid "Add SIC"
 msgstr "Новый SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Новая фактура продажи"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Новый заказ клиента"
 
@@ -512,7 +512,7 @@ msgstr "Добавить форму налогового учета"
 msgid "Add Timecard"
 msgstr "Добавить табель учета времени"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "Добавить в список"
 
@@ -534,7 +534,7 @@ msgstr "Новый пользователь"
 msgid "Add Vendor"
 msgstr "Новый поставщик"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Новая фактура поступления"
 
@@ -546,15 +546,15 @@ msgstr "Добавить возврат поставщику"
 msgid "Add Warehouse"
 msgstr "Новый склад"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "Добавить строку1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "Добавить строку2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "Добавить строку3"
 
@@ -582,8 +582,8 @@ msgstr "Добавленный id  [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -615,7 +615,7 @@ msgstr "Корректировка"
 msgid "Adjusted"
 msgstr "Урегулированный"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -692,9 +692,9 @@ msgstr "Разрешить ввод"
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -797,8 +797,8 @@ msgstr "Статус для подтверждения"
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "Подтвердить"
@@ -836,20 +836,20 @@ msgstr "апр"
 msgid "April"
 msgstr "апрель"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Вы уверены, что хотите удалить данный заказ?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Вы уверены, что хотите удалить резерв?"
 
@@ -922,16 +922,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr "Прикрепить"
@@ -962,31 +962,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr "Прикреплённый к типу"
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1019,7 +1019,7 @@ msgstr "август"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "Автоматический"
 
@@ -1088,7 +1088,7 @@ msgid "Balance"
 msgstr "Баланс"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Баланс"
@@ -1135,8 +1135,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1215,14 +1215,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Bin"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Невозможно удалить номенклатуру!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Невозможно удалить заказ!"
 
@@ -1393,19 +1393,19 @@ msgstr "Невозможно удалить заказ!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Невозможно удалить резерв!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Невозможно провести фактуру в закрытом периоде!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Невозможно провести оплату для закрытого периода!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Невозможно провести проводку в закрытом периоде!"
 
@@ -1415,15 +1415,15 @@ msgid ""
 msgstr ""
 "Невозможно провести проводку с дебетом и кредитом для обного и того же счета!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Невозможно провести проводку!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Невозможно сохранить заказ!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Невозможно сохранить резерв"
 
@@ -1443,7 +1443,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Касса"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr "Денежный Аккаунт"
 
@@ -1504,7 +1505,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1620,7 +1621,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Организация"
 
@@ -1653,7 +1654,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1705,7 +1706,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Подтвердить!"
 
@@ -1713,7 +1714,7 @@ msgstr "Подтвердить!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1756,8 +1757,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1768,7 +1769,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1817,7 +1818,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Цена"
 
@@ -1829,19 +1830,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Невозможно сохранить!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Невозможно пересестить инвентарь"
 
@@ -1861,8 +1862,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1926,7 +1927,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Кредит"
 
@@ -1947,7 +1948,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1971,7 +1972,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Валюта"
 
@@ -1980,7 +1981,7 @@ msgstr "Валюта"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2017,7 +2018,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2047,7 +2048,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2060,7 +2061,7 @@ msgstr "Код клиента"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Пропущен клиент!"
 
@@ -2076,7 +2077,7 @@ msgstr "Клиент отсутствует в справочнике!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2100,7 +2101,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2149,7 +2150,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2164,11 +2165,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2206,7 +2207,7 @@ msgstr "Дата оплаты"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Дата получена"
 
@@ -2230,7 +2231,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Пропущена дата"
 
@@ -2276,7 +2277,7 @@ msgstr "Дней"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Дебет"
 
@@ -2389,9 +2390,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2441,16 +2442,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Дата получения"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2458,11 +2459,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2484,7 +2485,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2536,13 +2537,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2559,7 +2560,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2630,16 +2631,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2655,7 +2656,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2671,7 +2672,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Выполнено"
 
@@ -2691,7 +2692,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2733,14 +2734,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Оплатить до"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Не указан срок оплаты!"
 
@@ -2752,8 +2753,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -3055,11 +3056,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3075,7 +3076,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3097,7 +3098,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3121,7 +3122,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3129,20 +3130,20 @@ msgstr ""
 msgid "Every"
 msgstr "каждый"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Курс"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Курс валюты"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Пропущен курс оплаты!"
 
@@ -3150,7 +3151,7 @@ msgstr "Пропущен курс оплаты!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Пропущен курс!"
 
@@ -3195,8 +3196,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3274,7 +3275,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3288,17 +3289,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3335,7 +3336,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3395,7 +3396,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3427,7 +3428,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "со склада"
 
@@ -3476,7 +3477,7 @@ msgstr "Номер справочника Главной книги"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3484,7 +3485,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3513,11 +3514,11 @@ msgstr "Создать"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Создать ордеры"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Создать ордеры покупки"
 
@@ -3562,8 +3563,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Группа"
 
@@ -3805,8 +3806,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Внутренние заметки"
 
@@ -3866,11 +3867,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Инвентарь сохранен!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Инвентарь перемещен!"
 
@@ -3878,8 +3879,8 @@ msgstr "Инвентарь перемещен!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3897,22 +3898,22 @@ msgstr "Счет-фактура"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Дата выставления"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Не указана дата выставления счета-фактуры"
 
@@ -3928,8 +3929,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3938,7 +3939,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Номер счета-фактуры"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Не указан номер счета-фактуры"
 
@@ -3996,7 +3997,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Номенклатура удалена!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Нет номенклатуры в справочнике!"
 
@@ -4024,7 +4025,7 @@ msgstr "янв"
 msgid "January"
 msgstr "январь"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4065,7 +4066,7 @@ msgstr "июн"
 msgid "June"
 msgstr "июнь"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4129,7 +4130,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Lead"
 
@@ -4350,11 +4351,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Пользователь"
 
@@ -4431,7 +4432,7 @@ msgstr "Менеджер"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4462,9 +4463,9 @@ msgid "May"
 msgstr "май"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Комментарий"
@@ -4811,15 +4812,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4833,15 +4834,15 @@ msgstr "Комментарии"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Ничего не введено!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Ничего не выбрано!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Ничего не перемещено!"
 
@@ -4866,7 +4867,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4885,7 +4886,7 @@ msgstr "код"
 msgid "Number Format"
 msgstr "Числовой формат"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4923,7 +4924,7 @@ msgstr "окт"
 msgid "October"
 msgstr "октябрь"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4938,7 +4939,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Вналичии"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4993,7 +4994,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Заказ клиента"
 
@@ -5011,12 +5012,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Дата заказа клиента"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Пропущена дата заказа"
 
@@ -5028,8 +5029,8 @@ msgstr "Заказы"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5037,15 +5038,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Номер заказа"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Пропущен номер заказа"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Заказ удален!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Ошибка создания ордера"
 
@@ -5132,8 +5133,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5149,7 +5150,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5157,11 +5158,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Упаковочный список"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Пропущена дата упаковочного списока!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Пропущен номер упаковочного списока!"
 
@@ -5185,7 +5186,7 @@ msgstr "Оплачено"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Товар"
 
@@ -5205,8 +5206,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5227,7 +5228,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5257,7 +5258,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Пароль"
 
@@ -5326,7 +5327,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Пропущена дата оплаты!"
 
@@ -5338,7 +5339,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5347,7 +5348,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Оплаты"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5355,11 +5356,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5394,7 +5395,7 @@ msgstr "Тел."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5525,8 +5526,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Сохранить"
@@ -5543,7 +5544,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Сохранить как новый"
 
@@ -5638,9 +5639,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Печать"
@@ -5649,11 +5650,11 @@ msgstr "Печать"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Напечатать и сохранить"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Напечатать и сохранить как новый"
 
@@ -5705,15 +5706,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5735,7 +5736,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5778,8 +5779,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5818,7 +5819,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5848,8 +5849,8 @@ msgid "Quarter"
 msgstr "Квартал"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5865,7 +5866,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Дата резервирования"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Пропущена дата резервирования!"
 
@@ -5873,11 +5874,11 @@ msgstr "Пропущена дата резервирования!"
 msgid "Quotation Number"
 msgstr "Номер резервирования"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Пропущен номер резервирования!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Резервирование удалено"
 
@@ -5892,7 +5893,7 @@ msgstr "Резервы"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5918,7 +5919,7 @@ msgstr "Запросы на резервирование"
 msgid "ROP"
 msgstr "ROP"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5959,7 +5960,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Recd"
 
@@ -5988,7 +5989,7 @@ msgstr "Подлежащий получению"
 msgid "Receive"
 msgstr "Получить"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Получить товары"
 
@@ -6016,7 +6017,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Отнести на счет"
 
@@ -6042,11 +6043,11 @@ msgstr "Повторяющиеся проводки"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Ссылка"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6083,9 +6084,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Остаток"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6113,7 +6118,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6125,7 +6130,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6161,11 +6166,11 @@ msgstr "Отчеты"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Req"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6286,11 +6291,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6319,7 +6324,7 @@ msgstr "Продажа"
 msgid "Sales"
 msgstr "Продажи"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Фактура клиента"
@@ -6328,8 +6333,8 @@ msgstr "Фактура клиента"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Номер проводки Фактуры клиента"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6394,7 +6399,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6447,7 +6452,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6464,7 +6469,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Сохранить как новый"
@@ -6473,7 +6478,7 @@ msgstr "Сохранить как новый"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6511,7 +6516,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6524,12 +6529,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Расписание"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Назначено расписание"
 
@@ -6670,11 +6675,11 @@ msgstr "Выбрать покупателя"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Выбрать поставщика"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Выбрать принтер"
 
@@ -6694,12 +6699,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Выберите postscript или PDF!"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Выберите txt, postscript или PDF!"
 
@@ -6790,7 +6795,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Серийный ном."
 
@@ -6808,11 +6813,11 @@ msgstr "Серийный номер"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Услуга"
 
@@ -6856,13 +6861,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Доставить"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Погрузить товары"
 
@@ -6892,12 +6897,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "доставить для"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6914,23 +6919,23 @@ msgstr "доставить через"
 msgid "Shipping"
 msgstr "Доставка"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Дата доставки"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Пропущена дата доставки"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -7006,12 +7011,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7092,11 +7097,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Состояние"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7180,7 +7185,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7243,8 +7248,8 @@ msgstr "ИТОГО"
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr "Тег"
 
@@ -7266,7 +7271,7 @@ msgstr "Налог"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7276,7 +7281,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7308,7 +7313,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Налоги включены в сумму"
@@ -7407,7 +7412,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7627,7 +7632,7 @@ msgstr "раз"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7662,7 +7667,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "на склад"
 
@@ -7708,7 +7713,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7729,7 +7734,7 @@ msgstr ""
 msgid "Total"
 msgstr "Итого"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7741,6 +7746,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Tracking Items"
@@ -7749,7 +7758,7 @@ msgstr "Tracking Items"
 msgid "Trade Discount"
 msgstr "Торговая скидка"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Проводка"
 
@@ -7782,20 +7791,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Проводки"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Перемещение"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Перемещение инвентаря"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Переместить от"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Переместить к"
 
@@ -7882,7 +7891,7 @@ msgstr "Два"
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7943,7 +7952,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7959,7 +7968,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7977,7 +7986,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8029,20 +8038,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Обновить"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Обновлено"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8104,7 +8113,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8190,8 +8199,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8210,7 +8219,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "История"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Фактура поставщика"
@@ -8226,7 +8235,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8249,7 +8258,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Пропущен поставщик!"
 
@@ -8286,7 +8295,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8363,7 +8372,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Какой это тип номеклатуры?"
 
@@ -8379,7 +8388,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8437,7 +8446,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Да"
@@ -8456,11 +8465,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8527,7 +8536,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8571,7 +8580,7 @@ msgstr "выполнено"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "шт."
 

--- a/locale/po/sv.po
+++ b/locale/po/sv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Swedish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "sv/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Ny anställd"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "Ny växelkurs"
 
@@ -458,11 +458,11 @@ msgstr "Ny vara"
 msgid "Add Pricegroup"
 msgstr "Ny prisgrupp"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Ny inköpsorder"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Ny offert"
 
@@ -470,7 +470,7 @@ msgstr "Ny offert"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Ny begäran om offert"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Ny sni-kod (industrikod)"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Ny kundfaktura"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Ny säljorder"
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Ny användare"
 msgid "Add Vendor"
 msgstr "Ny leverantör"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Ny leverantörsfaktura"
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Lägg till lager"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "Apr"
 msgid "April"
 msgstr "April"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Är du säker på att du vill radera Order Nummer"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Är du säker på att du vill radera Offert Nummer"
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "Augusti"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "Balans"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Balansräkning"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Antal i lager"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Kan inte radera vara"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Kan inte radera order"
 
@@ -1383,19 +1383,19 @@ msgstr "Kan inte radera order"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Kan inte radera offert"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Kan inte bokföra en faktura för en avslutad period"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Kan inte bokföra en betalning för en stängd period"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Kan inte bokföra under en stängd period"
 
@@ -1406,15 +1406,15 @@ msgstr ""
 "Kan inte bokföra transaktion med debitering och kreditering på samma "
 "kontonummer!"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Kan inte bokföra transaktion"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Kan inte spara order"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Kan inte spara offert!"
 
@@ -1434,7 +1434,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Betalningar"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1495,7 +1496,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1611,7 +1612,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Företag"
 
@@ -1644,7 +1645,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1696,7 +1697,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Bekräfta!"
 
@@ -1704,7 +1705,7 @@ msgstr "Bekräfta!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1747,8 +1748,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1759,7 +1760,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1808,7 +1809,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Kostnader"
 
@@ -1820,19 +1821,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Kan inte spara"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Kan inte överföra inventarier!"
 
@@ -1852,8 +1853,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1917,7 +1918,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Kredit"
 
@@ -1938,7 +1939,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1962,7 +1963,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Valuta"
 
@@ -1971,7 +1972,7 @@ msgstr "Valuta"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2008,7 +2009,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2038,7 +2039,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2051,7 +2052,7 @@ msgstr "Kund nr"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Kund saknas"
 
@@ -2067,7 +2068,7 @@ msgstr "Kund finns ej"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2140,7 +2141,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2155,11 +2156,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2197,7 +2198,7 @@ msgstr "Betalningsdatum"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "Datum mottaget"
 
@@ -2221,7 +2222,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Mottagningsdatum saknas"
 
@@ -2267,7 +2268,7 @@ msgstr "Dagar"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Debet"
 
@@ -2380,9 +2381,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2432,16 +2433,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Leveransdatum"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2449,11 +2450,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2475,7 +2476,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2527,13 +2528,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2550,7 +2551,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2621,16 +2622,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2638,7 +2639,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2646,7 +2647,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2662,7 +2663,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Klart"
 
@@ -2682,7 +2683,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2724,14 +2725,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Förfallodatum"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Förfallodatum saknas"
 
@@ -2743,8 +2744,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "E-Post"
 
@@ -3046,11 +3047,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3088,7 +3089,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3112,7 +3113,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3120,20 +3121,20 @@ msgstr ""
 msgid "Every"
 msgstr "Varje"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Vxl"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Växlingskurs"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Växlingskurs för saknad betalning"
 
@@ -3141,7 +3142,7 @@ msgstr "Växlingskurs för saknad betalning"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Växelkurs saknas"
 
@@ -3186,8 +3187,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "Valutakurs"
 
@@ -3265,7 +3266,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3279,17 +3280,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3326,7 +3327,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3386,7 +3387,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3418,7 +3419,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "Från lager"
 
@@ -3467,7 +3468,7 @@ msgstr "Huvudboks verifikat nr"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3475,7 +3476,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3504,11 +3505,11 @@ msgstr "Skapa"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Skapa order"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Skapa inköpsorder"
 
@@ -3553,8 +3554,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Grupp"
 
@@ -3796,8 +3797,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Egna anteckningar"
 
@@ -3856,11 +3857,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Lager sparat"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Lager överfört"
 
@@ -3868,8 +3869,8 @@ msgstr "Lager överfört"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3887,22 +3888,22 @@ msgstr "Faktura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fakturadatum"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Fakturadatum saknas"
 
@@ -3918,8 +3919,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3928,7 +3929,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Fakturanummer"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Fakturanummer saknas"
 
@@ -3986,7 +3987,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Vara raderad"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Varan finns inte i databasen"
 
@@ -4014,7 +4015,7 @@ msgstr "Jan"
 msgid "January"
 msgstr "Januari"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4055,7 +4056,7 @@ msgstr "Jun"
 msgid "June"
 msgstr "Juni"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4119,7 +4120,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "Leveranstid"
 
@@ -4340,11 +4341,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Logga in"
 
@@ -4421,7 +4422,7 @@ msgstr "Direktör"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4452,9 +4453,9 @@ msgid "May"
 msgstr "Maj"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Anteckning"
@@ -4801,15 +4802,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4823,15 +4824,15 @@ msgstr "Anmärkningar"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Inget inskrivet"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Ingenting valt"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Inget att överföra"
 
@@ -4856,7 +4857,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4875,7 +4876,7 @@ msgstr "Nummer"
 msgid "Number Format"
 msgstr "Nummerformat"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4913,7 +4914,7 @@ msgstr "Okt"
 msgid "October"
 msgstr "Oktober"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4928,7 +4929,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "I lager"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4983,7 +4984,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Order"
 
@@ -5001,12 +5002,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Orderdatum"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Orderdatum saknas"
 
@@ -5018,8 +5019,8 @@ msgstr "Beställningar"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5027,15 +5028,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Ordernummer"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Ordernummer saknas"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Order raderad"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Skapande av order misslyckades!"
 
@@ -5122,8 +5123,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5139,7 +5140,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5147,11 +5148,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Packsedel"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Packsedelsdatum saknas"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Packsedelsnummer saknas"
 
@@ -5175,7 +5176,7 @@ msgstr "Betalt"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Artikel"
 
@@ -5195,8 +5196,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5217,7 +5218,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5247,7 +5248,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Lösenord"
 
@@ -5316,7 +5317,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Betalningsdatum saknas"
 
@@ -5328,7 +5329,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5337,7 +5338,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Utbetalningar"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5345,11 +5346,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5384,7 +5385,7 @@ msgstr "Telefon"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5515,8 +5516,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Bokför"
@@ -5533,7 +5534,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Bokför som ny"
 
@@ -5628,9 +5629,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Skriv ut"
@@ -5639,11 +5640,11 @@ msgstr "Skriv ut"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Skriv och spara"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "Skriv ut och spara som ny"
 
@@ -5695,15 +5696,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5725,7 +5726,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5768,8 +5769,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5808,7 +5809,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5838,8 +5839,8 @@ msgid "Quarter"
 msgstr "Kvartal"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5855,7 +5856,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Offert datum"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Offert datum saknas"
 
@@ -5863,11 +5864,11 @@ msgstr "Offert datum saknas"
 msgid "Quotation Number"
 msgstr "Offert  nummer"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Offert nummer saknas"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Offert borttagen"
 
@@ -5882,7 +5883,7 @@ msgstr "Offerter"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5908,7 +5909,7 @@ msgstr "Begäran om offert"
 msgid "ROP"
 msgstr "Beställ vid"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5949,7 +5950,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Mottagen"
 
@@ -5978,7 +5979,7 @@ msgstr "Inbetalningar"
 msgid "Receive"
 msgstr "Ta emot"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Varumottagning"
 
@@ -6006,7 +6007,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Bokför på"
 
@@ -6032,11 +6033,11 @@ msgstr "Återkommande transaktion"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Referens"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6073,9 +6074,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Resterar"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6103,7 +6108,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6115,7 +6120,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6151,11 +6156,11 @@ msgstr "Rapporter"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Best"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6276,11 +6281,11 @@ msgstr "SNI-kod"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "Lagernr"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6309,7 +6314,7 @@ msgstr "Försäljning"
 msgid "Sales"
 msgstr "Försäljning"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Kundfaktura"
@@ -6318,8 +6323,8 @@ msgstr "Kundfaktura"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "Kundfaktura / Intäktsverifikat nr"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6384,7 +6389,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6429,7 +6434,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6437,7 +6442,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6454,7 +6459,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Spara som ny"
@@ -6463,7 +6468,7 @@ msgstr "Spara som ny"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6501,7 +6506,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6514,12 +6519,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Schemalägg"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "Schemalagd"
 
@@ -6660,11 +6665,11 @@ msgstr "Välj kund"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Välj leverantör"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "Välj skrivare"
 
@@ -6684,12 +6689,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Välj Postscript eller PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Välj text, postsript eller PDF!"
 
@@ -6780,7 +6785,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Serie nr."
 
@@ -6798,11 +6803,11 @@ msgstr "Serie nr."
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Tjänster"
 
@@ -6846,13 +6851,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Skicka"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Skicka varor"
 
@@ -6882,12 +6887,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Skicka till"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6904,23 +6909,23 @@ msgstr "Skicka med"
 msgid "Shipping"
 msgstr "Leveranser"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Skickat datum"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Leveransdatum saknas"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6996,12 +7001,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7082,11 +7087,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Stat"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7170,7 +7175,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7233,8 +7238,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7256,7 +7261,7 @@ msgstr "Moms"
 msgid "Tax Account"
 msgstr "Momskonto"
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7266,7 +7271,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7290,7 +7295,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7298,7 +7303,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Moms ingår"
@@ -7397,7 +7402,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7617,7 +7622,7 @@ msgstr "Gånger"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7652,7 +7657,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "Till lager"
 
@@ -7698,7 +7703,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7719,7 +7724,7 @@ msgstr ""
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7731,6 +7736,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "Spårbara varor"
@@ -7739,7 +7748,7 @@ msgstr "Spårbara varor"
 msgid "Trade Discount"
 msgstr "Handelsrabatt"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "Transaktion"
 
@@ -7772,20 +7781,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "Samtliga"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Överför"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "ÖVerför varor"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "Överför från"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Överför till"
 
@@ -7872,7 +7881,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7933,7 +7942,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7949,7 +7958,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7967,7 +7976,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8019,20 +8028,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Uppdatera"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Uppdaterad"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8094,7 +8103,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8180,8 +8189,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8200,7 +8209,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Leverantörshistorik"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Kredit inköp"
@@ -8216,7 +8225,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8239,7 +8248,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Leverantör saknas"
 
@@ -8276,7 +8285,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8353,7 +8362,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Vilken typ av artikel är detta?"
 
@@ -8369,7 +8378,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8427,7 +8436,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Ja"
@@ -8446,11 +8455,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8517,7 +8526,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8561,7 +8570,7 @@ msgstr "Färdigt"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "st"
 

--- a/locale/po/th.po
+++ b/locale/po/th.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Thai (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "th/)\n"
@@ -184,7 +184,7 @@ msgstr "ละทิ้ง"
 msgid "Access Denied"
 msgstr "ปฏิเสธการเข้าถึง"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr "ค้างรับค้างจ่าย"
 msgid "Accrual Basis:"
 msgstr "เกณฑ์ค้างรับค้างจ่าย"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "ค่าเสื่อมราคาสะสม"
 
@@ -422,7 +422,7 @@ msgstr "เพิ่ม Debit Note"
 msgid "Add Employee"
 msgstr "เพิ่มพนักงาน"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "เพิ่มอัตราแลกเปลี่ยน"
 
@@ -458,11 +458,11 @@ msgstr "เพิ่ม Part"
 msgid "Add Pricegroup"
 msgstr "เพิ่ม Pricegroup"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "เพิ่มใบสั่งซื้อ"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "เพิ่มใบเสนอราคา"
 
@@ -470,7 +470,7 @@ msgstr "เพิ่มใบเสนอราคา"
 msgid "Add Reporting Unit"
 msgstr "เพิ่มหน่วยการรายงาน"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "เพิ่ม Request for Quotation"
 
@@ -482,11 +482,11 @@ msgstr "เพิ่ม Return"
 msgid "Add SIC"
 msgstr "เพิ่ม SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "เพิ่มใบกำกับสินค้าขาย"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "เพิ่มใบสั่งขาย"
 
@@ -502,7 +502,7 @@ msgstr "เพิ่มแบบภาษี"
 msgid "Add Timecard"
 msgstr "เพิ่มบัตรลงเวลา"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "เพิ่มลงในรายการ"
 
@@ -524,7 +524,7 @@ msgstr "เพิ่มผู้ใช้"
 msgid "Add Vendor"
 msgstr "เพิ่มคู่ค้า"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "เพิ่มใบกำกับสินค้าคู่ค้า"
 
@@ -536,15 +536,15 @@ msgstr "เพิ่มการคืนสินค้าจากคู่ค
 msgid "Add Warehouse"
 msgstr "เพิ่มคลังสินค้า"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "เพิ่มบรรทัด 1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "เพิ่มบรรทัด 2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "เพิ่มบรรทัด 3"
 
@@ -572,8 +572,8 @@ msgstr "เพิ่มแล้ว id  [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr "ปรับ"
 msgid "Adjusted"
 msgstr "ถูกปรับ"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "เกณฑ์การปรับ"
 
@@ -682,9 +682,9 @@ msgstr "การป้อนเข้าระบบที่อนุญาต
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "เม.ย."
 msgid "April"
 msgstr "เมษายน"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr ""
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "สิงหาคม"
 msgid "Author: [_1]"
 msgstr "ผู้เขียน: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "อัตโนมัติ"
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "ยอดคงเหลือ"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "งบดุล"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "ไม่สามารถยกเลิก voided invoice"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1383,19 +1383,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1702,7 +1703,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4011,7 +4012,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4418,7 +4419,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5015,8 +5016,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5172,7 +5173,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5636,11 +5637,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,8 +6071,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6315,8 +6320,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6460,7 +6465,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/th_TH.po
+++ b/locale/po/th_TH.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Thai (Thailand) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/th_TH/)\n"
@@ -184,7 +184,7 @@ msgstr "ละทิ้ง"
 msgid "Access Denied"
 msgstr "ปฏิเสธการเข้าถึง"
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr "ค้างรับค้างจ่าย"
 msgid "Accrual Basis:"
 msgstr "เกณฑ์ค้างรับค้างจ่าย"
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr "ค่าเสื่อมราคาสะสม"
 
@@ -422,7 +422,7 @@ msgstr "เพิ่ม Debit Note"
 msgid "Add Employee"
 msgstr "เพิ่มพนักงาน"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "เพิ่มอัตราแลกเปลี่ยน"
 
@@ -458,11 +458,11 @@ msgstr "เพิ่ม Part"
 msgid "Add Pricegroup"
 msgstr "เพิ่ม Pricegroup"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "เพิ่มใบสั่งซื้อ"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "เพิ่มใบเสนอราคา"
 
@@ -470,7 +470,7 @@ msgstr "เพิ่มใบเสนอราคา"
 msgid "Add Reporting Unit"
 msgstr "เพิ่มหน่วยการรายงาน"
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "เพิ่ม Request for Quotation"
 
@@ -482,11 +482,11 @@ msgstr "เพิ่ม Return"
 msgid "Add SIC"
 msgstr "เพิ่ม SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "เพิ่มใบกำกับสินค้าขาย"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "เพิ่มใบสั่งขาย"
 
@@ -502,7 +502,7 @@ msgstr "เพิ่มแบบภาษี"
 msgid "Add Timecard"
 msgstr "เพิ่มบัตรลงเวลา"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "เพิ่มลงในรายการ"
 
@@ -524,7 +524,7 @@ msgstr "เพิ่มผู้ใช้"
 msgid "Add Vendor"
 msgstr "เพิ่มคู่ค้า"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "เพิ่มใบกำกับสินค้าคู่ค้า"
 
@@ -536,15 +536,15 @@ msgstr "เพิ่มการคืนสินค้าจากคู่ค
 msgid "Add Warehouse"
 msgstr "เพิ่มคลังสินค้า"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr "เพิ่มบรรทัด 1"
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr "เพิ่มบรรทัด 2"
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr "เพิ่มบรรทัด 3"
 
@@ -572,8 +572,8 @@ msgstr "เพิ่มแล้ว id  [_1]"
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr "ปรับ"
 msgid "Adjusted"
 msgstr "ถูกปรับ"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr "เกณฑ์การปรับ"
 
@@ -682,9 +682,9 @@ msgstr "การป้อนเข้าระบบที่อนุญาต
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "เม.ย."
 msgid "April"
 msgstr "เมษายน"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr ""
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "สิงหาคม"
 msgid "Author: [_1]"
 msgstr "ผู้เขียน: [_1]"
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr "อัตโนมัติ"
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "ยอดคงเหลือ"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "งบดุล"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr "ไม่สามารถยกเลิก voided invoice"
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1383,19 +1383,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1702,7 +1703,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4011,7 +4012,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4418,7 +4419,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5015,8 +5016,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5172,7 +5173,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5636,11 +5637,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,8 +6071,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6315,8 +6320,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6460,7 +6465,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/tr.po
+++ b/locale/po/tr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Turkish (http://www.transifex.com/ledgersmb/ledgersmb/language/"
 "tr/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -458,11 +458,11 @@ msgstr "Parça Ekle"
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Satınalma Sip. Ekle"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Satış Siparişi Ekle"
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr "Kullanıcı Ekle"
 msgid "Add Vendor"
 msgstr "Satıcı Ekle"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr "Nis"
 msgid "April"
 msgstr "Nisan"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Sipariş Numarasını silmek istediğinizden emin misiniz? Fiş: "
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "Ağustos"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Bilanço"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1383,19 +1383,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Şirket"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Onayla!"
 
@@ -1702,7 +1703,7 @@ msgstr "Onayla!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Alacak"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "Ödendiği Tarih"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Borç"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Vade Tarihi"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Vade Tarihi yok!"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Posta"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "D.Kuru"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Döviz Kuru"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr "Bu grubu çıkarmadan önce stok miktarı sıfır olmalıdır"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "Fatura"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Fatura Tarihi"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Fatura Tarihi yok!"
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Fatura No"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Fatura Numarası yok!"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Bu kalem dosyada yok!"
 
@@ -4011,7 +4012,7 @@ msgstr "Oca"
 msgid "January"
 msgstr "Ocak"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "Haz"
 msgid "June"
 msgstr "Haziran"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Giriş"
 
@@ -4418,7 +4419,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "May"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "Notlar:"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "Numara"
 msgid "Number Format"
 msgstr "Rakam Formatı"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "Eki"
 msgid "October"
 msgstr "Ekim"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "Stok:"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "Sipariş"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Sipariş Tarihi"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Sipariş Tarihi yok!"
 
@@ -5015,8 +5016,8 @@ msgstr "Sipariş Girişi"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Sipariş No"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Sipariş Numarası yok!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Paketleme Listesi"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5172,7 +5173,7 @@ msgstr "Ödendi"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "Parça"
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Şifre"
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "Ödeme Tarihi yok"
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Ödemeler"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5636,11 +5637,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Kaydet"
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,8 +6071,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr "Raporlar"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr ""
 msgid "Sales"
 msgstr "Satışlar"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6315,8 +6320,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6460,7 +6465,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "servis"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "Vergi"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Vergi Dahil"
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr "Toplam"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Bu ne çeşit bir kalemdir?"
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Evet"
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "ad"
 

--- a/locale/po/tr_TR.po
+++ b/locale/po/tr_TR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/tr_TR/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr ""
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -458,11 +458,11 @@ msgstr ""
 msgid "Add Pricegroup"
 msgstr ""
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr ""
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr ""
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr ""
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr ""
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr ""
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr ""
 
@@ -536,15 +536,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -826,20 +826,20 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr ""
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr ""
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr ""
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr ""
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr ""
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr ""
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr ""
 
@@ -1383,19 +1383,19 @@ msgstr ""
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr ""
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr ""
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr ""
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr ""
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr ""
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr ""
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr ""
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr ""
 
@@ -1702,7 +1703,7 @@ msgstr ""
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr ""
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr ""
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr ""
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr ""
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr ""
 
@@ -1969,7 +1970,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr ""
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr ""
 
@@ -2065,7 +2066,7 @@ msgstr ""
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr ""
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr ""
 
@@ -2265,7 +2266,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr ""
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr ""
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr ""
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr ""
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr ""
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr ""
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr ""
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr ""
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr ""
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr ""
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr ""
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr ""
 
@@ -3853,11 +3854,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr ""
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr ""
 
@@ -3865,8 +3866,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr ""
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr ""
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr ""
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr ""
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr ""
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr ""
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr ""
 
@@ -4011,7 +4012,7 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr ""
 
@@ -4418,7 +4419,7 @@ msgstr ""
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr ""
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr ""
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr ""
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr ""
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr ""
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr ""
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "Number Format"
 msgstr ""
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr ""
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr ""
 
@@ -5015,8 +5016,8 @@ msgstr ""
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr ""
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr ""
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr ""
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr ""
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr ""
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr ""
 
@@ -5172,7 +5173,7 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr ""
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr ""
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr ""
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr ""
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr ""
@@ -5636,11 +5637,11 @@ msgstr ""
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr ""
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr ""
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr ""
 
@@ -5860,11 +5861,11 @@ msgstr ""
 msgid "Quotation Number"
 msgstr ""
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr ""
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr ""
 
@@ -5879,7 +5880,7 @@ msgstr ""
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr ""
 msgid "ROP"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr ""
 
@@ -5975,7 +5976,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr ""
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr ""
 
@@ -6029,11 +6030,11 @@ msgstr ""
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr ""
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,8 +6071,12 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
+msgstr ""
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
 msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr ""
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr ""
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr ""
 msgid "Sales"
 msgstr ""
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr ""
@@ -6315,8 +6320,8 @@ msgstr ""
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr ""
@@ -6460,7 +6465,7 @@ msgstr ""
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr ""
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr ""
 
@@ -6657,11 +6662,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr ""
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr ""
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr ""
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr ""
 
@@ -6795,11 +6800,11 @@ msgstr ""
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr ""
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr ""
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr ""
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr ""
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr ""
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr ""
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr ""
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr ""
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr ""
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7736,7 +7745,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr ""
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr ""
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr ""
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr ""
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr ""
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr ""
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr ""
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr ""
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr ""
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr ""
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr ""
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr ""
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr ""
 

--- a/locale/po/uk.po
+++ b/locale/po/uk.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Ukrainian (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/uk/)\n"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -195,9 +195,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -205,7 +205,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "Додати працівника"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr ""
 
@@ -461,11 +461,11 @@ msgstr "Новий Товар"
 msgid "Add Pricegroup"
 msgstr "Додати цінову групу"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "Нове замовлення на купівлю"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "Котирування"
 
@@ -473,7 +473,7 @@ msgstr "Котирування"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "Додати запит на котирування"
 
@@ -485,11 +485,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "Додати SIC"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "Новий Рахуно-фактура"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "Нове замовлення на продаж"
 
@@ -505,7 +505,7 @@ msgstr ""
 msgid "Add Timecard"
 msgstr ""
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "Add Vendor"
 msgstr "Новий постачальник"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "Новий купівельний рахунок-фактура"
 
@@ -539,15 +539,15 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Додати склад"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -575,8 +575,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -685,9 +685,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -790,8 +790,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr ""
@@ -829,20 +829,20 @@ msgstr "квітня"
 msgid "April"
 msgstr "Квітень"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "Ви певні, що хочете видалити дане  замовлення?"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Ви певні, що хочете видалити номер котирування?"
 
@@ -915,16 +915,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -955,31 +955,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr "Серпень"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1081,7 +1081,7 @@ msgid "Balance"
 msgstr "Баланс"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "Баланс-зведення"
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1208,14 +1208,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "Корзина"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1323,12 +1323,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "Не вдається видалити цей елемент!"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "Не вдається видалити замовлення!"
 
@@ -1386,19 +1386,19 @@ msgstr "Не вдається видалити замовлення!"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "Не вдається видалити котирування!"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "Не вдається виставити рахунок-фактуру для закритого періоду!"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "Не вдається виставити платіж для закритого періоду!"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "Не вдається виставити проводку для закритого періоду!"
 
@@ -1407,15 +1407,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "Не вдається виставити проводку!"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "Не вдається зберегти замовлення!"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "Не вдається зберегти котирування!"
 
@@ -1435,7 +1435,8 @@ msgstr ""
 msgid "Cash"
 msgstr "Готівка"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1496,7 +1497,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1612,7 +1613,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "Підприємство"
 
@@ -1645,7 +1646,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "Підтвердіть!"
 
@@ -1705,7 +1706,7 @@ msgstr "Підтвердіть!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1748,8 +1749,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1760,7 +1761,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1809,7 +1810,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "Затрати"
 
@@ -1821,19 +1822,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "Не вдалось зберегти!"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "Не вдалось перевести інвентар!"
 
@@ -1853,8 +1854,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1918,7 +1919,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "Кредит"
 
@@ -1939,7 +1940,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1963,7 +1964,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "Валюта"
 
@@ -1972,7 +1973,7 @@ msgstr "Валюта"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2009,7 +2010,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2039,7 +2040,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2052,7 +2053,7 @@ msgstr "Номер клієнта"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "Не вказаний клієнт!"
 
@@ -2068,7 +2069,7 @@ msgstr "Клієнта нема в списку!"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2092,7 +2093,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2141,7 +2142,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2156,11 +2157,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2198,7 +2199,7 @@ msgstr "Дата оплати"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr ""
 
@@ -2222,7 +2223,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "Відсутня дата отримання!"
 
@@ -2268,7 +2269,7 @@ msgstr "Дні(в)"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "Дебит"
 
@@ -2381,9 +2382,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2433,16 +2434,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "Дата доставки"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2450,11 +2451,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2476,7 +2477,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2528,13 +2529,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2551,7 +2552,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2622,16 +2623,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2639,7 +2640,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2647,7 +2648,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2663,7 +2664,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "Зроблено"
 
@@ -2683,7 +2684,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2725,14 +2726,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "Заплатити до"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "Не вказаний термін оплати!"
 
@@ -2744,8 +2745,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "Ел. пошта"
 
@@ -3047,11 +3048,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3067,7 +3068,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3089,7 +3090,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3113,7 +3114,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3121,20 +3122,20 @@ msgstr ""
 msgid "Every"
 msgstr "Кожні"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "Курс"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "Курс валюти"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "Не вказаний курс валюти для платежу!"
 
@@ -3142,7 +3143,7 @@ msgstr "Не вказаний курс валюти для платежу!"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "Не вказаний курс валюти!"
 
@@ -3187,8 +3188,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "FX"
 
@@ -3266,7 +3267,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3280,17 +3281,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3327,7 +3328,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3387,7 +3388,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3419,7 +3420,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr ""
 
@@ -3468,7 +3469,7 @@ msgstr ""
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3476,7 +3477,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3505,11 +3506,11 @@ msgstr "Створити"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "Створити замовлення"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "Створити купівельні замовлення"
 
@@ -3554,8 +3555,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "Група"
 
@@ -3797,8 +3798,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "Внутрішні примітки"
 
@@ -3858,11 +3859,11 @@ msgstr ""
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "Інвентар збережено!"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "Інвентар перенесено!"
 
@@ -3870,8 +3871,8 @@ msgstr "Інвентар перенесено!"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3889,22 +3890,22 @@ msgstr "Рахунок-фактура"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "Дата виставлення"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "Не вказана дата виставлення рахунка-фактури"
 
@@ -3920,8 +3921,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3930,7 +3931,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "Номер рахунка-фактури"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "Не вказаний номер рахунка-фактури"
 
@@ -3988,7 +3989,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "Річ видалено!"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "Речі нема в списку!"
 
@@ -4016,7 +4017,7 @@ msgstr "січня"
 msgid "January"
 msgstr "січень"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4057,7 +4058,7 @@ msgstr "червня"
 msgid "June"
 msgstr "Червень"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4121,7 +4122,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr ""
 
@@ -4342,11 +4343,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "Вхід"
 
@@ -4423,7 +4424,7 @@ msgstr "Менеджер"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4454,9 +4455,9 @@ msgid "May"
 msgstr "травня"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "Нотатка"
@@ -4803,15 +4804,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4825,15 +4826,15 @@ msgstr "Примітки"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "Нічого не введено!"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "Нічого не вибрано!"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "Нема що перенести"
 
@@ -4858,7 +4859,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4877,7 +4878,7 @@ msgstr "Номер"
 msgid "Number Format"
 msgstr "Формат Числа"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4915,7 +4916,7 @@ msgstr "жовтня"
 msgid "October"
 msgstr "Жовтень"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "На руках"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4985,7 +4986,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr ""
 
@@ -5003,12 +5004,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Дата замовлення"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "Не вказано дату замовлення!"
 
@@ -5020,8 +5021,8 @@ msgstr "Виставлення замовлення"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5029,15 +5030,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "Номер замовлення"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "Відсутній номер замовлення"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "Замовлення видалено!"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "Створення замовлення зазнало невдачі!"
 
@@ -5124,8 +5125,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5141,7 +5142,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5149,11 +5150,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "Пакувальний список"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "Не вказано дату пакувального списку"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "Не вказано номер пакувального списку"
 
@@ -5177,7 +5178,7 @@ msgstr "Заплачено"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr ""
 
@@ -5197,8 +5198,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5219,7 +5220,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5249,7 +5250,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "Пароль"
 
@@ -5318,7 +5319,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr ""
 
@@ -5330,7 +5331,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5339,7 +5340,7 @@ msgstr ""
 msgid "Payments"
 msgstr "Платежі"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5347,11 +5348,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5386,7 +5387,7 @@ msgstr "Тел."
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5517,8 +5518,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "Виставити"
@@ -5535,7 +5536,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "Виставити як новий"
 
@@ -5630,9 +5631,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "Надрукувати"
@@ -5641,11 +5642,11 @@ msgstr "Надрукувати"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "Надрукувати і зберегти"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr ""
 
@@ -5697,15 +5698,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5727,7 +5728,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5770,8 +5771,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5810,7 +5811,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5840,8 +5841,8 @@ msgid "Quarter"
 msgstr "Квартал"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5857,7 +5858,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "Дата котирування"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "Відсутня дата котирування!"
 
@@ -5865,11 +5866,11 @@ msgstr "Відсутня дата котирування!"
 msgid "Quotation Number"
 msgstr "Номер котирування"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "Відсутній номер котирування!"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "Котирування видалено!"
 
@@ -5884,7 +5885,7 @@ msgstr "Котирування"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5910,7 +5911,7 @@ msgstr "RFQs"
 msgid "ROP"
 msgstr "ROP"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5951,7 +5952,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "Отримано"
 
@@ -5980,7 +5981,7 @@ msgstr "Належності (дебити)"
 msgid "Receive"
 msgstr "Отримати"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "Отримати товари"
 
@@ -6008,7 +6009,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "Внести в"
 
@@ -6034,11 +6035,11 @@ msgstr "Періодичні проводки"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "Посилання"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6075,9 +6076,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "Залишилось"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6153,11 +6158,11 @@ msgstr ""
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "Запит"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6278,11 +6283,11 @@ msgstr "SIC"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "SKU"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6311,7 +6316,7 @@ msgstr "Продаж"
 msgid "Sales"
 msgstr "Продаж"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "Рахунок-фактура"
@@ -6320,8 +6325,8 @@ msgstr "Рахунок-фактура"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6386,7 +6391,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6431,7 +6436,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6439,7 +6444,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6456,7 +6461,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "Зберегти як нове"
@@ -6465,7 +6470,7 @@ msgstr "Зберегти як нове"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6503,7 +6508,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "Розклад"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "В розкладі"
 
@@ -6662,11 +6667,11 @@ msgstr ""
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "Виберіть постачальника"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr ""
 
@@ -6686,12 +6691,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "Виберіть postscript або PDF"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "Виберіть txt, postscript або PDF!"
 
@@ -6782,7 +6787,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "Серійний No."
 
@@ -6800,11 +6805,11 @@ msgstr "Серійний номер"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "Послуга"
 
@@ -6848,13 +6853,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "Відіслати"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "Відіслати товари"
 
@@ -6884,12 +6889,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "Відіслати до"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6906,23 +6911,23 @@ msgstr "Відіслати через"
 msgid "Shipping"
 msgstr "Відісилання"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "Дата відсилання"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "Відсутня дата відсилання!"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6998,12 +7003,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7084,11 +7089,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "Штат"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7172,7 +7177,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7235,8 +7240,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7258,7 +7263,7 @@ msgstr "Податок"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7268,7 +7273,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7292,7 +7297,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7300,7 +7305,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "Податок включено"
@@ -7399,7 +7404,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7619,7 +7624,7 @@ msgstr ""
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7654,7 +7659,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr ""
 
@@ -7700,7 +7705,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7721,7 +7726,7 @@ msgstr ""
 msgid "Total"
 msgstr "Загальна Сума"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7733,6 +7738,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr ""
@@ -7741,7 +7750,7 @@ msgstr ""
 msgid "Trade Discount"
 msgstr "Торгова знижка"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr ""
 
@@ -7774,20 +7783,20 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "Перенесення"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "Перенести інвентар"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr ""
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "Перенести до"
 
@@ -7874,7 +7883,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7935,7 +7944,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7951,7 +7960,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7969,7 +7978,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8021,20 +8030,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "Оновити"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "Оновлено"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8096,7 +8105,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8182,8 +8191,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8202,7 +8211,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "Історія постачальника"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "Рахунок-фактура"
@@ -8218,7 +8227,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8241,7 +8250,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "Постачальник не існує"
 
@@ -8278,7 +8287,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8355,7 +8364,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "Який це вид/тип елемента"
 
@@ -8371,7 +8380,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8429,7 +8438,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "Tak"
@@ -8448,11 +8457,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8519,7 +8528,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8563,7 +8572,7 @@ msgstr "завершено"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "шт."
 

--- a/locale/po/zh-Hans.po
+++ b/locale/po/zh-Hans.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese Simplified (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/zh-Hans/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "新增職員"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "新增外汇率"
 
@@ -458,11 +458,11 @@ msgstr "新增原料"
 msgid "Add Pricegroup"
 msgstr "新增价格组"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "新增采购单"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "新增报价单"
 
@@ -470,7 +470,7 @@ msgstr "新增报价单"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "新增報價單要求"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "新增標準工業分類代碼"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "新增销售发票"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "新增销货单"
 
@@ -502,7 +502,7 @@ msgstr "新增報稅單"
 msgid "Add Timecard"
 msgstr "新增工時卡"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "新增到清單"
 
@@ -524,7 +524,7 @@ msgstr "新增使用者"
 msgid "Add Vendor"
 msgstr "新增供應商"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "新增供應商發票"
 
@@ -536,15 +536,15 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr "以調整"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "核准"
@@ -826,20 +826,20 @@ msgstr "四月"
 msgid "April"
 msgstr "四月"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "您是否确定要删除订单编号"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "您是否确定要删除报价单编号"
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "八月"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "餘額"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "资产负债表"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "箱"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "不能刪除項目！"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "不能删除定单"
 
@@ -1383,19 +1383,19 @@ msgstr "不能删除定单"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "不能删除报价单"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "不能在已關閉的時段內加入發票！"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "不能在已关闭的时段内加入款项"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "不能在已關閉的時段內加入交易！"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "在交易同一帳戶不能又出現在借方又出現在貸方！"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "不能加入交易！"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "不能储存定单"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "不能儲存報價單！"
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr "現金"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "公司"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "入帳成功！"
 
@@ -1702,7 +1703,7 @@ msgstr "入帳成功！"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "成本"
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "不能儲存！"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "存貨清單不能轉移！"
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "貸方"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "目前"
 
@@ -1969,7 +1970,7 @@ msgstr "目前"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr "客戶編號"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "未指明客户"
 
@@ -2065,7 +2066,7 @@ msgstr "沒有此客戶的記錄！"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "付款日期"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "收款日期"
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "未指明收款日期"
 
@@ -2265,7 +2266,7 @@ msgstr "日"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "借方"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "巳完成"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "到期日"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "未指明到期日！"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "電子郵件"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr "每"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "汇率"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "汇率"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "未指明付款的汇率"
 
@@ -3139,7 +3140,7 @@ msgstr "未指明付款的汇率"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "未指明匯率！"
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "外幣兌換"
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "從貨倉"
 
@@ -3465,7 +3466,7 @@ msgstr "總帳索引編號"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr "生成"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "产生订单"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "生成採購單"
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "组"
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "內部備忘錄"
 
@@ -3853,11 +3854,11 @@ msgstr "在停用此项组合品之前, 存货数量必需为零!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "已儲存存貨！"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "轉移的存貨！"
 
@@ -3865,8 +3866,8 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "发票"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "发票日期"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "未指明发票日期!"
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "发票编号"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "未指明發票編號！"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "已刪除項目！"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "查无此项目"
 
@@ -4011,7 +4012,7 @@ msgstr "一月"
 msgid "January"
 msgstr "一月"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "六月"
 msgid "June"
 msgstr "六月"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "交付時間"
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "登入"
 
@@ -4418,7 +4419,7 @@ msgstr "經理"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "五月"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "備忘錄"
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "備註"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "没有巳输入"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "没有巳选择"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "沒有可轉移的項目！"
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "編號"
 msgid "Number Format"
 msgstr "數字格式"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "十月"
 msgid "October"
 msgstr "十月"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "已有存量"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "订单"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "未指明下單日期！"
 
@@ -5015,8 +5016,8 @@ msgstr "下单项目"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "订单编号"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "未指明訂單編號！"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "已刪除訂單！"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "生成訂單失敗！"
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "出货单"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "未指明出貨單日期！"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "未指明包装清单编号!"
 
@@ -5172,7 +5173,7 @@ msgstr "已付"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "零件"
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "密碼"
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "未指明付款日期!"
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr "付款"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr "电话号码"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "加入"
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "當新的加入"
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "列印"
@@ -5636,11 +5637,11 @@ msgstr "列印"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "列印並儲存"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "列印並儲存作為新的"
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr "季度"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "報價單日期"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "未指明報價單日期！"
 
@@ -5860,11 +5861,11 @@ msgstr "未指明報價單日期！"
 msgid "Quotation Number"
 msgstr "报价单号码"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "未指明报价单号码"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "巳删除报价单"
 
@@ -5879,7 +5880,7 @@ msgstr "報價單"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr "报价请求"
 msgid "ROP"
 msgstr "再订点"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "已收到"
 
@@ -5975,7 +5976,7 @@ msgstr "应收帐户"
 msgid "Receive"
 msgstr "收到"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "收到貨物"
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "記錄於"
 
@@ -6029,11 +6030,11 @@ msgstr "多次记录"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "参考资料"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,9 +6071,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "尚【◎Fix:◎余;◎馀】"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr "報表"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "需要"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr "標準工業分類代碼"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "被指定的数量"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr "销售"
 msgid "Sales"
 msgstr "销售"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "銷售發票"
@@ -6315,8 +6320,8 @@ msgstr "銷售發票"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "銷售發票/應收帳交易編號"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "當新的儲存"
@@ -6460,7 +6465,7 @@ msgstr "當新的儲存"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "時間表"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "編排了時間"
 
@@ -6657,11 +6662,11 @@ msgstr "選擇客戶"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "选厂商"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "選擇印表機！"
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "選擇postscript或PDF！"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "選擇文字、postscript或PDF！"
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "序號"
 
@@ -6795,11 +6800,11 @@ msgstr "序號"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "服務"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "付運"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "海运货物"
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "海运至"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr "由海运"
 msgid "Shipping"
 msgstr "付運"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "付運日期"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "未指明海运日期"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "州"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "税金"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "巳含税金"
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr "次"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "到倉庫"
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr "总计"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "需要追蹤的項目"
@@ -7736,7 +7745,7 @@ msgstr "需要追蹤的項目"
 msgid "Trade Discount"
 msgstr "贸易折扣"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "交易"
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "交易"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "转移"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "转移存货"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "由這裡取貨"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "存貨至"
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "更新"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "巳更新"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "供应商历史"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "供应商发票"
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "未指明供应商"
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "此项目的型态?"
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "是"
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr "完成"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "個"
 

--- a/locale/po/zh-Hant.po
+++ b/locale/po/zh-Hant.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese Traditional (http://www.transifex.com/ledgersmb/"
 "ledgersmb/language/zh-Hant/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "新增職員"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "新增外汇率"
 
@@ -458,11 +458,11 @@ msgstr "新增原料"
 msgid "Add Pricegroup"
 msgstr "新增价格组"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "新增采购单"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "新增报价单"
 
@@ -470,7 +470,7 @@ msgstr "新增报价单"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "新增報價單要求"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "新增標準工業分類代碼"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "新增销售发票"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "新增销货单"
 
@@ -502,7 +502,7 @@ msgstr "新增報稅單"
 msgid "Add Timecard"
 msgstr "新增工時卡"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "新增到清單"
 
@@ -524,7 +524,7 @@ msgstr "新增使用者"
 msgid "Add Vendor"
 msgstr "新增供應商"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "新增供應商發票"
 
@@ -536,15 +536,15 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr "以調整"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "核准"
@@ -826,20 +826,20 @@ msgstr "四月"
 msgid "April"
 msgstr "四月"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "您是否确定要删除订单编号"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "您是否确定要删除报价单编号"
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "八月"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "餘額"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "资产负债表"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "箱"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "不能刪除項目！"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "不能删除定单"
 
@@ -1383,19 +1383,19 @@ msgstr "不能删除定单"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "不能删除报价单"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "不能在已關閉的時段內加入發票！"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "不能在已关闭的时段内加入款项"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "不能在已關閉的時段內加入交易！"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "在交易同一帳戶不能又出現在借方又出現在貸方！"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "不能加入交易！"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "不能储存定单"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "不能儲存報價單！"
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr "現金"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "公司"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "入帳成功！"
 
@@ -1702,7 +1703,7 @@ msgstr "入帳成功！"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "成本"
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "不能儲存！"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "存貨清單不能轉移！"
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "貸方"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "目前"
 
@@ -1969,7 +1970,7 @@ msgstr "目前"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr "客戶編號"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "未指明客户"
 
@@ -2065,7 +2066,7 @@ msgstr "沒有此客戶的記錄！"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "付款日期"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "收款日期"
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "未指明收款日期"
 
@@ -2265,7 +2266,7 @@ msgstr "日"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "借方"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "巳完成"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "到期日"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "未指明到期日！"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "電子郵件"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr "每"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "汇率"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "汇率"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "未指明付款的汇率"
 
@@ -3139,7 +3140,7 @@ msgstr "未指明付款的汇率"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "未指明匯率！"
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "外幣兌換"
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "從貨倉"
 
@@ -3465,7 +3466,7 @@ msgstr "總帳索引編號"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr "生成"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "产生订单"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "生成採購單"
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "组"
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "內部備忘錄"
 
@@ -3853,11 +3854,11 @@ msgstr "在停用此项组合品之前, 存货数量必需为零!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "已儲存存貨！"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "轉移的存貨！"
 
@@ -3865,8 +3866,8 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "发票"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "发票日期"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "未指明发票日期!"
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "发票编号"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "未指明發票編號！"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "已刪除項目！"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "查无此项目"
 
@@ -4011,7 +4012,7 @@ msgstr "一月"
 msgid "January"
 msgstr "一月"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "六月"
 msgid "June"
 msgstr "六月"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "交付時間"
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "登入"
 
@@ -4418,7 +4419,7 @@ msgstr "經理"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "五月"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "備忘錄"
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "備註"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "没有巳输入"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "没有巳选择"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "沒有可轉移的項目！"
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "編號"
 msgid "Number Format"
 msgstr "數字格式"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "十月"
 msgid "October"
 msgstr "十月"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "已有存量"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "订单"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "未指明下單日期！"
 
@@ -5015,8 +5016,8 @@ msgstr "下单项目"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "订单编号"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "未指明訂單編號！"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "已刪除訂單！"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "生成訂單失敗！"
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "出货单"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "未指明出貨單日期！"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "未指明包装清单编号!"
 
@@ -5172,7 +5173,7 @@ msgstr "已付"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "零件"
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "密碼"
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "未指明付款日期!"
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr "付款"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr "电话号码"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "加入"
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "當新的加入"
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "列印"
@@ -5636,11 +5637,11 @@ msgstr "列印"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "列印並儲存"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "列印並儲存作為新的"
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr "季度"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "報價單日期"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "未指明報價單日期！"
 
@@ -5860,11 +5861,11 @@ msgstr "未指明報價單日期！"
 msgid "Quotation Number"
 msgstr "报价单号码"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "未指明报价单号码"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "巳删除报价单"
 
@@ -5879,7 +5880,7 @@ msgstr "報價單"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr "报价请求"
 msgid "ROP"
 msgstr "再订点"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "已收到"
 
@@ -5975,7 +5976,7 @@ msgstr "应收帐户"
 msgid "Receive"
 msgstr "收到"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "收到貨物"
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "記錄於"
 
@@ -6029,11 +6030,11 @@ msgstr "多次记录"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "参考资料"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,9 +6071,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "尚【◎Fix:◎余;◎馀】"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr "報表"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "需要"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr "標準工業分類代碼"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "被指定的数量"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr "销售"
 msgid "Sales"
 msgstr "销售"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "銷售發票"
@@ -6315,8 +6320,8 @@ msgstr "銷售發票"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "銷售發票/應收帳交易編號"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "當新的儲存"
@@ -6460,7 +6465,7 @@ msgstr "當新的儲存"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "時間表"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "編排了時間"
 
@@ -6657,11 +6662,11 @@ msgstr "選擇客戶"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "选厂商"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "選擇印表機！"
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "選擇postscript或PDF！"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "選擇文字、postscript或PDF！"
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "序號"
 
@@ -6795,11 +6800,11 @@ msgstr "序號"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "服務"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "付運"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "海运货物"
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "海运至"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr "由海运"
 msgid "Shipping"
 msgstr "付運"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "付運日期"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "未指明海运日期"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "州"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "税金"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "巳含税金"
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr "次"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "到倉庫"
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr "总计"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "需要追蹤的項目"
@@ -7736,7 +7745,7 @@ msgstr "需要追蹤的項目"
 msgid "Trade Discount"
 msgstr "贸易折扣"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "交易"
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "交易"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "转移"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "转移存货"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "由這裡取貨"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "存貨至"
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "更新"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "巳更新"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "供应商历史"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "供应商发票"
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "未指明供应商"
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "此项目的型态?"
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "是"
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr "完成"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "個"
 

--- a/locale/po/zh_CN.po
+++ b/locale/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/zh_CN/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "新增职员"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "新增外汇率"
 
@@ -458,11 +458,11 @@ msgstr "新增原料"
 msgid "Add Pricegroup"
 msgstr "新增价格组"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "新增采购单"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "新增报价单"
 
@@ -470,7 +470,7 @@ msgstr "新增报价单"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "新增报价单要求"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "新增原文"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "新增销售发票"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "新增销货单"
 
@@ -502,7 +502,7 @@ msgstr "新增報稅單"
 msgid "Add Timecard"
 msgstr "新增工時卡"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "新增到清單"
 
@@ -524,7 +524,7 @@ msgstr "新增使用者"
 msgid "Add Vendor"
 msgstr "新增供应商"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "新增供应商发票"
 
@@ -536,15 +536,15 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr "以調整"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "核准"
@@ -826,20 +826,20 @@ msgstr "四月"
 msgid "April"
 msgstr "四月"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "您是否确定要删除订单编号"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "您是否确定要删除报价单编号"
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "八月"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "余额"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "资产负债表"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "箱"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "不能删除项目"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "不能删除定单"
 
@@ -1383,19 +1383,19 @@ msgstr "不能删除定单"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "不能删除报价单"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "不能在已关闭的时段内加入发票"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "不能在已关闭的时段内加入款项"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "不能在已关闭的时段内加入交易!"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "在交易同一帳戶不能又出現在借方又出現在貸方！"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "不能加入交易"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "不能储存定单"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "不能储存报价单"
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr "现金"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "公司"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "入帐成功!"
 
@@ -1702,7 +1703,7 @@ msgstr "入帐成功!"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "成本"
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "不能储存"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "存货清单不能转移"
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "贷方"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "目前"
 
@@ -1969,7 +1970,7 @@ msgstr "目前"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr "客户编号"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "未指明客户"
 
@@ -2065,7 +2066,7 @@ msgstr "客户未存档"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "付款日期"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "收款日期"
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "未指明收款日期"
 
@@ -2265,7 +2266,7 @@ msgstr "日"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "借方"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "巳完成"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "到期日"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "未指明到期日!"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "电子邮件"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr "每"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "汇率"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "汇率"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "未指明付款的汇率"
 
@@ -3139,7 +3140,7 @@ msgstr "未指明付款的汇率"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "未指明汇率"
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "外幣兌換"
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "从仓库"
 
@@ -3465,7 +3466,7 @@ msgstr "總帳索引編號"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr "产生"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "产生订单"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "产生采购单"
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "组"
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "内部备忘录"
 
@@ -3853,11 +3854,11 @@ msgstr "在停用此项组合品之前, 存货数量必需为零!"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "巳储存存货"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "转移的存货"
 
@@ -3865,8 +3866,8 @@ msgstr "转移的存货"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "发票"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "发票日期"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "未指明发票日期!"
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "发票编号"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "未指明发票编号!"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "巳删除项目"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "查无此项目"
 
@@ -4011,7 +4012,7 @@ msgstr "一月"
 msgid "January"
 msgstr "一月"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "六月"
 msgid "June"
 msgstr "六月"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "交货期"
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "登入"
 
@@ -4418,7 +4419,7 @@ msgstr "经理"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "五月"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "备忘录"
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "备注"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "没有巳输入"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "没有巳选择"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "没有可转移的项目"
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "编号"
 msgid "Number Format"
 msgstr "数字格式"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "十月"
 msgid "October"
 msgstr "十月"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "巳有存量"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "订单"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下单日期"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "未指明下单日期!"
 
@@ -5015,8 +5016,8 @@ msgstr "下单项目"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "订单编号"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "未指明订单编号!"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "巳删除订单"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "订单产生失败!"
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "出货单"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "未指明包装清单日期!"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "未指明包装清单编号!"
 
@@ -5172,7 +5173,7 @@ msgstr "已付"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "原料"
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "密码"
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "未指明付款日期!"
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr "付款"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr "电话号码"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "加入"
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "当新的加入"
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "列印"
@@ -5636,11 +5637,11 @@ msgstr "列印"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "打印及储存"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "列印及另存新档"
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr "季度"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "报价单日期"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "未指明报价单日期"
 
@@ -5860,11 +5861,11 @@ msgstr "未指明报价单日期"
 msgid "Quotation Number"
 msgstr "报价单号码"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "未指明报价单号码"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "巳删除报价单"
 
@@ -5879,7 +5880,7 @@ msgstr "报价单"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr "报价请求"
 msgid "ROP"
 msgstr "再订点"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "巳收到"
 
@@ -5975,7 +5976,7 @@ msgstr "应收帐户"
 msgid "Receive"
 msgstr "收到"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "收到货物"
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "记录【◎Fix:◎于;◎於】"
 
@@ -6029,11 +6030,11 @@ msgstr "多次记录"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "参考资料"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,9 +6071,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "尚【◎Fix:◎余;◎馀】"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr "报表"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "需要"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr "原文"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "被指定的数量"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr "销售"
 msgid "Sales"
 msgstr "销售"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "销售发票"
@@ -6315,8 +6320,8 @@ msgstr "销售发票"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "銷售發票/應收帳交易編號"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "当新的储存"
@@ -6460,7 +6465,7 @@ msgstr "当新的储存"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "预定"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "編排了時間"
 
@@ -6657,11 +6662,11 @@ msgstr "選擇客戶"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "选厂商"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "選擇印表機！"
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "【◎Fix:◎于;◎於】附言或PDF中选一"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "選擇文字、postscript或PDF！"
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "序号"
 
@@ -6795,11 +6800,11 @@ msgstr "序号"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "服务"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "船"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "海运货物"
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "海运至"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr "由海运"
 msgid "Shipping"
 msgstr "海运"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "海运日期"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "未指明海运日期"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "州"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "税金"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "巳含税金"
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr "次"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "到仓库"
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr "总计"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "需要追蹤的項目"
@@ -7736,7 +7745,7 @@ msgstr "需要追蹤的項目"
 msgid "Trade Discount"
 msgstr "贸易折扣"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "记录"
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "交易"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "转移"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "转移存货"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "调动从"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "存货至"
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "更新"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "巳更新"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "供应商历史"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "供应商发票"
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "未指明供应商"
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "此项目的型态?"
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "是"
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr "完成"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "个"
 

--- a/locale/po/zh_TW.po
+++ b/locale/po/zh_TW.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2023-01-02 23:47+0000\n"
+"POT-Creation-Date: 2023-01-27 13:25+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/zh_TW/)\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Access Denied"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:103
+#: UI/src/views/LoginPage.vue:113
 msgid "Access denied: Bad username or password"
 msgstr ""
 
@@ -192,9 +192,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Reconciliation/Summary.pm:137
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:68
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:70
-#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:637 old/bin/aa.pl:712
-#: old/bin/aa.pl:882 old/bin/ic.pl:1110 old/bin/ir.pl:427 old/bin/ir.pl:818
-#: old/bin/is.pl:463 old/bin/is.pl:914 old/bin/oe.pl:449
+#: lib/LedgerSMB/Scripts/report_aging.pm:141 old/bin/aa.pl:640 old/bin/aa.pl:715
+#: old/bin/aa.pl:889 old/bin/ic.pl:1110 old/bin/ir.pl:428 old/bin/ir.pl:840
+#: old/bin/is.pl:466 old/bin/is.pl:938 old/bin/oe.pl:449
 #: UI/Contact/contact.html:15 UI/Contact/divs/credit.html:186
 #: UI/Contact/divs/credit.html:187 UI/Reports/filters/aging.html:24
 #: UI/Reports/filters/gl.html:31 UI/Reports/filters/gl.html:294
@@ -202,7 +202,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:29 UI/Reports/filters/orders.html:29
 #: UI/Reports/filters/orders.html:177
 #: UI/Reports/filters/reconciliation_search.html:42 UI/accounts/edit.html:119
-#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:132
+#: UI/budgetting/budget_entry.html:57 UI/journal/journal_entry.html:135
 #: UI/payments/payment2.html:86 UI/payments/payment2.html:268
 #: UI/payments/payment2.html:345 UI/payments/payments_detail.html:135
 #: UI/payments/payments_detail.html:223 UI/payments/payments_filter.html:62
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Accrual Basis:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:819
+#: lib/LedgerSMB/Scripts/asset.pm:821
 msgid "Accum. Depreciation"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Add Employee"
 msgstr "新增職員"
 
-#: old/bin/oe.pl:1624
+#: old/bin/oe.pl:1625
 msgid "Add Exchange Rate"
 msgstr "新增外匯率"
 
@@ -458,11 +458,11 @@ msgstr "新增零件"
 msgid "Add Pricegroup"
 msgstr "新增價格組別"
 
-#: old/bin/io.pl:966 old/bin/oe.pl:63
+#: old/bin/io.pl:965 old/bin/oe.pl:63
 msgid "Add Purchase Order"
 msgstr "新增採購單"
 
-#: old/bin/io.pl:1023 old/bin/oe.pl:75
+#: old/bin/io.pl:1022 old/bin/oe.pl:75
 msgid "Add Quotation"
 msgstr "新增報價單"
 
@@ -470,7 +470,7 @@ msgstr "新增報價單"
 msgid "Add Reporting Unit"
 msgstr ""
 
-#: old/bin/io.pl:1004 old/bin/oe.pl:71
+#: old/bin/io.pl:1003 old/bin/oe.pl:71
 msgid "Add Request for Quotation"
 msgstr "新增報價單要求"
 
@@ -482,11 +482,11 @@ msgstr ""
 msgid "Add SIC"
 msgstr "新增標準工業分類代碼"
 
-#: old/bin/is.pl:116 old/bin/oe.pl:1531
+#: old/bin/is.pl:116 old/bin/oe.pl:1532
 msgid "Add Sales Invoice"
 msgstr "新增銷售發票"
 
-#: old/bin/io.pl:985 old/bin/oe.pl:67
+#: old/bin/io.pl:984 old/bin/oe.pl:67
 msgid "Add Sales Order"
 msgstr "新增銷貨單"
 
@@ -502,7 +502,7 @@ msgstr "新增報稅單"
 msgid "Add Timecard"
 msgstr "新增工時卡"
 
-#: old/bin/io.pl:1829
+#: old/bin/io.pl:1826
 msgid "Add To List"
 msgstr "新增到清單"
 
@@ -524,7 +524,7 @@ msgstr "新增使用者"
 msgid "Add Vendor"
 msgstr "新增供應商"
 
-#: old/bin/ir.pl:123 old/bin/oe.pl:1522
+#: old/bin/ir.pl:123 old/bin/oe.pl:1523
 msgid "Add Vendor Invoice"
 msgstr "新增供應商發票"
 
@@ -536,15 +536,15 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增倉庫"
 
-#: old/bin/io.pl:1642
+#: old/bin/io.pl:1641
 msgid "Add line1"
 msgstr ""
 
-#: old/bin/io.pl:1645
+#: old/bin/io.pl:1644
 msgid "Add line2"
 msgstr ""
 
-#: old/bin/io.pl:1649
+#: old/bin/io.pl:1648
 msgid "Add line3 "
 msgstr ""
 
@@ -572,8 +572,8 @@ msgstr ""
 msgid "Adding"
 msgstr ""
 
-#: old/bin/aa.pl:642 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:437
-#: old/bin/is.pl:473 old/bin/oe.pl:454 old/bin/pe.pl:578
+#: old/bin/aa.pl:645 old/bin/arap.pl:169 old/bin/ic.pl:1672 old/bin/ir.pl:438
+#: old/bin/is.pl:476 old/bin/oe.pl:454 old/bin/pe.pl:578
 #: UI/Contact/divs/address.html:80 UI/Contact/divs/address.html:119
 #: UI/Contact/divs/address.html:122 UI/Reports/filters/contact_search.html:89
 #: UI/Reports/filters/purchase_history.html:67
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Adjusted"
 msgstr "以調整"
 
-#: lib/LedgerSMB/Scripts/asset.pm:825
+#: lib/LedgerSMB/Scripts/asset.pm:827
 msgid "Adjusted Basis"
 msgstr ""
 
@@ -682,9 +682,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:237
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:281
 #: lib/LedgerSMB/Report/Orders.pm:225
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:710
-#: old/bin/aa.pl:879 old/bin/am.pl:312 old/bin/ir.pl:595 old/bin/ir.pl:815
-#: old/bin/is.pl:689 old/bin/is.pl:911 old/bin/pe.pl:952
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:131 old/bin/aa.pl:713
+#: old/bin/aa.pl:886 old/bin/am.pl:312 old/bin/ir.pl:596 old/bin/ir.pl:837
+#: old/bin/is.pl:692 old/bin/is.pl:935 old/bin/pe.pl:952
 #: UI/Reports/filters/gl.html:100 UI/Reports/filters/gl.html:106
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:317 UI/Reports/filters/orders.html:190
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:125
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:228
-#: lib/LedgerSMB/Scripts/asset.pm:528 lib/LedgerSMB/Scripts/asset.pm:644
-#: lib/LedgerSMB/Scripts/asset.pm:746 lib/LedgerSMB/Scripts/asset.pm:852
+#: lib/LedgerSMB/Scripts/asset.pm:529 lib/LedgerSMB/Scripts/asset.pm:645
+#: lib/LedgerSMB/Scripts/asset.pm:747 lib/LedgerSMB/Scripts/asset.pm:854
 #: lib/LedgerSMB/Scripts/budgets.pm:113 UI/reconciliation/report.html:438
 msgid "Approve"
 msgstr "核准"
@@ -826,20 +826,20 @@ msgstr "四月"
 msgid "April"
 msgstr "四月"
 
-#: lib/LedgerSMB/Scripts/asset.pm:579 lib/LedgerSMB/Scripts/asset.pm:689
-#: lib/LedgerSMB/Scripts/asset.pm:813
+#: lib/LedgerSMB/Scripts/asset.pm:580 lib/LedgerSMB/Scripts/asset.pm:695
+#: lib/LedgerSMB/Scripts/asset.pm:804
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:718
+#: lib/LedgerSMB/Scripts/asset.pm:719
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: old/bin/oe.pl:1404
+#: old/bin/oe.pl:1405
 msgid "Are you sure you want to delete Order Number"
 msgstr "您是否確定要刪除訂單編號"
 
-#: old/bin/oe.pl:1409
+#: old/bin/oe.pl:1410
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "您是否確定要刪除報價單編號"
 
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:332
+#: templates/demo/balance_sheet.html:360
 msgid "Assets to Equity"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:329
+#: templates/demo/balance_sheet.html:357
 msgid "Assets to Liabilities"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1113
-#: old/bin/ic.pl:922 old/bin/ir.pl:1029 old/bin/is.pl:1118 old/bin/oe.pl:995
+#: lib/LedgerSMB/Report/File/Incoming.pm:102 old/bin/aa.pl:1120
+#: old/bin/ic.pl:922 old/bin/ir.pl:1051 old/bin/is.pl:1142 old/bin/oe.pl:996
 #: UI/lib/attachments.html:56
 msgid "Attach"
 msgstr ""
@@ -952,31 +952,31 @@ msgstr ""
 msgid "Attached By"
 msgstr ""
 
-#: old/bin/aa.pl:1085 old/bin/ic.pl:894 old/bin/ir.pl:1003 old/bin/is.pl:1092
-#: old/bin/oe.pl:969 UI/lib/attachments.html:32
+#: old/bin/aa.pl:1092 old/bin/ic.pl:894 old/bin/ir.pl:1025 old/bin/is.pl:1116
+#: old/bin/oe.pl:970 UI/lib/attachments.html:32
 msgid "Attached To"
 msgstr ""
 
-#: old/bin/aa.pl:1084 old/bin/ic.pl:893 old/bin/ir.pl:1002 old/bin/is.pl:1091
-#: old/bin/oe.pl:968 UI/lib/attachments.html:31
+#: old/bin/aa.pl:1091 old/bin/ic.pl:893 old/bin/ir.pl:1024 old/bin/is.pl:1115
+#: old/bin/oe.pl:969 UI/lib/attachments.html:31
 msgid "Attached To Type"
 msgstr ""
 
-#: old/bin/aa.pl:1061 old/bin/ic.pl:870 old/bin/ir.pl:979 old/bin/is.pl:1068
-#: old/bin/oe.pl:945 UI/lib/attachments.html:4
+#: old/bin/aa.pl:1068 old/bin/ic.pl:870 old/bin/ir.pl:1001 old/bin/is.pl:1092
+#: old/bin/oe.pl:946 UI/lib/attachments.html:4
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: old/bin/aa.pl:1065 old/bin/aa.pl:1086 old/bin/ic.pl:874 old/bin/ic.pl:895
-#: old/bin/ir.pl:1004 old/bin/ir.pl:983 old/bin/is.pl:1072 old/bin/is.pl:1093
-#: old/bin/oe.pl:949 old/bin/oe.pl:970 UI/lib/attachments.html:10
+#: old/bin/aa.pl:1072 old/bin/aa.pl:1093 old/bin/ic.pl:874 old/bin/ic.pl:895
+#: old/bin/ir.pl:1005 old/bin/ir.pl:1026 old/bin/is.pl:1096 old/bin/is.pl:1117
+#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:10
 #: UI/lib/attachments.html:33
 msgid "Attached at"
 msgstr ""
 
-#: old/bin/aa.pl:1066 old/bin/aa.pl:1087 old/bin/ic.pl:875 old/bin/ic.pl:896
-#: old/bin/ir.pl:1005 old/bin/ir.pl:984 old/bin/is.pl:1073 old/bin/is.pl:1094
-#: old/bin/oe.pl:950 old/bin/oe.pl:971 UI/lib/attachments.html:11
+#: old/bin/aa.pl:1073 old/bin/aa.pl:1094 old/bin/ic.pl:875 old/bin/ic.pl:896
+#: old/bin/ir.pl:1006 old/bin/ir.pl:1027 old/bin/is.pl:1097 old/bin/is.pl:1118
+#: old/bin/oe.pl:951 old/bin/oe.pl:972 UI/lib/attachments.html:11
 #: UI/lib/attachments.html:34
 msgid "Attached by"
 msgstr ""
@@ -1009,7 +1009,7 @@ msgstr "八月"
 msgid "Author: [_1]"
 msgstr ""
 
-#: old/bin/ir.pl:556 old/bin/is.pl:409 old/bin/is.pl:644
+#: old/bin/ir.pl:557 old/bin/is.pl:411 old/bin/is.pl:647
 msgid "Automatic"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Balance"
 msgstr "餘額"
 
 #: UI/Reports/balance_sheet.html:23 UI/Reports/filters/balance_sheet.html:7
-#: templates/demo/balance_sheet.html:255 templates/demo/balance_sheet.tex:43
+#: templates/demo/balance_sheet.html:283 templates/demo/balance_sheet.tex:43
 #: sql/Pg-database.sql:2597
 msgid "Balance Sheet"
 msgstr "資產負債表"
@@ -1125,8 +1125,8 @@ msgstr ""
 msgid "Base system"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:597
-#: old/bin/is.pl:691
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:95 old/bin/ir.pl:598
+#: old/bin/is.pl:694
 msgid "Basis"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Batch Class"
 msgstr ""
 
-#: old/bin/aa.pl:606
+#: old/bin/aa.pl:609
 msgid "Batch Control Code"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Batch ID Missing"
 msgstr ""
 
-#: old/bin/aa.pl:611
+#: old/bin/aa.pl:614
 msgid "Batch Name"
 msgstr ""
 
@@ -1205,14 +1205,14 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:137
 #: lib/LedgerSMB/Report/Inventory/Search.pm:239 old/bin/ic.pl:2087
-#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1972
+#: old/bin/ic.pl:485 old/bin/io.pl:245 old/bin/oe.pl:1973
 #: UI/Reports/filters/search_goods.html:352 templates/demo/bin_list.html:106
 #: templates/demo/bin_list.tex:124 templates/demo/pick_list.html:96
 #: templates/demo/pick_list.tex:117 templates/demo/work_order.html:103
 msgid "Bin"
 msgstr "箱"
 
-#: old/bin/am.pl:969 old/bin/io.pl:1211 old/bin/oe.pl:277 old/bin/oe.pl:289
+#: old/bin/am.pl:969 old/bin/io.pl:1210 old/bin/oe.pl:277 old/bin/oe.pl:289
 #: old/bin/printer.pl:85 old/bin/printer.pl:99 templates/demo/bin_list.html:16
 #: templates/demo/bin_list.html:32 templates/demo/bin_list.tex:89
 #: sql/Pg-database.sql:2715 sql/Pg-database.sql:2728
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "CSV"
 msgstr ""
 
-#: old/bin/ir.pl:738 old/bin/is.pl:407 old/bin/is.pl:833
+#: old/bin/ir.pl:748 old/bin/is.pl:409 old/bin/is.pl:845
 msgid "Calculate Taxes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't post credits and debits on one line."
 msgstr ""
 
-#: old/bin/is.pl:603
+#: old/bin/is.pl:606
 msgid "Can't void a voided invoice!"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/report_aging.pm:157 lib/LedgerSMB/Scripts/setup.pm:184
-#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1833
+#: lib/LedgerSMB/Scripts/setup.pm:240 old/bin/io.pl:1830
 #: UI/templates/widget.html:146 UI/templates/widget.html:162
 #: UI/src/components/ConfigTableRow.vue:22
 msgid "Cancel"
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Cannot delete item!"
 msgstr "不能刪除項目！"
 
-#: old/bin/oe.pl:1442
+#: old/bin/oe.pl:1443
 msgid "Cannot delete order!"
 msgstr "不能刪除定單！"
 
@@ -1383,19 +1383,19 @@ msgstr "不能刪除定單！"
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: old/bin/oe.pl:1446
+#: old/bin/oe.pl:1447
 msgid "Cannot delete quotation!"
 msgstr "不能刪除報價單！"
 
-#: old/bin/ir.pl:1290 old/bin/is.pl:1386
+#: old/bin/ir.pl:1312 old/bin/is.pl:1410
 msgid "Cannot post invoice for a closed period!"
 msgstr "不能在已關閉的時段內加入發票！"
 
-#: old/bin/aa.pl:1384 old/bin/ir.pl:1305 old/bin/is.pl:1401
+#: old/bin/aa.pl:1391 old/bin/ir.pl:1327 old/bin/is.pl:1425
 msgid "Cannot post payment for a closed period!"
 msgstr "不能在已關閉的時段內加入款項！"
 
-#: old/bin/aa.pl:1370 old/bin/gl.pl:580
+#: old/bin/aa.pl:1377 old/bin/gl.pl:580
 msgid "Cannot post transaction for a closed period!"
 msgstr "不能在已關閉的時段內加入交易！"
 
@@ -1404,15 +1404,15 @@ msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr "在交易同一帳戶不能又出現在借方又出現在貸方！"
 
-#: old/bin/aa.pl:1438
+#: old/bin/aa.pl:1445
 msgid "Cannot post transaction!"
 msgstr "不能加入交易！"
 
-#: old/bin/oe.pl:1305
+#: old/bin/oe.pl:1306
 msgid "Cannot save order!"
 msgstr "不能儲存定單！"
 
-#: old/bin/oe.pl:1322
+#: old/bin/oe.pl:1323
 msgid "Cannot save quotation!"
 msgstr "不能儲存報價單！"
 
@@ -1432,7 +1432,8 @@ msgstr ""
 msgid "Cash"
 msgstr "現金"
 
-#: UI/Reports/filters/payments.html:50 UI/payments/payment2.html:346
+#: UI/Reports/filters/payments.html:50 UI/asset/begin_approval.html:65
+#: UI/payments/payment2.html:346
 msgid "Cash Account"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgid "Chord"
 msgstr ""
 
 #: old/bin/arap.pl:171 UI/Contact/divs/address.html:81
-#: UI/Contact/divs/address.html:143 UI/Reports/filters/contact_search.html:94
+#: UI/Contact/divs/address.html:141 UI/Reports/filters/contact_search.html:94
 #: UI/Reports/filters/purchase_history.html:75
 #: t/data/04-complex_template.html:386
 msgid "City"
@@ -1609,7 +1610,7 @@ msgstr ""
 #: UI/Contact/divs/company.html:2 UI/Reports/aging_report.html:12
 #: UI/Reports/display_report.html:19 UI/main.html:32
 #: templates/demo/display_report.html:49 templates/demo/display_report.tex:37
-#: UI/src/views/LoginPage.vue:37
+#: UI/src/views/LoginPage.vue:41
 msgid "Company"
 msgstr "公司"
 
@@ -1642,7 +1643,7 @@ msgstr ""
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:101
+#: UI/src/views/LoginPage.vue:111
 msgid "Company does not exist"
 msgstr ""
 
@@ -1694,7 +1695,7 @@ msgstr ""
 msgid "Confirm Operation"
 msgstr ""
 
-#: old/bin/oe.pl:1423
+#: old/bin/oe.pl:1424
 msgid "Confirm!"
 msgstr "入帳成功！"
 
@@ -1702,7 +1703,7 @@ msgstr "入帳成功！"
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: old/bin/io.pl:1719 UI/Reports/filters/contact_search.html:56
+#: old/bin/io.pl:1716 UI/Reports/filters/contact_search.html:56
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
 #: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
 #: templates/demo/purchase_order.html:77
@@ -1745,8 +1746,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1547 lib/LedgerSMB/Scripts/payment.pm:764
 #: lib/LedgerSMB/Scripts/payment.pm:826 old/bin/arap.pl:263 old/bin/ic.pl:1761
-#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:644
-#: old/bin/oe.pl:1659 old/bin/oe.pl:2183 old/bin/oe.pl:2680 old/bin/pe.pl:1095
+#: old/bin/ic.pl:2042 old/bin/ic.pl:2191 old/bin/ic.pl:949 old/bin/io.pl:643
+#: old/bin/oe.pl:1660 old/bin/oe.pl:2184 old/bin/oe.pl:2681 old/bin/pe.pl:1095
 #: old/bin/pe.pl:240 old/bin/pe.pl:659 old/bin/pe.pl:828
 #: UI/Contact/divs/credit.html:526 UI/Reports/co/filter_bm.html:138
 #: UI/Reports/co/filter_cd.html:114 UI/Reports/filters/aging.html:147
@@ -1757,7 +1758,7 @@ msgstr ""
 #: UI/Reports/filters/invoice_search.html:412 UI/Reports/filters/orders.html:222
 #: UI/Reports/filters/purchase_history.html:360
 #: UI/Reports/filters/taxforms.html:57 UI/Reports/filters/trial_balance.html:127
-#: UI/asset/begin_approval.html:65 UI/asset/begin_report.html:59
+#: UI/asset/begin_approval.html:75 UI/asset/begin_report.html:59
 #: UI/create_batch.html:44 UI/inventory/adjustment_setup.html:34
 #: UI/oe-save-warn.html:18 UI/payments/payments_filter.html:138
 #: UI/timecards/entry_filter.html:41
@@ -1806,7 +1807,7 @@ msgid "Copy to New Name"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Activity.pm:127 old/bin/ic.pl:1017
-#: old/bin/ic.pl:1266 old/bin/oe.pl:2524
+#: old/bin/ic.pl:1266 old/bin/oe.pl:2525
 msgid "Cost"
 msgstr "成本"
 
@@ -1818,19 +1819,19 @@ msgstr ""
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:120
+#: UI/src/components/ServerUI.js:133
 msgid "Could not connect to server"
 msgstr ""
 
-#: old/bin/ir.pl:1269 old/bin/is.pl:1366 old/bin/oe.pl:1338
+#: old/bin/ir.pl:1291 old/bin/is.pl:1390 old/bin/oe.pl:1339
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: old/bin/oe.pl:2116
+#: old/bin/oe.pl:2117
 msgid "Could not save!"
 msgstr "不能儲存！"
 
-#: old/bin/oe.pl:2386
+#: old/bin/oe.pl:2387
 msgid "Could not transfer Inventory!"
 msgstr "存貨清單不能轉移！"
 
@@ -1850,8 +1851,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Listings/Country.pm:62
 #: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:34
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1661
-#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:172
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:34 old/bin/io.pl:1660
+#: UI/Contact/divs/address.html:84 UI/Contact/divs/address.html:170
 #: UI/Contact/divs/company.html:94 UI/Contact/divs/employee.html:96
 #: UI/Contact/divs/person.html:118 UI/Reports/filters/contact_search.html:109
 #: UI/Reports/filters/purchase_history.html:99 UI/payroll/deduction.html:15
@@ -1915,7 +1916,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:91
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:92 UI/Reports/co/filter_bm.html:105
 #: UI/Reports/filters/gl.html:240 UI/Reports/filters/trial_balance.html:5
-#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:135
+#: UI/budgetting/budget_entry.html:62 UI/journal/journal_entry.html:138
 msgid "Credit"
 msgstr "貸方"
 
@@ -1936,7 +1937,7 @@ msgstr ""
 msgid "Credit Invoice"
 msgstr ""
 
-#: old/bin/aa.pl:587 old/bin/ir.pl:406 old/bin/is.pl:442 old/bin/oe.pl:429
+#: old/bin/aa.pl:590 old/bin/ir.pl:407 old/bin/is.pl:445 old/bin/oe.pl:429
 #: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:144
 #: UI/Contact/divs/credit.html:145
 msgid "Credit Limit"
@@ -1960,7 +1961,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/GL.pm:137
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:262
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:278 old/bin/ic.pl:1006
-#: old/bin/ic.pl:1101 old/bin/oe.pl:2529
+#: old/bin/ic.pl:1101 old/bin/oe.pl:2530
 msgid "Curr"
 msgstr "目前"
 
@@ -1969,7 +1970,7 @@ msgstr "目前"
 #: lib/LedgerSMB/Report/Contact/Search.pm:83
 #: lib/LedgerSMB/Report/Inventory/Search.pm:315
 #: lib/LedgerSMB/Report/Orders.pm:230 lib/LedgerSMB/Scripts/currency.pm:240
-#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1638
+#: old/bin/aa.pl:461 old/bin/ir.pl:313 old/bin/is.pl:314 old/bin/oe.pl:1639
 #: old/bin/oe.pl:343 UI/Configuration/rate.html:28
 #: UI/Contact/divs/credit.html:220 UI/Contact/divs/credit.html:221
 #: UI/Contact/pricelist.csv:46 UI/Contact/pricelist.html:57
@@ -2006,7 +2007,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:197
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:251
 #: lib/LedgerSMB/Report/Orders.pm:179 lib/LedgerSMB/Report/Orders.pm:185
-#: old/bin/aa.pl:550 old/bin/ic.pl:1109 old/bin/is.pl:430 old/bin/pe.pl:1074
+#: old/bin/aa.pl:553 old/bin/ic.pl:1109 old/bin/is.pl:432 old/bin/pe.pl:1074
 #: old/bin/pe.pl:924 UI/Contact/divs/credit.html:14
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
@@ -2036,7 +2037,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:117
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:180
-#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1599
+#: lib/LedgerSMB/Scripts/configuration.pm:128 old/bin/io.pl:1598
 #: UI/Reports/filters/invoice_outstanding.html:10
 #: UI/Reports/filters/invoice_search.html:11
 #: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:14
@@ -2049,7 +2050,7 @@ msgstr "客戶編號"
 msgid "Customer Search"
 msgstr ""
 
-#: old/bin/aa.pl:1353 old/bin/is.pl:1375 old/bin/oe.pl:1273 old/bin/pe.pl:1153
+#: old/bin/aa.pl:1360 old/bin/is.pl:1399 old/bin/oe.pl:1274 old/bin/pe.pl:1153
 msgid "Customer missing!"
 msgstr "未指明客戶！"
 
@@ -2065,7 +2066,7 @@ msgstr "沒有此客戶的記錄！"
 msgid "Customer/Vendor Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:808
+#: lib/LedgerSMB/Scripts/asset.pm:816
 msgid "D M"
 msgstr ""
 
@@ -2089,7 +2090,7 @@ msgstr ""
 msgid "Data from your ledger"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1343
+#: lib/LedgerSMB/Scripts/payment.pm:413 old/bin/aa.pl:1350
 msgid "Data not saved.  Please try again."
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Database exists."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:105
+#: UI/src/views/LoginPage.vue:115
 msgid "Database version mismatch"
 msgstr ""
 
@@ -2153,11 +2154,11 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:137
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
 #: lib/LedgerSMB/Scripts/asset.pm:464 lib/LedgerSMB/Scripts/payment.pm:191
-#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:878 old/bin/ir.pl:814
-#: old/bin/is.pl:910 old/bin/oe.pl:1642 old/bin/pe.pl:937
+#: lib/LedgerSMB/Scripts/payment.pm:928 old/bin/aa.pl:885 old/bin/ir.pl:836
+#: old/bin/is.pl:934 old/bin/oe.pl:1643 old/bin/pe.pl:937
 #: UI/Reports/filters/gl.html:203 UI/Reports/filters/orders.html:147
 #: UI/asset/begin_report.html:21 UI/inventory/adjustment_setup.html:16
-#: UI/journal/journal_entry.html:40 UI/payments/payment2.html:100
+#: UI/journal/journal_entry.html:43 UI/payments/payment2.html:100
 #: UI/payments/payments_detail.html:333 UI/payments/use_overpayment2.html:85
 #: templates/demo/ap_transaction.html:60 templates/demo/ap_transaction.html:151
 #: templates/demo/ap_transaction.tex:76 templates/demo/ap_transaction.tex:127
@@ -2195,7 +2196,7 @@ msgstr "付款日期"
 msgid "Date Range"
 msgstr ""
 
-#: old/bin/oe.pl:1847
+#: old/bin/oe.pl:1848
 msgid "Date Received"
 msgstr "收款日期"
 
@@ -2219,7 +2220,7 @@ msgstr ""
 msgid "Date of Birth"
 msgstr ""
 
-#: old/bin/oe.pl:2101
+#: old/bin/oe.pl:2102
 msgid "Date received missing!"
 msgstr "未指明收款日期！"
 
@@ -2265,7 +2266,7 @@ msgstr "日"
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:85
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:86 UI/Reports/filters/gl.html:233
 #: UI/Reports/filters/trial_balance.html:4 UI/budgetting/budget_entry.html:61
-#: UI/journal/journal_entry.html:134
+#: UI/journal/journal_entry.html:137
 msgid "Debit"
 msgstr "借方"
 
@@ -2378,9 +2379,9 @@ msgstr ""
 #: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:121
 #: lib/LedgerSMB/Report/Listings/User.pm:99
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:992
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:234 old/bin/aa.pl:999
 #: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/ic.pl:828 old/bin/ic.pl:850
-#: old/bin/ir.pl:919 old/bin/is.pl:1008 old/bin/oe.pl:699 old/bin/oe.pl:929
+#: old/bin/ir.pl:941 old/bin/is.pl:1032 old/bin/oe.pl:700 old/bin/oe.pl:930
 #: old/bin/pe.pl:156 old/bin/pe.pl:518 UI/Contact/divs/address.html:52
 #: UI/Contact/divs/bank_act.html:15 UI/Contact/divs/contact_info.html:11
 #: UI/Contact/pricelist.html:66 UI/accounts/edit.html:104
@@ -2430,16 +2431,16 @@ msgstr ""
 msgid "Delivery Date"
 msgstr "到期日"
 
-#: lib/LedgerSMB/Scripts/asset.pm:596
+#: lib/LedgerSMB/Scripts/asset.pm:597
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:585
+#: lib/LedgerSMB/Scripts/asset.pm:586
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:573 lib/LedgerSMB/Scripts/asset.pm:683
-#: lib/LedgerSMB/Scripts/asset.pm:796
+#: lib/LedgerSMB/Scripts/asset.pm:574 lib/LedgerSMB/Scripts/asset.pm:689
+#: lib/LedgerSMB/Scripts/asset.pm:798
 msgid "Dep. Starts"
 msgstr ""
 
@@ -2447,11 +2448,11 @@ msgstr ""
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:620
+#: lib/LedgerSMB/Scripts/asset.pm:621
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:614
+#: lib/LedgerSMB/Scripts/asset.pm:615
 msgid "Dep. this run"
 msgstr ""
 
@@ -2473,7 +2474,7 @@ msgstr ""
 msgid "Depreciate Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:511 UI/accounts/edit.html:502
+#: lib/LedgerSMB/Scripts/asset.pm:512 UI/accounts/edit.html:502
 #: sql/Pg-database.sql:2657
 msgid "Depreciation"
 msgstr ""
@@ -2525,13 +2526,13 @@ msgstr ""
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:110
 #: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:74
 #: lib/LedgerSMB/Report/co/Caja_Diaria.pm:76 lib/LedgerSMB/Scripts/asset.pm:331
-#: lib/LedgerSMB/Scripts/asset.pm:695 lib/LedgerSMB/Scripts/asset.pm:791
+#: lib/LedgerSMB/Scripts/asset.pm:684 lib/LedgerSMB/Scripts/asset.pm:793
 #: lib/LedgerSMB/Scripts/currency.pm:138 lib/LedgerSMB/Scripts/currency.pm:53
-#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:657 old/bin/aa.pl:713
+#: lib/LedgerSMB/Scripts/file.pm:138 old/bin/aa.pl:660 old/bin/aa.pl:716
 #: old/bin/am.pl:303 old/bin/ic.pl:1260 old/bin/ic.pl:2016 old/bin/ic.pl:2083
-#: old/bin/ic.pl:739 old/bin/io.pl:1722 old/bin/io.pl:233 old/bin/ir.pl:454
-#: old/bin/is.pl:498 old/bin/oe.pl:1965 old/bin/oe.pl:2164 old/bin/oe.pl:2237
-#: old/bin/oe.pl:2271 old/bin/oe.pl:2516 old/bin/pe.pl:221 old/bin/pe.pl:267
+#: old/bin/ic.pl:739 old/bin/io.pl:1719 old/bin/io.pl:233 old/bin/ir.pl:455
+#: old/bin/is.pl:501 old/bin/oe.pl:1966 old/bin/oe.pl:2165 old/bin/oe.pl:2238
+#: old/bin/oe.pl:2272 old/bin/oe.pl:2517 old/bin/pe.pl:221 old/bin/pe.pl:267
 #: old/bin/pe.pl:296 old/bin/pe.pl:947 UI/Contact/divs/contact_info.html:30
 #: UI/Contact/divs/contact_info.html:99 UI/Contact/divs/credit.html:28
 #: UI/Contact/divs/credit.html:85 UI/Contact/divs/credit.html:86
@@ -2548,7 +2549,7 @@ msgstr ""
 #: UI/budgetting/budget_entry.html:26 UI/budgetting/budget_entry.html:63
 #: UI/create_batch.html:19 UI/create_batch.html:73
 #: UI/file/internal-file-list.html:43 UI/inventory/adjustment_entry.html:25
-#: UI/journal/journal_entry.html:53 UI/payments/payment2.html:188
+#: UI/journal/journal_entry.html:56 UI/payments/payment2.html:188
 #: UI/reconciliation/report.html:150 UI/reconciliation/report.html:265
 #: UI/reconciliation/report.html:338 UI/timecards/timecard-week.html:111
 #: UI/timecards/timecard.html:45 templates/demo/bin_list.html:100
@@ -2619,16 +2620,16 @@ msgstr ""
 msgid "Discount:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:706
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:512 sql/Pg-database.sql:2655
+#: lib/LedgerSMB/Scripts/asset.pm:513 sql/Pg-database.sql:2655
 #: sql/Pg-database.sql:2658
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:802
+#: lib/LedgerSMB/Scripts/asset.pm:810
 msgid "Disposal Date"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:859
+#: lib/LedgerSMB/Scripts/asset.pm:861
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -2644,7 +2645,7 @@ msgstr ""
 msgid "Division by 0 error"
 msgstr ""
 
-#: old/bin/io.pl:1947
+#: old/bin/io.pl:1944
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
@@ -2660,7 +2661,7 @@ msgstr ""
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: old/bin/oe.pl:2062 old/bin/oe.pl:2070
+#: old/bin/oe.pl:2063 old/bin/oe.pl:2071
 msgid "Done"
 msgstr "已完成"
 
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Dr."
 msgstr ""
 
-#: old/bin/aa.pl:1222 old/bin/aa.pl:1488 old/bin/gl.pl:106 old/bin/ir.pl:95
+#: old/bin/aa.pl:1229 old/bin/aa.pl:1495 old/bin/gl.pl:106 old/bin/ir.pl:95
 msgid "Draft Posted"
 msgstr ""
 
@@ -2722,14 +2723,14 @@ msgstr ""
 #: lib/LedgerSMB/Report/Aging.pm:130
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:107
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:270
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:685
-#: old/bin/ir.pl:481 old/bin/is.pl:536
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:299 old/bin/aa.pl:688
+#: old/bin/ir.pl:482 old/bin/is.pl:539
 #: UI/Reports/filters/invoice_outstanding.html:234
 #: UI/Reports/filters/invoice_search.html:357
 msgid "Due Date"
 msgstr "到期日"
 
-#: old/bin/aa.pl:1358
+#: old/bin/aa.pl:1365
 msgid "Due Date missing!"
 msgstr "未指明到期日！"
 
@@ -2741,8 +2742,8 @@ msgstr ""
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1007 old/bin/oe.pl:2069
-#: old/bin/oe.pl:663 old/bin/oe.pl:928 UI/Reports/filters/contact_search.html:48
+#: old/bin/am.pl:316 old/bin/arap.pl:404 old/bin/is.pl:1031 old/bin/oe.pl:2070
+#: old/bin/oe.pl:664 old/bin/oe.pl:929 UI/Reports/filters/contact_search.html:48
 msgid "E-mail"
 msgstr "電子郵件"
 
@@ -3044,11 +3045,11 @@ msgstr ""
 msgid "Entity Class"
 msgstr ""
 
-#: old/bin/ir.pl:424 old/bin/is.pl:460 old/bin/oe.pl:446
+#: old/bin/ir.pl:425 old/bin/is.pl:463 old/bin/oe.pl:446
 msgid "Entity Code"
 msgstr ""
 
-#: old/bin/aa.pl:627
+#: old/bin/aa.pl:630
 msgid "Entity Control Code"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Entry ID"
 msgstr ""
 
-#: old/bin/ir.pl:935 old/bin/is.pl:1024 old/bin/printer.pl:104
+#: old/bin/ir.pl:957 old/bin/is.pl:1048 old/bin/printer.pl:104
 #: UI/templates/widget.html:45
 msgid "Envelope"
 msgstr ""
@@ -3086,7 +3087,7 @@ msgstr ""
 msgid "Equity (Temporary)"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:335
+#: templates/demo/balance_sheet.html:363
 msgid "Equity to Liabilities"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:590
+#: lib/LedgerSMB/Scripts/asset.pm:591
 msgid "Est. Life"
 msgstr ""
 
@@ -3118,20 +3119,20 @@ msgstr ""
 msgid "Every"
 msgstr "每"
 
-#: old/bin/aa.pl:880 old/bin/ir.pl:816 old/bin/is.pl:912
+#: old/bin/aa.pl:887 old/bin/ir.pl:838 old/bin/is.pl:936
 msgid "Exch"
 msgstr "匯率"
 
 #: lib/LedgerSMB/Report/Contact/History.pm:117
 #: lib/LedgerSMB/Scripts/payment.pm:938 old/bin/aa.pl:468 old/bin/ir.pl:322
-#: old/bin/is.pl:323 old/bin/oe.pl:1646 old/bin/oe.pl:353 old/bin/oe.pl:361
+#: old/bin/is.pl:323 old/bin/oe.pl:1647 old/bin/oe.pl:353 old/bin/oe.pl:361
 #: UI/Reports/filters/overpayments.html:50 UI/Reports/filters/payments.html:113
 #: UI/payments/payment2.html:136 UI/payments/payments_detail.html:148
 #: UI/payments/payments_detail.html:157 UI/payments/use_overpayment2.html:98
 msgid "Exchange Rate"
 msgstr "匯率"
 
-#: old/bin/aa.pl:1391 old/bin/ir.pl:1313 old/bin/is.pl:1409
+#: old/bin/aa.pl:1398 old/bin/ir.pl:1335 old/bin/is.pl:1433
 msgid "Exchange rate for payment missing!"
 msgstr "未指明付款的匯率！"
 
@@ -3139,7 +3140,7 @@ msgstr "未指明付款的匯率！"
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: old/bin/aa.pl:1373 old/bin/ir.pl:1293 old/bin/is.pl:1389 old/bin/oe.pl:1277
+#: old/bin/aa.pl:1380 old/bin/ir.pl:1315 old/bin/is.pl:1413 old/bin/oe.pl:1278
 msgid "Exchange rate missing!"
 msgstr "未指明匯率！"
 
@@ -3184,8 +3185,8 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:106
-#: UI/journal/journal_entry.html:133
+#: UI/budgetting/budget_entry.html:59 UI/journal/journal_entry.html:109
+#: UI/journal/journal_entry.html:136
 msgid "FX"
 msgstr "外幣兌換"
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:1067
+#: lib/LedgerSMB/Scripts/asset.pm:1070
 msgid "File Imported"
 msgstr ""
 
@@ -3277,17 +3278,17 @@ msgstr ""
 msgid "File Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1063 old/bin/aa.pl:1082
-#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1000 old/bin/ir.pl:981
-#: old/bin/is.pl:1070 old/bin/is.pl:1089 old/bin/oe.pl:947 old/bin/oe.pl:966
+#: lib/LedgerSMB/Scripts/file.pm:137 old/bin/aa.pl:1070 old/bin/aa.pl:1089
+#: old/bin/ic.pl:872 old/bin/ic.pl:891 old/bin/ir.pl:1003 old/bin/ir.pl:1022
+#: old/bin/is.pl:1094 old/bin/is.pl:1113 old/bin/oe.pl:948 old/bin/oe.pl:967
 #: UI/Contact/divs/files.html:9 UI/lib/attachments.html:8
 #: UI/lib/attachments.html:29
 msgid "File name"
 msgstr ""
 
-#: old/bin/aa.pl:1064 old/bin/aa.pl:1083 old/bin/ic.pl:873 old/bin/ic.pl:892
-#: old/bin/ir.pl:1001 old/bin/ir.pl:982 old/bin/is.pl:1071 old/bin/is.pl:1090
-#: old/bin/oe.pl:948 old/bin/oe.pl:967 UI/lib/attachments.html:9
+#: old/bin/aa.pl:1071 old/bin/aa.pl:1090 old/bin/ic.pl:873 old/bin/ic.pl:892
+#: old/bin/ir.pl:1004 old/bin/ir.pl:1023 old/bin/is.pl:1095 old/bin/is.pl:1114
+#: old/bin/oe.pl:949 old/bin/oe.pl:968 UI/lib/attachments.html:9
 #: UI/lib/attachments.html:30
 msgid "File type"
 msgstr ""
@@ -3324,7 +3325,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: templates/demo/balance_sheet.html:327
+#: templates/demo/balance_sheet.html:355
 msgid "First column only"
 msgstr ""
 
@@ -3384,7 +3385,7 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: old/bin/ic.pl:1115 old/bin/oe.pl:2245 old/bin/pe.pl:745
+#: old/bin/ic.pl:1115 old/bin/oe.pl:2246 old/bin/pe.pl:745
 #: UI/Contact/divs/credit.html:432 UI/Reports/co/filter_bm.html:20
 #: UI/Reports/co/filter_cd.html:38 UI/Reports/filters/contact_search.html:116
 #: UI/Reports/filters/income_statement.html:125
@@ -3416,7 +3417,7 @@ msgstr ""
 msgid "From File"
 msgstr ""
 
-#: old/bin/oe.pl:2258
+#: old/bin/oe.pl:2259
 msgid "From Warehouse"
 msgstr "從貨倉"
 
@@ -3465,7 +3466,7 @@ msgstr "總帳索引編號"
 msgid "Gain"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:837
+#: lib/LedgerSMB/Scripts/asset.pm:839
 msgid "Gain (Loss)"
 msgstr ""
 
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Gain Account"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:725
+#: lib/LedgerSMB/Scripts/asset.pm:726
 msgid "Gain/Loss"
 msgstr ""
 
@@ -3502,11 +3503,11 @@ msgstr "生成"
 msgid "Generate Control Code"
 msgstr ""
 
-#: old/bin/oe.pl:2626
+#: old/bin/oe.pl:2627
 msgid "Generate Orders"
 msgstr "生成訂單"
 
-#: old/bin/oe.pl:2531
+#: old/bin/oe.pl:2532
 msgid "Generate Purchase Orders"
 msgstr "生成採購單"
 
@@ -3551,8 +3552,8 @@ msgid "Grand Total"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:55 old/bin/ic.pl:1269
-#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2168 old/bin/oe.pl:2241
-#: old/bin/oe.pl:2276 old/bin/pe.pl:127
+#: old/bin/ic.pl:418 old/bin/io.pl:267 old/bin/oe.pl:2169 old/bin/oe.pl:2242
+#: old/bin/oe.pl:2277 old/bin/pe.pl:127
 msgid "Group"
 msgstr "組別"
 
@@ -3794,8 +3795,8 @@ msgstr ""
 msgid "Internal Files"
 msgstr ""
 
-#: old/bin/aa.pl:850 old/bin/ir.pl:712 old/bin/ir.pl:720 old/bin/is.pl:808
-#: old/bin/is.pl:816 old/bin/oe.pl:837
+#: old/bin/aa.pl:857 old/bin/ir.pl:722 old/bin/ir.pl:730 old/bin/is.pl:820
+#: old/bin/is.pl:828 old/bin/oe.pl:838
 msgid "Internal Notes"
 msgstr "內部備忘錄"
 
@@ -3853,11 +3854,11 @@ msgstr "在停用此製成品之前, 存貨數量必需為零！"
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 
-#: old/bin/oe.pl:2113
+#: old/bin/oe.pl:2114
 msgid "Inventory saved!"
 msgstr "已儲存存貨！"
 
-#: old/bin/oe.pl:2383
+#: old/bin/oe.pl:2384
 msgid "Inventory transferred!"
 msgstr "轉移的存貨！"
 
@@ -3865,8 +3866,8 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:303
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:269
-#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1151
-#: old/bin/is.pl:1413 old/bin/is.pl:273 old/bin/printer.pl:48
+#: lib/LedgerSMB/Scripts/payment.pm:927 old/bin/am.pl:961 old/bin/io.pl:1150
+#: old/bin/is.pl:1437 old/bin/is.pl:273 old/bin/printer.pl:48
 #: UI/templates/widget.html:47 templates/demo/invoice.html:16
 #: templates/demo/invoice.tex:138 templates/demo/printPayment.html:44
 #: sql/Pg-database.sql:1037 sql/Pg-database.sql:2608 sql/Pg-database.sql:2707
@@ -3884,22 +3885,22 @@ msgstr "發票"
 msgid "Invoice #"
 msgstr ""
 
-#: old/bin/aa.pl:677 old/bin/ir.pl:473 old/bin/is.pl:528
+#: old/bin/aa.pl:680 old/bin/ir.pl:474 old/bin/is.pl:531
 msgid "Invoice Created"
 msgstr ""
 
-#: old/bin/aa.pl:1359
+#: old/bin/aa.pl:1366
 msgid "Invoice Created Date missing!"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/History.pm:125
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:681 old/bin/ir.pl:477
-#: old/bin/is.pl:532 UI/Reports/filters/invoice_outstanding.html:158
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:684 old/bin/ir.pl:478
+#: old/bin/is.pl:535 UI/Reports/filters/invoice_outstanding.html:158
 #: UI/Reports/filters/invoice_search.html:283
 msgid "Invoice Date"
 msgstr "發票日期"
 
-#: old/bin/aa.pl:1357 old/bin/io.pl:1264 old/bin/ir.pl:1278 old/bin/is.pl:1374
+#: old/bin/aa.pl:1364 old/bin/io.pl:1263 old/bin/ir.pl:1300 old/bin/is.pl:1398
 msgid "Invoice Date missing!"
 msgstr "未指明發票日期！"
 
@@ -3915,8 +3916,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:67
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:90
 #: lib/LedgerSMB/Report/PNL/Invoice.pm:81
-#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:668
-#: old/bin/ir.pl:463 old/bin/is.pl:519
+#: lib/LedgerSMB/Report/Taxform/Details.pm:93 old/bin/aa.pl:671
+#: old/bin/ir.pl:464 old/bin/is.pl:522
 #: UI/Reports/filters/invoice_outstanding.html:137
 #: UI/Reports/filters/invoice_search.html:89
 #: UI/Reports/filters/invoice_search.html:262 UI/asset/edit_asset.html:205
@@ -3925,7 +3926,7 @@ msgstr ""
 msgid "Invoice Number"
 msgstr "發票編號"
 
-#: old/bin/io.pl:1274
+#: old/bin/io.pl:1273
 msgid "Invoice Number missing!"
 msgstr "未指明發票編號！"
 
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Item deleted!"
 msgstr "已刪除項目！"
 
-#: old/bin/io.pl:614
+#: old/bin/io.pl:613
 msgid "Item not on file!"
 msgstr "沒有此項目的記錄！"
 
@@ -4011,7 +4012,7 @@ msgstr "一月"
 msgid "January"
 msgstr "一月"
 
-#: UI/src/components/ServerUI.js:117
+#: UI/src/components/ServerUI.js:130
 msgid "JavaScript error: "
 msgstr ""
 
@@ -4052,7 +4053,7 @@ msgstr "六月"
 msgid "June"
 msgstr "六月"
 
-#: templates/demo/balance_sheet.html:326
+#: templates/demo/balance_sheet.html:354
 msgid "Key Ratios"
 msgstr ""
 
@@ -4116,7 +4117,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: old/bin/oe.pl:2527 sql/Pg-database.sql:516
+#: old/bin/oe.pl:2528 sql/Pg-database.sql:516
 msgid "Lead"
 msgstr "交付時間"
 
@@ -4337,11 +4338,11 @@ msgstr ""
 msgid "Logged out due to inactivity"
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:46
+#: UI/src/views/LoginPage.vue:52
 msgid "Logging in... Please wait."
 msgstr ""
 
-#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:41
+#: UI/setup/credentials.html:91 UI/src/views/LoginPage.vue:47
 msgid "Login"
 msgstr "登入"
 
@@ -4418,7 +4419,7 @@ msgstr "經理"
 msgid "Manager:"
 msgstr ""
 
-#: old/bin/ir.pl:560 old/bin/is.pl:413 old/bin/is.pl:648
+#: old/bin/ir.pl:561 old/bin/is.pl:415 old/bin/is.pl:651
 msgid "Manual"
 msgstr ""
 
@@ -4449,9 +4450,9 @@ msgid "May"
 msgstr "五月"
 
 #: lib/LedgerSMB/Report/GL.pm:158 lib/LedgerSMB/Scripts/payment.pm:933
-#: old/bin/aa.pl:884 old/bin/ir.pl:599 old/bin/ir.pl:820 old/bin/is.pl:693
-#: old/bin/is.pl:916 UI/Reports/filters/gl.html:73
-#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:137
+#: old/bin/aa.pl:891 old/bin/ir.pl:600 old/bin/ir.pl:842 old/bin/is.pl:696
+#: old/bin/is.pl:940 UI/Reports/filters/gl.html:73
+#: UI/Reports/filters/gl.html:273 UI/journal/journal_entry.html:140
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
 msgid "Memo"
 msgstr "備忘錄"
@@ -4798,15 +4799,15 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:295
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:274
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:302
-#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:849 old/bin/ic.pl:764
-#: old/bin/ir.pl:709 old/bin/is.pl:803 old/bin/oe.pl:836
+#: lib/LedgerSMB/Scripts/contact.pm:194 old/bin/aa.pl:856 old/bin/ic.pl:764
+#: old/bin/ir.pl:719 old/bin/is.pl:815 old/bin/oe.pl:837
 #: UI/Contact/divs/notes.html:2 UI/Contact/divs/notes.html:6
 #: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:47
 #: UI/Reports/filters/contact_search.html:75 UI/Reports/filters/gl.html:90
 #: UI/Reports/filters/invoice_outstanding.html:247
 #: UI/Reports/filters/invoice_search.html:150
 #: UI/Reports/filters/invoice_search.html:370
-#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:79
+#: UI/Reports/filters/search_goods.html:373 UI/journal/journal_entry.html:82
 #: UI/payments/payment2.html:50 UI/payments/use_overpayment2.html:70
 #: UI/timecards/timecard.html:134 t/data/04-complex_template.html:33
 #: t/data/04-complex_template.html:626 templates/demo/printPayment.html:99
@@ -4820,15 +4821,15 @@ msgstr "備註"
 msgid "Notes:<br />"
 msgstr ""
 
-#: old/bin/oe.pl:2110
+#: old/bin/oe.pl:2111
 msgid "Nothing entered!"
 msgstr "沒有任何輸入！"
 
-#: old/bin/oe.pl:2401 old/bin/oe.pl:2660 old/bin/pe.pl:1070
+#: old/bin/oe.pl:2402 old/bin/oe.pl:2661 old/bin/pe.pl:1070
 msgid "Nothing selected!"
 msgstr "沒有選擇任何東西！"
 
-#: old/bin/oe.pl:2127
+#: old/bin/oe.pl:2128
 msgid "Nothing to transfer!"
 msgstr "沒有可轉移的項目！"
 
@@ -4853,7 +4854,7 @@ msgid "Null model numbers"
 msgstr ""
 
 #: old/bin/ic.pl:1257 old/bin/ic.pl:2010 old/bin/ic.pl:2079 old/bin/ic.pl:738
-#: old/bin/io.pl:230 old/bin/oe.pl:1962 old/bin/pe.pl:178 old/bin/pe.pl:260
+#: old/bin/io.pl:230 old/bin/oe.pl:1963 old/bin/pe.pl:178 old/bin/pe.pl:260
 #: old/bin/pe.pl:292 UI/Contact/divs/credit.html:26
 #: UI/Contact/divs/credit.html:77 UI/Contact/divs/credit.html:78
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
@@ -4872,7 +4873,7 @@ msgstr "編號"
 msgid "Number Format"
 msgstr "數字格式"
 
-#: old/bin/io.pl:954
+#: old/bin/io.pl:953
 msgid "Number missing in Row [_1]"
 msgstr ""
 
@@ -4910,7 +4911,7 @@ msgstr "十月"
 msgid "October"
 msgstr "十月"
 
-#: old/bin/is.pl:789
+#: old/bin/is.pl:792
 msgid "Off Hold"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "On Hand"
 msgstr "已有存量"
 
-#: old/bin/is.pl:791 UI/Reports/filters/invoice_outstanding.html:89
+#: old/bin/is.pl:794 UI/Reports/filters/invoice_outstanding.html:89
 #: UI/Reports/filters/invoice_search.html:188
 msgid "On Hold"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:307
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:220
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2520
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:272 old/bin/oe.pl:2521
 msgid "Order"
 msgstr "訂單"
 
@@ -4998,12 +4999,12 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: old/bin/oe.pl:1917 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
+#: old/bin/oe.pl:1918 old/bin/oe.pl:406 templates/demo/purchase_order.html:75
 #: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
-#: old/bin/io.pl:1266 old/bin/oe.pl:1263 old/bin/oe.pl:1464
+#: old/bin/io.pl:1265 old/bin/oe.pl:1264 old/bin/oe.pl:1465
 msgid "Order Date missing!"
 msgstr "未指明下單日期！"
 
@@ -5015,8 +5016,8 @@ msgstr "下單項目"
 msgid "Order Lines"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:673
-#: old/bin/ir.pl:468 old/bin/is.pl:523 old/bin/oe.pl:1912 old/bin/oe.pl:400
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:71 old/bin/aa.pl:676
+#: old/bin/ir.pl:469 old/bin/is.pl:526 old/bin/oe.pl:1913 old/bin/oe.pl:400
 #: UI/Reports/filters/invoice_outstanding.html:144
 #: UI/Reports/filters/invoice_search.html:99
 #: UI/Reports/filters/invoice_search.html:269 UI/Reports/filters/orders.html:40
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Order Number"
 msgstr "訂單編號"
 
-#: old/bin/io.pl:1276 old/bin/oe.pl:1463
+#: old/bin/io.pl:1275 old/bin/oe.pl:1464
 msgid "Order Number missing!"
 msgstr "未指明訂單編號！"
 
-#: old/bin/oe.pl:1441
+#: old/bin/oe.pl:1442
 msgid "Order deleted!"
 msgstr "已刪除訂單！"
 
-#: old/bin/oe.pl:2649
+#: old/bin/oe.pl:2650
 msgid "Order generation failed!"
 msgstr "生成訂單失敗！"
 
@@ -5119,8 +5120,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:75
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:275
-#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:689 old/bin/is.pl:540
-#: old/bin/oe.pl:1923 old/bin/oe.pl:415
+#: lib/LedgerSMB/Report/Orders.pm:238 old/bin/aa.pl:692 old/bin/is.pl:543
+#: old/bin/oe.pl:1924 old/bin/oe.pl:415
 #: UI/Reports/filters/invoice_outstanding.html:150
 #: UI/Reports/filters/invoice_search.html:109
 #: UI/Reports/filters/invoice_search.html:275 UI/Reports/filters/orders.html:62
@@ -5136,7 +5137,7 @@ msgstr ""
 msgid "POST AND PRINT"
 msgstr ""
 
-#: old/bin/am.pl:964 old/bin/io.pl:1170 old/bin/ir.pl:934 old/bin/is.pl:1023
+#: old/bin/am.pl:964 old/bin/io.pl:1169 old/bin/ir.pl:956 old/bin/is.pl:1047
 #: old/bin/is.pl:275 old/bin/oe.pl:265 old/bin/oe.pl:284 old/bin/printer.pl:76
 #: old/bin/printer.pl:94 templates/demo/packing_list.html:16
 #: templates/demo/packing_list.html:33 templates/demo/packing_list.tex:96
@@ -5144,11 +5145,11 @@ msgstr ""
 msgid "Packing List"
 msgstr "出貨單"
 
-#: old/bin/io.pl:1265
+#: old/bin/io.pl:1264
 msgid "Packing List Date missing!"
 msgstr "未指明出貨單日期！"
 
-#: old/bin/io.pl:1275
+#: old/bin/io.pl:1274
 msgid "Packing List Number missing!"
 msgstr "未指明出貨單編號！"
 
@@ -5172,7 +5173,7 @@ msgstr "已付"
 msgid "Parent"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:628
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:107 old/bin/io.pl:627
 msgid "Part"
 msgstr "零件"
 
@@ -5192,8 +5193,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:101
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:162
 #: lib/LedgerSMB/Report/PNL/Product.pm:77
-#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2160
-#: old/bin/oe.pl:2233 old/bin/oe.pl:2267 old/bin/oe.pl:2514 old/bin/pe.pl:942
+#: lib/LedgerSMB/Scripts/configuration.pm:125 old/bin/oe.pl:2161
+#: old/bin/oe.pl:2234 old/bin/oe.pl:2268 old/bin/oe.pl:2515 old/bin/pe.pl:942
 #: UI/Reports/filters/cogs_lines.html:8
 #: UI/Reports/filters/inventory_activity.html:8
 #: UI/Reports/filters/purchase_history.html:243
@@ -5214,7 +5215,7 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:730
+#: lib/LedgerSMB/Scripts/asset.pm:731
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
@@ -5244,7 +5245,7 @@ msgstr ""
 
 #: UI/Contact/divs/user.html:59 UI/setup/credentials.html:68
 #: UI/setup/edit_user.html:49 UI/setup/new_user.html:29
-#: UI/src/views/LoginPage.vue:32
+#: UI/src/views/LoginPage.vue:34
 msgid "Password"
 msgstr "密碼"
 
@@ -5313,7 +5314,7 @@ msgstr ""
 msgid "Payment batch"
 msgstr ""
 
-#: old/bin/aa.pl:1381 old/bin/ir.pl:1302 old/bin/is.pl:1398
+#: old/bin/aa.pl:1388 old/bin/ir.pl:1324 old/bin/is.pl:1422
 msgid "Payment date missing!"
 msgstr "未指明付款日期！"
 
@@ -5325,7 +5326,7 @@ msgstr ""
 msgid "Payment due by [_1]."
 msgstr ""
 
-#: old/bin/aa.pl:863 old/bin/ir.pl:803 old/bin/is.pl:899
+#: old/bin/aa.pl:870 old/bin/ir.pl:825 old/bin/is.pl:923
 #: UI/payments/payment1.html:22 UI/payments/payments_detail.html:6
 #: templates/demo/ap_transaction.html:140 templates/demo/ap_transaction.tex:125
 #: templates/demo/ar_transaction.html:137 templates/demo/ar_transaction.tex:142
@@ -5334,7 +5335,7 @@ msgstr ""
 msgid "Payments"
 msgstr "付款"
 
-#: old/bin/is.pl:611
+#: old/bin/is.pl:614
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
@@ -5342,11 +5343,11 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:701
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:712
+#: lib/LedgerSMB/Scripts/asset.pm:713
 msgid "Percent Remaining"
 msgstr ""
 
@@ -5381,7 +5382,7 @@ msgstr "電話號碼"
 msgid "Physical"
 msgstr ""
 
-#: old/bin/am.pl:965 old/bin/io.pl:1193 old/bin/is.pl:274 old/bin/oe.pl:264
+#: old/bin/am.pl:965 old/bin/io.pl:1192 old/bin/is.pl:274 old/bin/oe.pl:264
 #: old/bin/oe.pl:283 old/bin/printer.pl:72 old/bin/printer.pl:90
 #: templates/demo/pick_list.html:16 templates/demo/pick_list.html:32
 #: templates/demo/pick_list.tex:89 sql/Pg-database.sql:2711
@@ -5512,8 +5513,8 @@ msgstr ""
 msgid "Please use the 1.3 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:988
-#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:915 old/bin/is.pl:1003
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:237 old/bin/aa.pl:995
+#: old/bin/gl.pl:234 old/bin/gl.pl:236 old/bin/ir.pl:937 old/bin/is.pl:1027
 #: UI/payments/payment2.html:508
 msgid "Post"
 msgstr "加入"
@@ -5530,7 +5531,7 @@ msgstr ""
 msgid "Post Yearend"
 msgstr ""
 
-#: old/bin/aa.pl:991 old/bin/ir.pl:916 old/bin/is.pl:1006
+#: old/bin/aa.pl:998 old/bin/ir.pl:938 old/bin/is.pl:1030
 msgid "Post as new"
 msgstr "當新的加入"
 
@@ -5625,9 +5626,9 @@ msgid "Primary Phone"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Taxform/Details.pm:140
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:987
-#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1002 old/bin/oe.pl:2066
-#: old/bin/oe.pl:651 old/bin/oe.pl:921 UI/payments/payments_detail.html:511
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:134 old/bin/aa.pl:994
+#: old/bin/am.pl:317 old/bin/arap.pl:479 old/bin/is.pl:1026 old/bin/oe.pl:2067
+#: old/bin/oe.pl:652 old/bin/oe.pl:922 UI/payments/payments_detail.html:511
 #: UI/timecards/timecard.html:159
 msgid "Print"
 msgstr "列印"
@@ -5636,11 +5637,11 @@ msgstr "列印"
 msgid "Print Batch"
 msgstr ""
 
-#: old/bin/oe.pl:667 old/bin/oe.pl:924
+#: old/bin/oe.pl:668 old/bin/oe.pl:925
 msgid "Print and Save"
 msgstr "列印並儲存"
 
-#: old/bin/oe.pl:675 old/bin/oe.pl:927
+#: old/bin/oe.pl:676 old/bin/oe.pl:928
 msgid "Print and Save as new"
 msgstr "列印並儲存作為新的"
 
@@ -5692,15 +5693,15 @@ msgstr ""
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:608
+#: lib/LedgerSMB/Scripts/asset.pm:609
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:602
+#: lib/LedgerSMB/Scripts/asset.pm:603
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:831
+#: lib/LedgerSMB/Scripts/asset.pm:374 lib/LedgerSMB/Scripts/asset.pm:833
 msgid "Proceeds"
 msgstr ""
 
@@ -5722,7 +5723,7 @@ msgstr ""
 msgid "Profit and Loss"
 msgstr ""
 
-#: old/bin/aa.pl:1058 old/bin/ic.pl:938 old/bin/ir.pl:976 old/bin/is.pl:1065
+#: old/bin/aa.pl:1065 old/bin/ic.pl:938 old/bin/ir.pl:998 old/bin/is.pl:1089
 msgid "Profit/Loss"
 msgstr ""
 
@@ -5765,8 +5766,8 @@ msgstr ""
 msgid "Purchase History"
 msgstr ""
 
-#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1204 old/bin/ir.pl:918
-#: old/bin/oe.pl:1299 old/bin/oe.pl:276 old/bin/oe.pl:692 old/bin/oe.pl:935
+#: old/bin/am.pl:743 old/bin/am.pl:968 old/bin/io.pl:1203 old/bin/ir.pl:940
+#: old/bin/oe.pl:1300 old/bin/oe.pl:276 old/bin/oe.pl:693 old/bin/oe.pl:936
 #: old/bin/printer.pl:81 UI/Contact/divs/credit.html:352
 #: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:16
 #: templates/demo/purchase_order.html:32 templates/demo/purchase_order.tex:116
@@ -5805,7 +5806,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:88
 #: lib/LedgerSMB/Report/Inventory/History.pm:158
 #: lib/LedgerSMB/Report/Inventory/Search.pm:319 old/bin/ic.pl:1252
-#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1968 old/bin/oe.pl:2250
+#: old/bin/ic.pl:2090 old/bin/io.pl:236 old/bin/oe.pl:1969 old/bin/oe.pl:2251
 #: old/bin/pe.pl:950 UI/Reports/filters/purchase_history.html:283
 #: UI/timecards/timecard-week.html:99 templates/demo/bin_list.html:103
 #: templates/demo/bin_list.tex:123 templates/demo/invoice.html:106
@@ -5835,8 +5836,8 @@ msgid "Quarter"
 msgstr "季"
 
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
-#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1218 old/bin/io.pl:1225
-#: old/bin/oe.pl:1310 old/bin/oe.pl:242 old/bin/oe.pl:683 old/bin/oe.pl:932
+#: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1217 old/bin/io.pl:1224
+#: old/bin/oe.pl:1311 old/bin/oe.pl:242 old/bin/oe.pl:684 old/bin/oe.pl:933
 #: old/bin/printer.pl:54 UI/Contact/divs/credit.html:368
 #: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
 #: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1884
@@ -5852,7 +5853,7 @@ msgstr ""
 msgid "Quotation Date"
 msgstr "報價單日期"
 
-#: old/bin/io.pl:1267 old/bin/oe.pl:1266 old/bin/oe.pl:1470
+#: old/bin/io.pl:1266 old/bin/oe.pl:1267 old/bin/oe.pl:1471
 msgid "Quotation Date missing!"
 msgstr "未指明報價單日期！"
 
@@ -5860,11 +5861,11 @@ msgstr "未指明報價單日期！"
 msgid "Quotation Number"
 msgstr "報價單號碼"
 
-#: old/bin/io.pl:1277 old/bin/oe.pl:1469
+#: old/bin/io.pl:1276 old/bin/oe.pl:1470
 msgid "Quotation Number missing!"
 msgstr "未指明報價單號碼！"
 
-#: old/bin/oe.pl:1445
+#: old/bin/oe.pl:1446
 msgid "Quotation deleted!"
 msgstr "已刪除報價單！"
 
@@ -5879,7 +5880,7 @@ msgstr "報價單"
 msgid "Quote Number"
 msgstr ""
 
-#: old/bin/oe.pl:251 old/bin/oe.pl:694 old/bin/oe.pl:933 old/bin/printer.pl:59
+#: old/bin/oe.pl:251 old/bin/oe.pl:695 old/bin/oe.pl:934 old/bin/printer.pl:59
 #: UI/Contact/divs/credit.html:355 t/data/04-complex_template.html:352
 #: sql/Pg-database.sql:1885 sql/Pg-database.sql:2586 sql/Pg-database.sql:2718
 #: sql/Pg-database.sql:2733
@@ -5905,7 +5906,7 @@ msgstr "報價請求"
 msgid "ROP"
 msgstr "再訂點"
 
-#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:596 old/bin/is.pl:690
+#: lib/LedgerSMB/Scripts/currency.pm:256 old/bin/ir.pl:597 old/bin/is.pl:693
 #: UI/Configuration/rate.html:49 templates/demo/timecard.html:107
 #: templates/demo/timecard.tex:60
 msgid "Rate"
@@ -5946,7 +5947,7 @@ msgstr ""
 msgid "Rebuild/Upgrade?"
 msgstr ""
 
-#: old/bin/io.pl:177 old/bin/oe.pl:1952 templates/demo/bin_list.html:104
+#: old/bin/io.pl:177 old/bin/oe.pl:1953 templates/demo/bin_list.html:104
 msgid "Recd"
 msgstr "已收到"
 
@@ -5975,7 +5976,7 @@ msgstr "應收帳戶"
 msgid "Receive"
 msgstr "收到"
 
-#: old/bin/oe.pl:1845
+#: old/bin/oe.pl:1846
 msgid "Receive Merchandise"
 msgstr "收到貨物"
 
@@ -6003,7 +6004,7 @@ msgstr ""
 msgid "Reconciliation Reports"
 msgstr ""
 
-#: old/bin/ir.pl:448 old/bin/is.pl:492
+#: old/bin/ir.pl:449 old/bin/is.pl:495
 msgid "Record in"
 msgstr "記錄於"
 
@@ -6029,11 +6030,11 @@ msgstr "重覆出現的交易"
 #: old/bin/arap.pl:580 UI/Reports/filters/budget_search.html:18
 #: UI/Reports/filters/gl.html:23 UI/Reports/filters/gl.html:210
 #: UI/Reports/filters/unapproved.html:29 UI/accounts/yearend.html:32
-#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:19
+#: UI/budgetting/budget_entry.html:16 UI/journal/journal_entry.html:22
 msgid "Reference"
 msgstr "參考資料"
 
-#: old/bin/io.pl:1278
+#: old/bin/io.pl:1277
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6070,9 +6071,13 @@ msgstr ""
 msgid "Rem. Life"
 msgstr ""
 
-#: old/bin/aa.pl:589 old/bin/ir.pl:411 old/bin/is.pl:447 old/bin/oe.pl:434
+#: old/bin/aa.pl:592 old/bin/ir.pl:412 old/bin/is.pl:450 old/bin/oe.pl:434
 msgid "Remaining"
 msgstr "尚餘"
+
+#: old/bin/aa.pl:851 old/bin/ir.pl:772 old/bin/is.pl:868
+msgid "Remaining balance"
+msgstr ""
 
 #: UI/Contact/divs/bank_act.html:24 UI/Contact/divs/bank_act.html:64
 #: t/data/04-complex_template.html:559
@@ -6100,7 +6105,7 @@ msgstr ""
 msgid "Report Name"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:541
+#: lib/LedgerSMB/Scripts/asset.pm:542
 msgid "Report Results"
 msgstr ""
 
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Report Type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:633
+#: lib/LedgerSMB/Scripts/asset.pm:634
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
@@ -6148,11 +6153,11 @@ msgstr "報表"
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: old/bin/oe.pl:2522
+#: old/bin/oe.pl:2523
 msgid "Req"
 msgstr "需要"
 
-#: old/bin/oe.pl:1316 templates/demo/request_quotation.html:16
+#: old/bin/oe.pl:1317 templates/demo/request_quotation.html:16
 #: templates/demo/request_quotation.html:32
 #: templates/demo/request_quotation.tex:116
 msgid "Request for Quotation"
@@ -6273,11 +6278,11 @@ msgstr "標準工業分類代碼"
 msgid "SIC:"
 msgstr ""
 
-#: old/bin/io.pl:268 old/bin/oe.pl:1954 old/bin/oe.pl:2512
+#: old/bin/io.pl:268 old/bin/oe.pl:1955 old/bin/oe.pl:2513
 msgid "SKU"
 msgstr "庫存單位"
 
-#: old/bin/ir.pl:485
+#: old/bin/ir.pl:486
 msgid "SO Number"
 msgstr ""
 
@@ -6306,7 +6311,7 @@ msgstr "銷售"
 msgid "Sales"
 msgstr "銷售"
 
-#: old/bin/ir.pl:933 old/bin/is.pl:1022 old/bin/oe.pl:679 old/bin/oe.pl:930
+#: old/bin/ir.pl:955 old/bin/is.pl:1046 old/bin/oe.pl:680 old/bin/oe.pl:931
 #: sql/Pg-database.sql:2664
 msgid "Sales Invoice"
 msgstr "銷售發票"
@@ -6315,8 +6320,8 @@ msgstr "銷售發票"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr "銷售發票/應收帳交易編號"
 
-#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1156 old/bin/is.pl:1009
-#: old/bin/oe.pl:1293 old/bin/oe.pl:262 old/bin/oe.pl:681 old/bin/oe.pl:934
+#: old/bin/am.pl:737 old/bin/am.pl:966 old/bin/io.pl:1155 old/bin/is.pl:1033
+#: old/bin/oe.pl:1294 old/bin/oe.pl:262 old/bin/oe.pl:682 old/bin/oe.pl:935
 #: old/bin/printer.pl:64 UI/Contact/divs/credit.html:365
 #: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
 #: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1882
@@ -6381,7 +6386,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Scripts/asset.pm:354 lib/LedgerSMB/Scripts/budgets.pm:104
 #: old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84 old/bin/ic.pl:826
-#: old/bin/ic.pl:835 old/bin/oe.pl:656 old/bin/oe.pl:923 old/bin/pe.pl:149
+#: old/bin/ic.pl:835 old/bin/oe.pl:657 old/bin/oe.pl:924 old/bin/pe.pl:149
 #: old/bin/pe.pl:517 UI/Configuration/sequence.html:7
 #: UI/Configuration/sequence.html:117 UI/Configuration/settings.html:91
 #: UI/Contact/divs/bank_act.html:74 UI/Contact/divs/company.html:151
@@ -6426,7 +6431,7 @@ msgstr ""
 msgid "Save Groups"
 msgstr ""
 
-#: UI/Contact/divs/address.html:184 t/data/04-complex_template.html:485
+#: UI/Contact/divs/address.html:182 t/data/04-complex_template.html:485
 msgid "Save Location"
 msgstr ""
 
@@ -6434,7 +6439,7 @@ msgstr ""
 msgid "Save New"
 msgstr ""
 
-#: UI/Contact/divs/address.html:192
+#: UI/Contact/divs/address.html:190
 msgid "Save New Location"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid "Save Translations"
 msgstr ""
 
 #: old/bin/am.pl:66 old/bin/am.pl:75 old/bin/gl.pl:243 old/bin/ic.pl:827
-#: old/bin/ic.pl:844 old/bin/oe.pl:671 old/bin/oe.pl:926
+#: old/bin/ic.pl:844 old/bin/oe.pl:672 old/bin/oe.pl:927
 #: UI/accounts/edit.html:96 UI/accounts/edit.html:557
 msgid "Save as new"
 msgstr "當新的儲存"
@@ -6460,7 +6465,7 @@ msgstr "當新的儲存"
 msgid "Save the fixes provided and attempt to continue migration"
 msgstr ""
 
-#: old/bin/oe.pl:658 UI/Configuration/sequence.html:119
+#: old/bin/oe.pl:659 UI/Configuration/sequence.html:119
 #: UI/Contact/pricelist.html:98 UI/accounts/edit.html:89
 #: UI/accounts/edit.html:550 UI/am-taxes.html:78 UI/asset/edit_asset.html:222
 #: UI/asset/edit_class.html:66 UI/asset/import_asset.html:32
@@ -6498,7 +6503,7 @@ msgstr ""
 msgid "Saving over an existing document.  Continue?"
 msgstr ""
 
-#: old/bin/oe.pl:657 UI/Configuration/sequence.html:118
+#: old/bin/oe.pl:658 UI/Configuration/sequence.html:118
 #: UI/Contact/pricelist.html:97 UI/accounts/edit.html:88
 #: UI/accounts/edit.html:549 UI/am-taxes.html:77 UI/asset/edit_asset.html:221
 #: UI/asset/edit_class.html:65 UI/asset/import_asset.html:31
@@ -6511,12 +6516,12 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: old/bin/aa.pl:989 old/bin/gl.pl:245 old/bin/ir.pl:917 old/bin/is.pl:1004
-#: old/bin/oe.pl:697 old/bin/oe.pl:922
+#: old/bin/aa.pl:996 old/bin/gl.pl:245 old/bin/ir.pl:939 old/bin/is.pl:1028
+#: old/bin/oe.pl:698 old/bin/oe.pl:923
 msgid "Schedule"
 msgstr "時間表"
 
-#: old/bin/printer.pl:154 UI/journal/journal_entry.html:326
+#: old/bin/printer.pl:154 UI/journal/journal_entry.html:329
 msgid "Scheduled"
 msgstr "編排了時間"
 
@@ -6657,11 +6662,11 @@ msgstr "選擇客戶"
 msgid "Select Templates to Load"
 msgstr ""
 
-#: old/bin/oe.pl:2631
+#: old/bin/oe.pl:2632
 msgid "Select Vendor"
 msgstr "選擇供應商"
 
-#: old/bin/arapprn.pl:310 old/bin/is.pl:1454 old/bin/oe.pl:1380
+#: old/bin/arapprn.pl:310 old/bin/is.pl:1478 old/bin/oe.pl:1381
 msgid "Select a Printer!"
 msgstr "選擇印表機！"
 
@@ -6681,12 +6686,12 @@ msgstr ""
 msgid "Select or Enter User"
 msgstr ""
 
-#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1452
-#: old/bin/oe.pl:1378
+#: old/bin/arapprn.pl:308 old/bin/arapprn.pl:86 old/bin/is.pl:1476
+#: old/bin/oe.pl:1379
 msgid "Select postscript or PDF!"
 msgstr "選擇postscript或PDF！"
 
-#: old/bin/io.pl:1123
+#: old/bin/io.pl:1122
 msgid "Select txt, postscript or PDF!"
 msgstr "選擇文字、postscript或PDF！"
 
@@ -6777,7 +6782,7 @@ msgstr ""
 msgid "Serial #"
 msgstr ""
 
-#: old/bin/io.pl:265 old/bin/oe.pl:1975
+#: old/bin/io.pl:265 old/bin/oe.pl:1976
 msgid "Serial No."
 msgstr "序號"
 
@@ -6795,11 +6800,11 @@ msgstr "序號"
 msgid "Serialnumber"
 msgstr ""
 
-#: UI/src/components/ServerUI.js:122
+#: UI/src/components/ServerUI.js:135
 msgid "Server returned insecure response"
 msgstr ""
 
-#: old/bin/io.pl:630
+#: old/bin/io.pl:629
 msgid "Service"
 msgstr "服務"
 
@@ -6843,13 +6848,13 @@ msgstr ""
 msgid "Seventy"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1948
+#: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:170 old/bin/oe.pl:1949
 #: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
 #: sql/Pg-database.sql:2582
 msgid "Ship"
 msgstr "付運"
 
-#: old/bin/oe.pl:1840
+#: old/bin/oe.pl:1841
 msgid "Ship Merchandise"
 msgstr "付運貨物"
 
@@ -6879,12 +6884,12 @@ msgstr ""
 msgid "Ship Via"
 msgstr ""
 
-#: old/bin/aa.pl:990 old/bin/io.pl:1585 old/bin/is.pl:1005 old/bin/oe.pl:2068
-#: old/bin/oe.pl:661 old/bin/oe.pl:925
+#: old/bin/aa.pl:997 old/bin/io.pl:1584 old/bin/is.pl:1029 old/bin/oe.pl:2069
+#: old/bin/oe.pl:662 old/bin/oe.pl:926
 msgid "Ship to"
 msgstr "付運至"
 
-#: old/bin/is.pl:508 old/bin/oe.pl:1901 old/bin/oe.pl:609
+#: old/bin/is.pl:511 old/bin/oe.pl:1902 old/bin/oe.pl:610
 #: templates/demo/bin_list.html:80 templates/demo/invoice.html:84
 #: templates/demo/invoice.tex:149 templates/demo/packing_list.html:71
 #: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
@@ -6901,23 +6906,23 @@ msgstr "付運公司"
 msgid "Shipping"
 msgstr "付運"
 
-#: old/bin/oe.pl:1842
+#: old/bin/oe.pl:1843
 msgid "Shipping Date"
 msgstr "付運日期"
 
-#: old/bin/oe.pl:2097
+#: old/bin/oe.pl:2098
 msgid "Shipping Date missing!"
 msgstr "未指明付運日期！"
 
-#: old/bin/ir.pl:936 old/bin/is.pl:1025 old/bin/printer.pl:108
+#: old/bin/ir.pl:958 old/bin/is.pl:1049 old/bin/printer.pl:108
 msgid "Shipping Label"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Contact/Purchase.pm:115
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:290
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:314
-#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:504 old/bin/oe.pl:1896
-#: old/bin/oe.pl:605 UI/Reports/filters/invoice_outstanding.html:261
+#: lib/LedgerSMB/Report/Orders.pm:246 old/bin/is.pl:507 old/bin/oe.pl:1897
+#: old/bin/oe.pl:606 UI/Reports/filters/invoice_outstanding.html:261
 #: UI/Reports/filters/invoice_search.html:384 templates/demo/bin_list.html:79
 #: templates/demo/bin_list.tex:99 templates/demo/invoice.html:83
 #: templates/demo/invoice.tex:148 templates/demo/packing_list.html:70
@@ -6993,12 +6998,12 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:81
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:136
 #: lib/LedgerSMB/Scripts/payment.pm:197 lib/LedgerSMB/Scripts/recon.pm:491
-#: old/bin/aa.pl:883 old/bin/ir.pl:819 old/bin/is.pl:915
+#: old/bin/aa.pl:890 old/bin/ir.pl:841 old/bin/is.pl:939
 #: UI/Reports/filters/gl.html:67 UI/Reports/filters/gl.html:267
 #: UI/Reports/filters/inventory_adj.html:13
 #: UI/Reports/filters/invoice_search.html:130
 #: UI/Reports/filters/payments.html:64 UI/inventory/adjustment_setup.html:26
-#: UI/journal/journal_entry.html:136 UI/payments/payment2.html:113
+#: UI/journal/journal_entry.html:139 UI/payments/payment2.html:113
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
@@ -7079,11 +7084,11 @@ msgstr ""
 msgid "Starting Date:"
 msgstr ""
 
-#: old/bin/aa.pl:693 old/bin/io.pl:1655 old/bin/ir.pl:489 old/bin/is.pl:544
+#: old/bin/aa.pl:696 old/bin/io.pl:1654 old/bin/ir.pl:490 old/bin/is.pl:547
 msgid "State"
 msgstr "州"
 
-#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:151
+#: UI/Contact/divs/address.html:82 UI/Contact/divs/address.html:149
 #: UI/Reports/filters/contact_search.html:99
 #: UI/Reports/filters/purchase_history.html:83
 #: t/data/04-complex_template.html:387
@@ -7167,7 +7172,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: old/bin/io.pl:1304 old/bin/ir.pl:681 old/bin/is.pl:762 old/bin/oe.pl:818
+#: old/bin/io.pl:1303 old/bin/ir.pl:682 old/bin/is.pl:765 old/bin/oe.pl:819
 #: UI/Reports/filters/gl.html:318
 #: UI/Reports/filters/invoice_outstanding.html:275
 #: UI/Reports/filters/invoice_search.html:398 UI/Reports/filters/orders.html:213
@@ -7230,8 +7235,8 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:75
 #: lib/LedgerSMB/Report/Listings/Asset.pm:128
-#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:568
-#: lib/LedgerSMB/Scripts/asset.pm:678 lib/LedgerSMB/Scripts/asset.pm:786
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90 lib/LedgerSMB/Scripts/asset.pm:569
+#: lib/LedgerSMB/Scripts/asset.pm:679 lib/LedgerSMB/Scripts/asset.pm:788
 msgid "Tag"
 msgstr ""
 
@@ -7253,7 +7258,7 @@ msgstr "稅金"
 msgid "Tax Account"
 msgstr ""
 
-#: old/bin/ir.pl:598 old/bin/is.pl:692
+#: old/bin/ir.pl:599 old/bin/is.pl:695
 msgid "Tax Code"
 msgstr ""
 
@@ -7263,7 +7268,7 @@ msgstr ""
 msgid "Tax Form"
 msgstr ""
 
-#: old/bin/aa.pl:714
+#: old/bin/aa.pl:717
 msgid "Tax Form Applied"
 msgstr ""
 
@@ -7287,7 +7292,7 @@ msgstr ""
 msgid "Tax Forms"
 msgstr ""
 
-#: old/bin/aa.pl:632 old/bin/ir.pl:432 old/bin/is.pl:468
+#: old/bin/aa.pl:635 old/bin/ir.pl:433 old/bin/is.pl:471
 msgid "Tax ID"
 msgstr ""
 
@@ -7295,7 +7300,7 @@ msgstr ""
 msgid "Tax ID/SSN"
 msgstr ""
 
-#: old/bin/ir.pl:585 old/bin/is.pl:678 old/bin/oe.pl:790
+#: old/bin/ir.pl:586 old/bin/is.pl:681 old/bin/oe.pl:791
 #: UI/Contact/divs/credit.html:316 UI/Contact/divs/credit.html:317
 msgid "Tax Included"
 msgstr "已含稅金"
@@ -7394,7 +7399,7 @@ msgstr ""
 msgid "Template Listing"
 msgstr ""
 
-#: old/bin/aa.pl:1187 old/bin/gl.pl:360
+#: old/bin/aa.pl:1194 old/bin/gl.pl:360
 msgid "Template Saved!"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr "次"
 msgid "Timing"
 msgstr ""
 
-#: old/bin/ic.pl:1116 old/bin/oe.pl:2248 old/bin/pe.pl:748
+#: old/bin/ic.pl:1116 old/bin/oe.pl:2249 old/bin/pe.pl:748
 #: UI/Contact/divs/credit.html:444 UI/Reports/co/filter_bm.html:26
 #: UI/Reports/co/filter_cd.html:44 UI/Reports/filters/aging.html:33
 #: UI/Reports/filters/income_statement.html:137
@@ -7649,7 +7654,7 @@ msgstr ""
 msgid "To Pay"
 msgstr ""
 
-#: old/bin/oe.pl:2263
+#: old/bin/oe.pl:2264
 msgid "To Warehouse"
 msgstr "到倉庫"
 
@@ -7695,7 +7700,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Taxform/Details.pm:105
 #: lib/LedgerSMB/Report/Taxform/Summary.pm:100
 #: lib/LedgerSMB/Scripts/asset.pm:492 lib/LedgerSMB/Scripts/payment.pm:929
-#: old/bin/ir.pl:745 old/bin/is.pl:841 old/bin/oe.pl:850
+#: old/bin/ir.pl:755 old/bin/is.pl:853 old/bin/oe.pl:851
 #: UI/Reports/filters/invoice_outstanding.html:206
 #: UI/Reports/filters/invoice_search.html:329 UI/payments/payment1.html:99
 #: UI/payments/payment1.html:109 UI/payments/payment2.html:482
@@ -7716,7 +7721,7 @@ msgstr ""
 msgid "Total"
 msgstr "總計"
 
-#: lib/LedgerSMB/Scripts/asset.pm:626
+#: lib/LedgerSMB/Scripts/asset.pm:627
 msgid "Total Accum. Dep."
 msgstr ""
 
@@ -7728,6 +7733,10 @@ msgstr ""
 msgid "Total Paid"
 msgstr ""
 
+#: old/bin/aa.pl:850 old/bin/ir.pl:766 old/bin/is.pl:862
+msgid "Total paid"
+msgstr ""
+
 #: UI/accounts/edit.html:418
 msgid "Tracking Items"
 msgstr "需要追蹤的項目"
@@ -7736,7 +7745,7 @@ msgstr "需要追蹤的項目"
 msgid "Trade Discount"
 msgstr "貿易折扣"
 
-#: old/bin/aa.pl:998 old/bin/am.pl:960
+#: old/bin/aa.pl:1005 old/bin/am.pl:960
 msgid "Transaction"
 msgstr "交易"
 
@@ -7769,20 +7778,20 @@ msgstr ""
 msgid "Transactions"
 msgstr "所有交易"
 
-#: old/bin/oe.pl:2252 old/bin/oe.pl:2368 sql/Pg-database.sql:2584
+#: old/bin/oe.pl:2253 old/bin/oe.pl:2369 sql/Pg-database.sql:2584
 #: sql/Pg-database.sql:2619
 msgid "Transfer"
 msgstr "轉移"
 
-#: old/bin/oe.pl:2134 old/bin/oe.pl:2279
+#: old/bin/oe.pl:2135 old/bin/oe.pl:2280
 msgid "Transfer Inventory"
 msgstr "轉移存貨"
 
-#: old/bin/oe.pl:2152
+#: old/bin/oe.pl:2153
 msgid "Transfer from"
 msgstr "由這裡取貨"
 
-#: old/bin/oe.pl:2156
+#: old/bin/oe.pl:2157
 msgid "Transfer to"
 msgstr "存貨至"
 
@@ -7869,7 +7878,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/History.pm:149
 #: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:128
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:85
-#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1716
+#: lib/LedgerSMB/Scripts/asset.pm:470 old/bin/io.pl:1713
 #: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:117
 #: UI/Contact/divs/contact_info.html:29 UI/Contact/divs/credit.html:25
 #: UI/Contact/divs/wage.html:7 UI/Reports/filters/search_goods.html:13
@@ -7930,7 +7939,7 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:92
 #: lib/LedgerSMB/Report/Inventory/History.pm:133
 #: lib/LedgerSMB/Report/Inventory/Search.pm:231 old/bin/ic.pl:1254
-#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1970
+#: old/bin/ic.pl:783 old/bin/io.pl:238 old/bin/oe.pl:1971
 #: UI/Reports/filters/purchase_history.html:293
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:165 templates/demo/product_receipt.tex:135
@@ -7946,7 +7955,7 @@ msgstr ""
 msgid "Unknown "
 msgstr ""
 
-#: UI/src/components/ServerUI.js:127
+#: UI/src/components/ServerUI.js:140
 msgid "Unknown (JavaScript) error"
 msgstr ""
 
@@ -7964,7 +7973,7 @@ msgstr ""
 msgid "Unknown database found."
 msgstr ""
 
-#: UI/src/views/LoginPage.vue:107
+#: UI/src/views/LoginPage.vue:117
 msgid "Unknown error preventing login"
 msgstr ""
 
@@ -8016,20 +8025,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:986 old/bin/gl.pl:230
-#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:914 old/bin/is.pl:1001
-#: old/bin/oe.pl:2065 old/bin/oe.pl:646 old/bin/oe.pl:920 old/bin/pe.pl:516
+#: lib/LedgerSMB/Scripts/budgets.pm:98 old/bin/aa.pl:993 old/bin/gl.pl:230
+#: old/bin/ic.pl:825 old/bin/ic.pl:834 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: old/bin/oe.pl:2066 old/bin/oe.pl:647 old/bin/oe.pl:921 old/bin/pe.pl:516
 #: UI/am-taxes.html:71 UI/payments/payment2.html:502
 #: UI/payments/payments_detail.html:483 UI/payroll/deduction.html:85
 #: UI/payroll/income.html:90 UI/reconciliation/report.html:409
 msgid "Update"
 msgstr "更新"
 
-#: old/bin/ic.pl:776 old/bin/oe.pl:648
+#: old/bin/ic.pl:776 old/bin/oe.pl:649
 msgid "Updated"
 msgstr "已更新"
 
-#: old/bin/oe.pl:647
+#: old/bin/oe.pl:648
 msgid "Updating..."
 msgstr ""
 
@@ -8091,7 +8100,7 @@ msgstr ""
 msgid "Use Overpayment"
 msgstr ""
 
-#: old/bin/io.pl:1825
+#: old/bin/io.pl:1822
 msgid "Use Shipto"
 msgstr ""
 
@@ -8177,8 +8186,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Invoices/Outstanding.pm:195
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:248
 #: lib/LedgerSMB/Report/Orders.pm:182 lib/LedgerSMB/Report/Orders.pm:188
-#: old/bin/aa.pl:553 old/bin/ic.pl:1014 old/bin/ir.pl:392 old/bin/oe.pl:2518
-#: old/bin/oe.pl:2669 old/bin/pe.pl:1075 old/bin/pe.pl:925
+#: old/bin/aa.pl:556 old/bin/ic.pl:1014 old/bin/ir.pl:393 old/bin/oe.pl:2519
+#: old/bin/oe.pl:2670 old/bin/pe.pl:1075 old/bin/pe.pl:925
 #: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
 #: UI/Reports/filters/aging.html:13
 #: UI/Reports/filters/invoice_outstanding.html:5
@@ -8197,7 +8206,7 @@ msgstr ""
 msgid "Vendor History"
 msgstr "供應商歷史"
 
-#: old/bin/oe.pl:687 old/bin/oe.pl:931 UI/Contact/divs/credit.html:349
+#: old/bin/oe.pl:688 old/bin/oe.pl:932 UI/Contact/divs/credit.html:349
 #: t/data/04-complex_template.html:334 sql/Pg-database.sql:2660
 msgid "Vendor Invoice"
 msgstr "供應商發票"
@@ -8213,7 +8222,7 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:115
 #: lib/LedgerSMB/Report/Invoices/Payments.pm:178
-#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1600
+#: lib/LedgerSMB/Scripts/configuration.pm:129 old/bin/io.pl:1599
 #: UI/Reports/filters/invoice_outstanding.html:6
 #: UI/Reports/filters/invoice_search.html:6
 #: UI/Reports/filters/overpayments.html:19 UI/Reports/filters/payments.html:15
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Vendor Search"
 msgstr ""
 
-#: old/bin/aa.pl:1354 old/bin/ir.pl:1279 old/bin/oe.pl:1274
+#: old/bin/aa.pl:1361 old/bin/ir.pl:1301 old/bin/oe.pl:1275
 msgid "Vendor missing!"
 msgstr "未指明供應商！"
 
@@ -8273,7 +8282,7 @@ msgstr ""
 msgid "Wages/Deductions"
 msgstr ""
 
-#: old/bin/oe.pl:1852 UI/Reports/filters/search_goods.html:415
+#: old/bin/oe.pl:1853 UI/Reports/filters/search_goods.html:415
 #: templates/demo/bin_list.html:78 templates/demo/bin_list.tex:97
 #: templates/demo/packing_list.html:69 templates/demo/packing_list.tex:105
 #: templates/demo/pick_list.html:69 templates/demo/pick_list.tex:97
@@ -8350,7 +8359,7 @@ msgstr ""
 msgid "What is LedgerSMB"
 msgstr ""
 
-#: old/bin/io.pl:621
+#: old/bin/io.pl:620
 msgid "What type of item is this?"
 msgstr "此項目屬於甚麼類別？"
 
@@ -8366,7 +8375,7 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: old/bin/am.pl:967 old/bin/io.pl:1163 old/bin/oe.pl:263 old/bin/printer.pl:68
+#: old/bin/am.pl:967 old/bin/io.pl:1162 old/bin/oe.pl:263 old/bin/printer.pl:68
 #: templates/demo/work_order.html:16 templates/demo/work_order.html:32
 #: templates/demo/work_order.tex:124 sql/Pg-database.sql:2713
 #: sql/Pg-database.sql:2726
@@ -8424,7 +8433,7 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1428
+#: lib/LedgerSMB/Report/Taxform/List.pm:100 old/bin/oe.pl:1429
 #: UI/Configuration/settings.html:37 UI/setup/confirm_operation.html:29
 msgid "Yes"
 msgstr "是"
@@ -8443,11 +8452,11 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#: old/bin/io.pl:1658
+#: old/bin/io.pl:1657
 msgid "Zip Code"
 msgstr ""
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:158
+#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:156
 msgid "Zip/Post Code"
 msgstr ""
 
@@ -8514,7 +8523,7 @@ msgstr ""
 msgid "bug"
 msgstr ""
 
-#: old/bin/io.pl:1652
+#: old/bin/io.pl:1651
 msgid "city"
 msgstr ""
 
@@ -8558,7 +8567,7 @@ msgstr "完成"
 msgid "e"
 msgstr ""
 
-#: old/bin/ir.pl:1236 old/bin/is.pl:1337 old/bin/oe.pl:1240
+#: old/bin/ir.pl:1258 old/bin/is.pl:1361 old/bin/oe.pl:1241
 msgid "ea"
 msgstr "個"
 

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -846,6 +846,10 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
                  $selectARAP
               </select></td>
         </tr>
+        <tr><td>&nbsp;</td></td>
+        <tr class="transaction-total-paid"><td>| . $form->format_amount(\%myconfig, $form->{oldtotalpaid}, $form->{_setting_decimal_places} ) . qq|</td><td></td><td>| . $locale->text('Total paid') . qq|</td></tr>
+        <tr class="transaction-remaining-balance"><td>| . $form->format_amount(\%myconfig, $form->{invtotal} - $form->{oldtotalpaid}, $form->{_setting_decimal_places} ) . qq|</td><td></td><td>| . $locale->text('Remaining balance') . qq|</td></tr>
+        <tr><td>&nbsp;</td></td>
         <tr>
            <td>&nbsp;</td>
            <td>&nbsp;</td>

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -697,6 +697,15 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
         $hold = qq| <font size="17"><b> This invoice is On Hold </b></font> |;
     }
 
+    $totalpaid = 0;
+    foreach my $i ( 1 .. $form->{paidaccounts} ) {
+        next if $readonly and not $form->{"datepaid_$i"};
+        $totalpaid += $form->{"paid_$i"};
+    }
+    $remaining_balance = $form->{invtotal} - $totalpaid;
+    $totalpaid = $form->format_amount( \%myconfig, $totalpaid, $form->{_setting_decimal_places}, 0 );
+    $remaining_balance = $form->format_amount( \%myconfig, $remaining_balance, $form->{_setting_decimal_places}, 0 );
+
     print qq|
   <tr>
     <td>
@@ -750,6 +759,18 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                                                      $form->{invtotal}
                                                      * $form->{exchangerate}, $form->{_setting_decimal_places})
           . "</td><td>$form->{defaultcurrency}</td></tr>") : '') . qq|
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+      <tr class="invoice-total-paid">
+        <th>| . $locale->text('Total paid') . qq|</th><td align=right>$totalpaid</td><td>$form->{currency}</td>
+      </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+      <tr class="invoice-remaining-balance">
+        <th>| . $locale->text('Remaining balance') . qq|</th><td align=right>$remaining_balance</td><td>$form->{currency}</td>
+      </tr>
         </table>
       </td>
     </tr>

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -794,6 +794,15 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
         $hold_button_text = $locale->text('On Hold');
     }
 
+    $totalpaid = 0;
+    foreach my $i ( 1 .. $form->{paidaccounts} ) {
+        next if $readonly and not $form->{"datepaid_$i"};
+        $totalpaid += $form->{"paid_$i"};
+    }
+    $remaining_balance = $form->{invtotal} - $totalpaid;
+    $totalpaid = $form->format_amount( \%myconfig, $totalpaid, $form->{_setting_decimal_places}, 0 );
+    $remaining_balance = $form->format_amount( \%myconfig, $remaining_balance, $form->{_setting_decimal_places}, 0 );
+
     print qq|
   <tr>
     <td>
@@ -846,6 +855,18 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
       (($form->{currency} ne $form->{defaultcurrency})
        ? "<tr><td><!-- total --></td><td align=right>$invtotal_bc</td><td>$form->{defaultcurrency}</td></tr>" : '')
       . qq|
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+      <tr class="invoice-total-paid">
+        <th>| . $locale->text('Total paid') . qq|</th><td align=right>$totalpaid</td><td>$form->{currency}</td>
+      </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+      <tr class="invoice-remaining-balance">
+        <th>| . $locale->text('Remaining balance') . qq|</th><td align=right>$remaining_balance</td><td>$form->{currency}</td>
+      </tr>
           $taxincluded
         </table>
       </td>


### PR DESCRIPTION
After this change, the invoice screens (both sales and purchase) will look like this:

![2023-01-27_10-30](https://user-images.githubusercontent.com/2326559/215091900-b6e4e931-b562-4a7b-9617-76afe485375a.png)


(Note that the CSS to set the font characteristics is not included.)

Added the same for transaction screens, which now look like:


![2023-01-27_14-19](https://user-images.githubusercontent.com/2326559/215098304-e3545373-f2f4-4105-9550-043f8b6998be.png)
