### PR TITLE
Align SQL implementation with Perl

### DIFF
--- a/sql/modules/Settings.sql
+++ b/sql/modules/Settings.sql
@@ -91,7 +91,11 @@ AS
 $$
         UPDATE defaults SET value = setting__increment_base(value)
         WHERE setting_key = in_key
-        RETURNING value;
+  RETURNING (
+    -- return the old value
+    -- note: only works at the 'read committed' isolation or lower
+    select value from defaults where setting_key = in_key
+  );
 
 $$ LANGUAGE SQL;
 

--- a/xt/45.3-ledgersmb-setting.t
+++ b/xt/45.3-ledgersmb-setting.t
@@ -104,8 +104,8 @@ is($$accounts[0]->{accno}, '1002', 'accounts_by_link returns correct account');
 
 # Increment a field
 ok($setting->set('TEST_SETTING_KEY', 'A-123-1234-B'), 'set increment test key');
-is($setting->increment(undef, 'TEST_SETTING_KEY'), 'A-123-1235-B', 'increment returned ok');
-is($setting->get('TEST_SETTING_KEY'), 'A-123-1235-B', 'increment round-trip from database');
+is($setting->increment(undef, 'TEST_SETTING_KEY'), 'A-123-1234-B', 'increment returned ok');
+is($setting->get('TEST_SETTING_KEY'), 'A-123-1235-B', 'setting lists next value in database');
 
 
 # Don't commit any of our changes

--- a/xt/66-cucumber/04-users/change-permissions.feature
+++ b/xt/66-cucumber/04-users/change-permissions.feature
@@ -12,7 +12,7 @@ Scenario: Remove a user permission
   Then I should see the Contact Search screen
   When I press "Search"
   Then I should see the Contact Search Report screen
-  When I click Control Code "A-00002"
+  When I click Control Code "A-00001"
   Then I should see the Edit Contact screen
   When I select the "User" tab
   Then I expect the "account all" checkbox to be selected
@@ -27,7 +27,7 @@ Scenario: Add a user permission
   Then I should see the Contact Search screen
   When I press "Search"
   Then I should see the Contact Search Report screen
-  When I click Control Code "A-00002"
+  When I click Control Code "A-00001"
   Then I should see the Edit Contact screen
   When I select the "User" tab
   Then I expect the "account all" checkbox to be not selected


### PR DESCRIPTION
In 1.8, the sequence numbers in 'defaults' are the "next value" instead of the "last value".  This aligns the SQL implementation to follow the same paradigm as the Perl code.
