### PR TITLE
Patch the workflow state to indicate approval

### DIFF
--- a/sql/changes/1.10/fix-arap-approval-state.sql
+++ b/sql/changes/1.10/fix-arap-approval-state.sql
@@ -1,0 +1,9 @@
+
+update workflow u
+   set state = 'POSTED'
+       from workflow w
+       join transactions t on t.workflow_id = w.workflow_id
+ where w.workflow_id = u.workflow_id
+   and w.state in ('SAVED', 'INITIAL')
+   and t.approved;
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -168,6 +168,7 @@ mc/delete-migration-validation-data.sql
 1.10/unique-transaction-reconciliation.sql
 1.10/missing-fkeys.sql
 1.10/file-tranaction-cascade-delete.sql
+1.10/fix-arap-approval-state.sql
 # 1.11 changes
 1.11/menu-system-users.sql
 1.11/country-config.sql


### PR DESCRIPTION
Follow-up to the fix to make Transaction Approval > Drafts update the workflow as well as the transaction state.
