### PR TITLE
Clear $@ before dying

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -351,6 +351,7 @@ This function replaces explicit 'exit()' calls.
 =cut
 
 sub finalize_request {
+    undef $@;
     die;
 }
 


### PR DESCRIPTION
Without clearing `$@`, the last error is being rethrown, which might look like a genuine error. This is currently showing with Workflow 1.61 in combination with the invoice screen: sometimes an error gets appended to the invoice screen, even when it has rendered successfully. The cause how Workflow works internally in combination with its failure to protect the value of `$@`.
