### PR TITLE
Handle form state with a state machine

### DIFF
--- a/UI/src/components/ConfigTable.machines.js
+++ b/UI/src/components/ConfigTable.machines.js
@@ -11,36 +11,10 @@ import {
     state,
     transition
 } from "@/robot-vue";
-
-function progressNotify(fn, progress) {
-    return async (ctx) => {
-        let dismiss;
-
-        if (progress) {
-            let cbp = ctx.notifications[progress];
-            if (cbp) {
-                cbp(ctx, (d) => {
-                    dismiss = d;
-                });
-            }
-        }
-        return fn(ctx).finally((value) => {
-            if (dismiss) {
-                dismiss();
-            }
-            return value;
-        });
-    };
-}
-
-function notify(notification) {
-    return (ctx) => {
-        let cb = ctx.notifications[notification];
-        if (cb) {
-            cb(ctx);
-        }
-    };
-}
+import {
+    progressNotify,
+    notify
+} from "@/machine-helpers.js";
 
 function handleError(ctx, error) {
     return { ...ctx, error };

--- a/UI/src/components/ConfigTableRow.vue
+++ b/UI/src/components/ConfigTableRow.vue
@@ -57,31 +57,31 @@ const { service, send, state } = createRowMachine(props.store, {
         rowId: props.id,
         adding: props.type === "new",
         notifications: {
-            "acquiring": (ctx, cb) => {
+            "acquiring": (ctx, { dismissReceiver }) => {
                 notify({
                     title: t("Getting latest data"),
                     type: "info",
-                    dismissReceiver: cb
+                    dismissReceiver
                 });
             },
-            "adding": (ctx, cb) => {
+            "adding": (ctx, { dismissReceiver }) => {
                 notify({
                     title: t("Adding"),
                     type: "info",
-                    dismissReceiver: cb
+                    dismissReceiver
                 });
             },
             "added": (ctx) => { notify({ title: t("Added") }); },
-            "deleting": (ctx, cb) => {
+            "deleting": (ctx, { dismissReceiver }) => {
                 notify({
                     title: t("Deleting"),
                     type: "info",
-                    dismissReceiver: cb
+                    dismissReceiver
                 });
             },
             "deleted": (ctx) => { notify({ title: t("Deleted") }); },
-            "saving": (ctx, cb) => {
-                notify({ title: t("Saving"), type: "info", dismissReceiver: cb });
+            "saving": (ctx, { dismissReceiver }) => {
+                notify({ title: t("Saving"), type: "info", dismissReceiver });
             },
             "saved": (ctx) => { notify({ title: t("Saved") }); },
         }

--- a/UI/src/components/ImportCSV-Base.machines.js
+++ b/UI/src/components/ImportCSV-Base.machines.js
@@ -1,0 +1,85 @@
+/** @format */
+
+import {
+    action,
+    createMachine,
+    immediate,
+    interpret,
+    invoke,
+    guard,
+    reduce,
+    state,
+    transition
+} from "@/robot-vue";
+import {
+    progressNotify,
+    notify,
+    testNot,
+    testResponseOkFn,
+    transitionFormValid,
+    transitionFormInvalid
+} from "@/machine-helpers.js";
+
+function submitUpload(ctx) {
+    let data = new FormData(ctx.form.value);
+    data.append("action", "run_import");
+
+    return fetch("import_csv.pl", {
+        method: "POST",
+        body: data,
+        headers: new Headers({
+            "X-Requested-With": "XMLHttpRequest"
+        })
+    });
+}
+
+function createImportMachine(initialContext) {
+    return interpret(
+        createMachine({
+            invalid: state(
+                transitionFormValid('input','ready'),
+            ),
+            ready: state(
+                transitionFormInvalid('input', 'invalid'),
+                transition('submit', 'submitting'),
+            ),
+            submitting: invoke(
+                progressNotify(submitUpload),
+                transition(
+                    'error', 'ready',
+                    action(notify("submitError"))),
+                transition(
+                    'done', 'submitted',
+                    reduce((ctx, e) => ({ ...ctx, response: e.data})),
+                ),
+            ),
+            submitted: state(
+                immediate('parsing'),
+            ),
+            parsing: invoke(
+                ctx => ctx.response.json(),
+                transition(
+                    'done', 'failed',
+                    guard(testNot(testResponseOkFn())),
+                    action(notify("processingError")),
+                ),
+                transition(
+                    'done', 'final',
+                    action(notify("success")),
+                ),
+                transition(
+                    'error', 'error',
+                    reduce(notify("responseError"))),
+            ),
+            failed: state(
+                transitionFormValid('input', 'ready'),
+                transitionFormInvalid('input', 'invalid'),
+            ),
+            final: state(),
+            error: state(),
+        }, initialCtx => initialCtx),
+        () => {},
+        initialContext);
+}
+
+export { createImportMachine };

--- a/UI/src/components/Toast.vue
+++ b/UI/src/components/Toast.vue
@@ -38,6 +38,6 @@ if (props.data.dismissReceiver) {
          @mouseenter="send('hold')"
          @mouseleave="send('release')">
         <div class="title" >{{ title }}</div>
-        <div v-if="text">{{ text }}</div>
+        <div v-if="text" style="margin-top:1em">{{ text }}</div>
     </div>
 </template>

--- a/UI/src/machine-helpers.js
+++ b/UI/src/machine-helpers.js
@@ -1,0 +1,63 @@
+/** @format */
+
+import { guard, transition } from "@/robot-vue";
+const registry = require("dijit/registry");
+
+export function testNot(fn) {
+    return (...args) => !fn(...args);
+}
+
+export function testFormValidFn(formFn=(ctx)=>(ctx.form.value)) {
+    return (ctx) => registry.findWidgets(formFn(ctx)).reduce(
+            (acc, w) => (acc && (w.disabled || !w.validate || w.validate())),
+            true
+    );
+}
+
+export function testResponseOkFn(responseFn=(ctx)=>(ctx.response)) {
+    return (ctx) => responseFn(ctx).ok;
+}
+
+export function testResponseStatusFn(status, responseFn=(ctx)=>(ctx.response)) {
+    return (ctx) => responseFn(ctx).status === status;
+}
+
+export function transitionFormValid(event, target) {
+    return transition(event, target,
+                      guard(testFormValidFn()));
+}
+
+export function transitionFormInvalid(event, target) {
+    return transition(event, target,
+                      guard(testNot(testFormValidFn())));
+}
+
+export function progressNotify(fn, progress) {
+    return async (ctx) => {
+        let dismiss;
+
+        if (progress) {
+            let cbp = ctx.notifications[progress];
+            if (cbp) {
+                cbp(ctx, {
+                    dismissReceiver: (d) => { dismiss = d; }
+                });
+            }
+        }
+        return fn(ctx).finally(() => {
+            if (dismiss) {
+                dismiss();
+            }
+        });
+    };
+}
+
+export function notify(notification) {
+    return (ctx, event) => {
+        let cb = ctx.notifications[notification];
+        if (cb) {
+            cb(ctx, { event });
+        }
+    };
+}
+

--- a/UI/src/views/LoginPage.machines.js
+++ b/UI/src/views/LoginPage.machines.js
@@ -1,0 +1,119 @@
+/** @format */
+
+import {
+    action,
+    createMachine,
+    immediate,
+    interpret,
+    invoke,
+    guard,
+    reduce,
+    state,
+    transition
+} from "@/robot-vue";
+const registry = require("dijit/registry");
+
+const not = (fn) => (
+    (...args) => !fn(...args)
+);
+const formValid =
+      (ctx) => registry.findWidgets(ctx.form.value).reduce(
+            (acc, w) => (acc && (w.disabled || !w.validate || w.validate())),
+            true
+        );
+const okResponse = (ctx) => ctx.response.ok;
+const responseStatus = (status) => (
+    (ctx) => (ctx.response.status === status)
+);
+
+
+function submitLogin(ctx) {
+    return fetch("login.pl?action=authenticate&company=" + encodeURI(ctx.company.value), {
+        method: "POST",
+        body: JSON.stringify({
+            company: ctx.company.value,
+            password: ctx.password.value,
+            login: ctx.username.value
+        }),
+        headers: new Headers({
+            "X-Requested-With": "XMLHttpRequest",
+            "Content-Type": "application/json"
+        })
+    });
+}
+
+const transitionToInvalid =
+    (event) => transition(event, 'invalid',
+                                guard(not(formValid)));
+const transitionToReady =
+    (event) => transition(event, 'ready',
+                                guard(formValid));
+
+
+function createLoginMachine(initialContext) {
+    return interpret(
+        createMachine({
+            invalid: state(
+                transitionToReady('input'),
+            ),
+            ready: state(
+                transitionToInvalid('input'),
+                transition('submit', 'submitting'),
+            ),
+            submitting: invoke(
+                submitLogin,
+                transition(
+                    'error', 'ready',
+                    action((ctx, e) => { alert(e.error); }) // eslint-disable-line no-alert
+                ),
+                transition(
+                    'done', 'submitted',
+                    reduce((ctx, e) => ({ ...ctx, response: e.data})),
+                ),
+            ),
+            submitted: state(
+                immediate(
+                    'failed',
+                    guard(responseStatus(401)),
+                    action((ctx) => {
+                        ctx.errorText.value = ctx.t("Access denied: Bad username or password");
+                    }),
+                ),
+                immediate(
+                    'failed',
+                    guard(responseStatus(521)),
+                    action((ctx) => {
+                        ctx.errorText.value = ctx.t("Database version mismatch");
+                    }),
+                ),
+                immediate(
+                    'ready',
+                    guard(not(okResponse)),
+                    action((ctx) => {
+                        alert(ctx.t("Unknown error preventing login")); // eslint-disable-line no-alert
+                    }),
+                ),
+                immediate('parsing'),
+            ),
+            parsing: invoke(
+                ctx => ctx.response.json(),
+                transition(
+                    'done', 'final',
+                    action((ctx, e) => { window.location.href = e.data.target; }),
+                ),
+                transition(
+                    'error', 'error',
+                    reduce((ctx, e) => ({ ...ctx, error: e.data }))),
+            ),
+            failed: state(
+                transitionToReady('input'),
+                transitionToInvalid('input'),
+            ),
+            final: state(),
+            error: state(),
+        }, initialCtx => initialCtx),
+        () => {},
+        initialContext);
+}
+
+export { createLoginMachine };


### PR DESCRIPTION
Remaining work:

* [x] Add errors returned by the server upon CSV upload to the popup-Toast
* [x] Determine the next-state upon CSV processing (server-side); choices so far are
   a. Reset the form to empty and start from scratch
   b. Show a greyed-out button with nowhere to go
   c. Clean the upload file field, but leave others in place for re-use; otherwise like (a)
  d. Show a greyed-out button which becomes active on the first form activity (e.g. changing the file or tabbing to another input field)

Went with (d) for now.