### PR TITLE
Remove interdependency between main and tree components

### DIFF
--- a/UI/js-src/lsmb/menus/Tree.js
+++ b/UI/js-src/lsmb/menus/Tree.js
@@ -71,7 +71,6 @@ define([
         model: model,
         showRoot: false,
         openOnClick: true,
-        load_link: null,
         postCreate: function () {
             this.inherited(arguments);
 
@@ -147,11 +146,11 @@ define([
                 // function).
                 url += "#" + Date.now();
 
-                if (this.load_link) {
+                if (window.__lsmbLoadLink) {
                     if (url.charAt(0) !== "/") {
                         url = "/" + url;
                     }
-                    this.load_link(url);
+                    window.__lsmbLoadLink(url);
                 }
             }
         },

--- a/UI/src/main-vue.js
+++ b/UI/src/main-vue.js
@@ -12,7 +12,6 @@ import { useSessionUserStore } from "@/store/sessionUser";
 
 import { createPinia } from "pinia";
 
-const registry = require("dijit/registry");
 const dojoParser = require("dojo/parser");
 
 let app;
@@ -36,23 +35,16 @@ if (document.getElementById("main")) {
             return { t };
         },
         mounted() {
-            let m = document.getElementById("main");
-
-            this.$nextTick(() => {
-                dojoParser.parse(m).then(() => {
-                    let r = registry.byId("top_menu");
-                    if (r) {
-                        // Setup doesn't have top_menu
-                        r.load_link = (url) => this.$router.push(url);
-                    }
-                    document.body.setAttribute("data-lsmb-done", "true");
-                });
-            });
             window.__lsmbLoadLink = (url) =>
                 this.$router.push(
                     // eslint-disable-next-line no-useless-escape
                     url.replace(/^https?:\/\/(?:[^@\/]+)/, "")
                 );
+
+            let m = document.getElementById("main");
+            dojoParser.parse(m).then(() => {
+                document.body.setAttribute("data-lsmb-done", "true");
+            });
         },
         beforeUpdate() {
             document.body.removeAttribute("data-lsmb-done");


### PR DESCRIPTION
Instead of poking directly in the tree's state, set a global variable for the tree to pick up.
