### PR TITLE
Resolve FireFox warning

### DIFF
--- a/UI/lib/ui-header.html
+++ b/UI/lib/ui-header.html
@@ -48,7 +48,12 @@
        END;
     %]
     <script>
-        window.alert("[% ALERT %]");
+      let h;
+      h = () => {
+          window.removeEventListener('DOMContentLoaded', h);
+          window.alert("[% ALERT %]");
+      };
+      window.addEventListener('DOMContentLoaded', h);
     </script>
     [% END %]
     <script>


### PR DESCRIPTION
FireFox complains that the page isn't fully loaded, but the alert() call is forcing the page to be rendered anyway.
