### PR TITLE
Replace calls to removed function report_request_error()

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -190,8 +190,10 @@ export default {
             .getElementById("maindiv")
             .setAttribute("data-lsmb-done", "true");
         this.$nextTick(() => this.updateContent(this.uiURL));
-        window.__lsmbSubmitForm = (req) =>
-            this.updateContent(req.url, req.options);
+        window.__lsmbSubmitForm =
+            (req) => this.updateContent(req.url, req.options);
+        window.__lsmbReportError =
+            (err) => this._report_error(err);
     },
     beforeUpdate() {
         this._cleanWidgets();


### PR DESCRIPTION
The function is no longer available as "maindiv" no longer is a Dojo widget (instead, it's a Vue widget, but that's a separate universe entirely...).
