### PR TITLE
Follow-up to #7048: Improve old-UI integration with Vue

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -71,6 +71,7 @@ export default {
                         // Vue won't re-render... so don't rerun the parser!
                         return;
                     }
+                    this._cleanWidgets();
                     this.content = newContent;
                     this.$nextTick(() => {
                         let maindiv = document.getElementById("maindiv");
@@ -195,9 +196,6 @@ export default {
             (req) => this.updateContent(req.url, req.options);
         window.__lsmbReportError =
             (err) => this._report_error(err);
-    },
-    beforeUpdate() {
-        this._cleanWidgets();
     },
     render() {
         let body = this.content.match(/<body[^>]*>([\s\S]*)(<\/body>)?/i);


### PR DESCRIPTION
With the widgets destroyed in `beforeUpdate`, it turns out that we can still get stuck with a UI "dead in the water": when the UI update fails with an error, the widgets have already been destroyed, but the UI is still visible (and looks like it can be used after closing the error dialog). By destroying the widgets just before they get replaced, the opportunities for this scenario are much reduced (if not eliminated).