### PR TITLE
Wrap Dijit widgets required to move the UI away from directly depending on Dojo

### DIFF
--- a/UI/Configuration/settings.html
+++ b/UI/Configuration/settings.html
@@ -1,6 +1,6 @@
 [% PROCESS elements.html %]
 <body class="lsmb [% dojo_theme %]">
-  <form data-dojo-type="lsmb/Form"
+  <form is="lsmb-form"
         id="system-settings"
         method="post"
         action="[% form.script %]">
@@ -102,7 +102,7 @@
               };
            END;
            PROCESS button element_data={
-                   name => 'action'
+                   name => '__action'
                    value => 'save_defaults'
                    text => text('Save')} %]
   </form>

--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.11.0-dev",
       "license": "GPL-2.0-or-later",
       "dependencies": {
+        "@ungap/custom-elements": "^1.3.0",
         "content-disposition": "0.5.4",
         "dijit": "1.17.3",
         "dojo": "1.17.3",
@@ -4087,6 +4088,11 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@ungap/custom-elements": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.3.0.tgz",
+      "integrity": "sha512-f4q/s76+8nOy+fhrNHyetuoPDR01lmlZB5czfCG+OOnBw/Wf+x48DcCDPmMQY7oL8xYFL8qfenMoiS8DUkKBUw=="
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.3.4",
@@ -24444,6 +24450,11 @@
           "dev": true
         }
       }
+    },
+    "@ungap/custom-elements": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.3.0.tgz",
+      "integrity": "sha512-f4q/s76+8nOy+fhrNHyetuoPDR01lmlZB5czfCG+OOnBw/Wf+x48DcCDPmMQY7oL8xYFL8qfenMoiS8DUkKBUw=="
     },
     "@vue/compiler-core": {
       "version": "3.3.4",

--- a/UI/package.json
+++ b/UI/package.json
@@ -43,6 +43,7 @@
     "url": "git+https://github.com/ledgersmb/LedgerSMB.git"
   },
   "dependencies": {
+    "@ungap/custom-elements": "^1.3.0",
     "content-disposition": "0.5.4",
     "dijit": "1.17.3",
     "dojo": "1.17.3",

--- a/UI/reconciliation/report.html
+++ b/UI/reconciliation/report.html
@@ -110,15 +110,15 @@ END %]
 [% i = 1 %]
 <table border=0 id="cleared-table">
     <tr class="listtop">
-        <th colspan="10">[% INCLUDE input element_data = {
-        type = "toggle"
-        name = "b_cleared_table"
-        label = text('Cleared Transactions')
-        checked = b_cleared_table
-        "data-dojo-type" = "lsmb/PublishToggleButton"
-        "data-dojo-props" = "topic:'ui/reconciliation/report/b_cleared_table'"
-        }
-        %]</th>
+      <th colspan="10"><label for="b-cleared-table">[% text('Cleared Transactions') %]</label>
+        <input
+          type="toggle"
+          name="b_cleared_table"
+          id="b-cleared-table"
+          checked="[% b_cleared_table %]"
+          data-dojo-type="lsmb/PublishToggleButton"
+          data-dojo-props="topic:'ui/reconciliation/report/b_cleared_table'" />
+      </th>
     </tr>
     <tr class="listheading">
         <th class="header" rowspan="2" scope="rowgroup"></th>
@@ -246,15 +246,16 @@ END;
 IF have_mismatches ; -%]
 <table border=0 id="error-table">
     <tr class="listtop">
-        <th colspan="10">[% INCLUDE input element_data = {
-        type = "toggle"
-        name = "b_mismatch_table"
-        label = text('Mismatched Transactions (from upload)')
-        checked = b_mismatch_table
-        "data-dojo-type" = "lsmb/PublishToggleButton"
-        "data-dojo-props" = "topic:'ui/reconciliation/report/b_mismatch_table'"
-        }
-        %]</th>
+      <th colspan="10"><label for="b-mismatch-table">[%
+          text('Mismatched Transactions (from upload)') %]</label>
+        <input
+          type="toggle"
+          name="b_mismatch_table"
+          id="b-mismatch-table"
+          checked="[% b_mismatch_table %]"
+          data-dojo-type="lsmb/PublishToggleButton"
+          data-dojo-props="topic:'ui/reconciliation/report/b_mismatch_table'" />
+      </th>
     </tr>
     <tr class="listheading">
         <th class="header"></th>
@@ -321,15 +322,15 @@ IF have_outstanding ;
 -%]
 <table id="outstanding-table">
     <tr class="listtop">
-        <th colspan="6">[% INCLUDE input element_data = {
-        type = "toggle"
-        name = "b_outstanding_table"
-        label = text('Outstanding Transactions')
-        checked = b_outstanding_table
-        "data-dojo-type" = "lsmb/PublishToggleButton"
-        "data-dojo-props" = "topic:'ui/reconciliation/report/b_outstanding_table'"
-        }
-        %]</th>
+        <th colspan="6"><label for="b-outstanding-table">[% text('Outstanding Transactions') %]</label>
+        <input
+          type="toggle"
+          name="b_outstanding_table"
+          id="b-outstanding-table"
+          checked="[% b_outstanding_table %]"
+          data-dojo-type="lsmb/PublishToggleButton"
+          data-dojo-props="topic:'ui/reconciliation/report/b_outstanding_table'" />
+        </th>
     </tr>
     <tr class="listheading">
         <th class="header">[% text('Cleared') %]</th>

--- a/UI/src/elements/lsmb-base-checked.js
+++ b/UI/src/elements/lsmb-base-checked.js
@@ -1,0 +1,28 @@
+/** @format */
+/* eslint-disable class-methods-use-this, max-classes-per-file */
+
+import { LsmbBaseInput } from "@/elements/lsmb-base-input";
+
+export class LsmbBaseChecked extends LsmbBaseInput {
+
+    static get observedAttributes() {
+        /* all but "checked" prop are inherited */
+        return ["disabled", "readonly", "required", "value", "checked"];
+    }
+
+    _boolAttrs() {
+        return ["disabled", "readonly", "required", "checked"];
+    }
+
+    get checked() {
+        return this.hasAttribute("checked");
+    }
+
+    set checked(newValue) {
+        if (newValue) {
+            this.setAttribute("checked", "");
+        } else {
+            this.removeAttribute("checked");
+        }
+    }
+}

--- a/UI/src/elements/lsmb-base-input.js
+++ b/UI/src/elements/lsmb-base-input.js
@@ -8,6 +8,7 @@ const registry = require("dijit/registry");
 export class LsmbBaseInput extends LsmbDijit {
 
     dojoLabel = null;
+
     connected = false;
 
     constructor() {

--- a/UI/src/elements/lsmb-base-input.js
+++ b/UI/src/elements/lsmb-base-input.js
@@ -6,6 +6,7 @@ import { LsmbDijit } from "@/elements/lsmb-dijit";
 const registry = require("dijit/registry");
 
 export class LsmbBaseInput extends LsmbDijit {
+    static idRegex = /[^\p{IsAlnum}]/g;
 
     dojoLabel = null;
 
@@ -35,6 +36,13 @@ export class LsmbBaseInput extends LsmbDijit {
         throw new Error(
             "lsmb-base-input is an abstract base class! don't use directly!"
         );
+    }
+
+    _setIdProp(props) {
+        if (props.name) {
+            /* eslint-disable no-param-reassign */
+            props.id = props.name.replaceAll(LsmbBaseInput.idRegex, "-");
+        }
     }
 
     static get observedAttributes() {
@@ -87,6 +95,9 @@ export class LsmbBaseInput extends LsmbDijit {
             props.id = this.getAttribute('id');
             this.removeAttribute('id');
         }
+        if (!props.id) {
+            this._setIdProp(props);
+        }
         let widgetElm = document.createElement("span");
         [ ...this.children ].forEach((c) => { widgetElm.appendChild(c); });
         this._widgetRoot().appendChild(widgetElm);
@@ -100,6 +111,7 @@ export class LsmbBaseInput extends LsmbDijit {
             this.dojoLabel.innerHTML = this.getAttribute("label");
             this.dojoLabel.classList.add("label");
             this.dojoLabel.setAttribute('for', props.id);
+            this.dojoLabel.setAttribute('id', props.id + '-label');
 
             // without this handler, we bubble 2 events "to the outside"
             this.dojoLabel.addEventListener("click", (e) =>

--- a/UI/src/elements/lsmb-button.js
+++ b/UI/src/elements/lsmb-button.js
@@ -7,6 +7,8 @@ const Button = require("dijit/form/Button");
 const registry = require("dijit/registry");
 
 export class LsmbButton extends LsmbDijit {
+    static idRegex = /[^\p{IsAlnum}]/g;
+
     label = null;
 
     constructor() {
@@ -14,7 +16,7 @@ export class LsmbButton extends LsmbDijit {
     }
 
     _valueAttrs() {
-        return ["type"];
+        return ["name", "type", "value"];
     }
 
     connectedCallback() {
@@ -22,6 +24,16 @@ export class LsmbButton extends LsmbDijit {
         this.innerHTML = "";
         let props = this._collectProps();
         props.label = this.label;
+        if (this.hasAttribute('id')) {
+            // move the ID property to the widget we're creating
+            // in order to correctly link any labels
+            props.id = this.getAttribute('id');
+            this.removeAttribute('id');
+        }
+        if (!props.id && props.name && props.value) {
+            /* eslint-disable no-param-reassign */
+            props.id = (props.name + "-" + props.value).replaceAll(LsmbButton.idRegex, "-");
+        }
 
         this.dojoWidget = new Button(props);
         this.appendChild(this.dojoWidget.domNode);

--- a/UI/src/elements/lsmb-checkbox.js
+++ b/UI/src/elements/lsmb-checkbox.js
@@ -8,6 +8,13 @@ const dojoCheckBox = require("dijit/form/CheckBox");
 export class LsmbCheckBox extends LsmbBaseChecked {
     widgetWrapper = null;
 
+    _stdProps() {
+        return {
+            ...super._stdProps(),
+            value: 1
+        };
+    }
+
     _widgetRoot() {
         if (this.widgetWrapper) {
             return this.widgetWrapper;

--- a/UI/src/elements/lsmb-checkbox.js
+++ b/UI/src/elements/lsmb-checkbox.js
@@ -1,0 +1,26 @@
+/** @format */
+/* eslint-disable class-methods-use-this, max-classes-per-file */
+
+import { LsmbBaseChecked } from "@/elements/lsmb-base-checked";
+
+const dojoCheckBox = require("dijit/form/CheckBox");
+
+export class LsmbCheckBox extends LsmbBaseChecked {
+    widgetWrapper = null;
+
+    _widgetRoot() {
+        if (this.widgetWrapper) {
+            return this.widgetWrapper;
+        }
+        this.widgetWrapper = document.createElement("span");
+        this.appendChild(this.widgetWrapper);
+
+        return this.widgetWrapper;
+    }
+
+    _widgetClass() {
+        return dojoCheckBox;
+    }
+}
+
+customElements.define("lsmb-checkbox", LsmbCheckBox);

--- a/UI/src/elements/lsmb-date.js
+++ b/UI/src/elements/lsmb-date.js
@@ -9,7 +9,22 @@ export class LsmbDate extends LsmbBaseInput {
     widgetWrapper = null;
 
     _stdProps() {
-        return { size: 10 };
+        return {
+            ...super._stdProps(),
+            size: 10
+        };
+    }
+
+    _collectProps() {
+        let props = super._collectProps();
+        if ("value" in props && !props.value) {
+            // a value of "" is interpreted as Unix 'epoch'
+            // instead, we want it to be interpreted as 'empty'
+            // so, delete the property
+            delete props.value;
+        }
+
+        return props;
     }
 
     _widgetRoot() {

--- a/UI/src/elements/lsmb-filtering-select.js
+++ b/UI/src/elements/lsmb-filtering-select.js
@@ -1,0 +1,14 @@
+/** @format */
+/* eslint-disable class-methods-use-this, max-classes-per-file */
+
+import { LsmbBaseInput } from "@/elements/lsmb-base-input";
+
+const dojoSelect = require("lsmb/FilteringSelect");
+
+export class LsmbFilteringSelect extends LsmbBaseInput {
+    _widgetClass() {
+        return dojoSelect;
+    }
+}
+
+customElements.define("lsmb-filtering-select", LsmbFilteringSelect);

--- a/UI/src/elements/lsmb-form.js
+++ b/UI/src/elements/lsmb-form.js
@@ -1,0 +1,30 @@
+/** @format */
+/* eslint-disable class-methods-use-this */
+
+import { LsmbDijit } from "@/elements/lsmb-dijit";
+
+const Form  = require("lsmb/Form");
+const registry = require("dijit/registry");
+const parser = require("dojo/parser");
+
+export class LsmbForm extends HTMLFormElement {
+
+    formWidget = null;
+
+    connectedCallback() {
+        let props = {};
+        props.method = this.method;
+        props.action = this.action;
+        props.id = this.id;
+        this.formWidget = new Form(props, this);
+    }
+
+    disconnectedCallback() {
+        if (this.formWidget) {
+            registry.remove(this.formWidget.id);
+            this.formWidget = null;
+        }
+    }
+}
+
+customElements.define("lsmb-form", LsmbForm, { extends: "form" });

--- a/UI/src/elements/lsmb-password.js
+++ b/UI/src/elements/lsmb-password.js
@@ -5,7 +5,10 @@ import { LsmbText } from "@/elements/lsmb-text";
 
 export class LsmbPassword extends LsmbText {
     _stdProps() {
-        return { type: "password" };
+        return {
+            ...super._stdProps(),
+            type: "password"
+        };
     }
 
     constructor() {

--- a/UI/src/elements/lsmb-radio.js
+++ b/UI/src/elements/lsmb-radio.js
@@ -1,0 +1,26 @@
+/** @format */
+/* eslint-disable class-methods-use-this, max-classes-per-file */
+
+import { LsmbBaseChecked } from "@/elements/lsmb-base-checked";
+
+const dojoRadioButton = require("dijit/form/RadioButton");
+
+export class LsmbRadioButton extends LsmbBaseChecked {
+    widgetWrapper = null;
+
+    _widgetRoot() {
+        if (this.widgetWrapper) {
+            return this.widgetWrapper;
+        }
+        this.widgetWrapper = document.createElement("span");
+        this.appendChild(this.widgetWrapper);
+
+        return this.widgetWrapper;
+    }
+
+    _widgetClass() {
+        return dojoRadioButton;
+    }
+}
+
+customElements.define("lsmb-radio", LsmbRadioButton);

--- a/UI/src/elements/lsmb-radio.js
+++ b/UI/src/elements/lsmb-radio.js
@@ -8,6 +8,13 @@ const dojoRadioButton = require("dijit/form/RadioButton");
 export class LsmbRadioButton extends LsmbBaseChecked {
     widgetWrapper = null;
 
+    _setIdProp(props) {
+        if (props.name && props.value) {
+            /* eslint-disable no-param-reassign */
+            props.id = (props.name + "-" + props.value).replaceAll(LsmbRadioButton.idRegex, "-");
+        }
+    }
+
     _widgetRoot() {
         if (this.widgetWrapper) {
             return this.widgetWrapper;

--- a/UI/src/elements/lsmb-select.js
+++ b/UI/src/elements/lsmb-select.js
@@ -1,0 +1,14 @@
+/** @format */
+/* eslint-disable class-methods-use-this, max-classes-per-file */
+
+import { LsmbBaseInput } from "@/elements/lsmb-base-input";
+
+const dojoSelect = require("dijit/form/Select");
+
+export class LsmbSelect extends LsmbBaseInput {
+    _widgetClass() {
+        return dojoSelect;
+    }
+}
+
+customElements.define("lsmb-select", LsmbSelect);

--- a/UI/src/elements/lsmb-text.js
+++ b/UI/src/elements/lsmb-text.js
@@ -7,7 +7,11 @@ const dojoTextBox = require("dijit/form/ValidationTextBox");
 
 export class LsmbText extends LsmbBaseInput {
     _stdProps() {
-        return { type: "text" };
+        return {
+            ...super._stdProps(),
+            size: 60,
+            type: "text"
+        };
     }
 
     _valueAttrs() {

--- a/UI/src/main-vue.js
+++ b/UI/src/main-vue.js
@@ -1,6 +1,12 @@
 /** @format */
 /* eslint-disable no-console, import/no-unresolved, vue/multi-word-component-names */
 
+/* import polyfills */
+
+import '@ungap/custom-elements';
+
+/* continue regular application */
+
 import { createApp } from "vue";
 import router from "@/router";
 import i18n, { setI18nLanguage } from "@/i18n";


### PR DESCRIPTION
The purpose of this PR is to move parsing of the DOM away from Dojo: the browser can do it a lot more efficiently using Custom Web Components. These web components can instantiate Dojo widgets (for now) to create a consistent UI experience (which we can later swap for another type of custom element for a different look).

We make Dojo widgets out of standard elements in some places, such as [the `TABLE` element which is converted to a `lsmb/InvoiceLines` widget](https://github.com/ledgersmb/LedgerSMB/blob/29763d643e75935a71d59bd25d8500650dc018cf/old/bin/io.pl#L253). Support for this usage exists in custom web components [using the `is` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is).

There's a problem with Custom Built-in Web Components: [Safari does not support Custom Web Elements for built-in elements](https://www.sobyte.net/post/2021-08/safari-buildin-custom-element-polyfill/). There is a solution to that problem: using a [polyfill](https://github.com/WebReflection/custom-elements-builtin).

