### PR TITLE
Remove whitespace concatenations when importing elements.html

### DIFF
--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -1,61 +1,61 @@
 [%
-  default_keys = ['id', 'class', 'title']  # Defaults for all attributes
+  default_keys = ['id', 'class', 'title'];  # Defaults for all attributes
 
   # Defaults for input attributes
   default_input_keys = default_keys.merge(
          ['type', 'name', 'disabled', 'size', 'value',
           'data-dojo-type','data-dojo-props', 'data-dojo-attach-point',
-          'required', 'tabindex'])
+          'required', 'tabindex']);
 
-  input_keys.hidden       = default_keys.merge(['type', 'name', 'value'])
-  input_keys.file         = default_input_keys.merge(['accept'])
-  input_keys.image        = default_input_keys.merge(['alt', 'src'])
-  input_keys.checkbox     = default_input_keys.merge(['checked'])
-  input_keys.toggle       = default_input_keys.merge(['checked'])
-  input_keys.radio        = default_input_keys.merge(['checked'])
-  input_keys.password     = default_input_keys
-  input_keys.date         = default_input_keys
-  input_keys.text         = default_input_keys.merge(['maxlength', 'readonly'])
+  input_keys.hidden       = default_keys.merge(['type', 'name', 'value']);
+  input_keys.file         = default_input_keys.merge(['accept']);
+  input_keys.image        = default_input_keys.merge(['alt', 'src']);
+  input_keys.checkbox     = default_input_keys.merge(['checked']);
+  input_keys.toggle       = default_input_keys.merge(['checked']);
+  input_keys.radio        = default_input_keys.merge(['checked']);
+  input_keys.password     = default_input_keys;
+  input_keys.date         = default_input_keys;
+  input_keys.text         = default_input_keys.merge(['maxlength', 'readonly']);
 
 
   textarea_keys           = default_input_keys.merge(['cols', 'rows',
-                                                      'readonly', 'style', 'wrap' ])
-  select_keys             = default_input_keys.merge(['multiple', 'readonly'])
-  option_keys             = default_keys.merge(['tabindex', 'disabled', 'value', 'selected'])
+                                                      'readonly', 'style', 'wrap' ]);
+  select_keys             = default_input_keys.merge(['multiple', 'readonly']);
+  option_keys             = default_keys.merge(['tabindex', 'disabled', 'value', 'selected']);
   button_keys             = default_input_keys.merge(['data-lsmb-doing',
-                                                      'data-lsmb-done'])
-  toggle_keys             = default_input_keys.merge(['showLabel', 'label'])
-  for_keys                = default_keys.merge(['for'])
+                                                      'data-lsmb-done']);
+  toggle_keys             = default_input_keys.merge(['showLabel', 'label']);
+  for_keys                = default_keys.merge(['for']);
 
   # ELEMENT DEFAULTS
 
   element_defaults.checkbox = {
     value = '1',
     'data-dojo-type' = 'dijit/form/CheckBox'
-  }
+  };
 
   #radio
   element_defaults.radio = {
          'data-dojo-type' = 'dijit/form/RadioButton'
-  }
+  };
 
   #file
   element_defaults.file = {
     size = '60'
-  }
+  };
 
   #password
   element_defaults.password = {
     size = '60',
     "data-dojo-type" = "dijit/form/ValidationTextBox"
-  }
+  };
 
   # text
   element_defaults.text = {
     size = '60',
     maxlength = '255',
     "data-dojo-type" = "dijit/form/ValidationTextBox"
-  }
+  };
 
   # date
   USER.dojo_dateformat = USER.dateformat.replace('mm','MM');
@@ -63,44 +63,42 @@
     "data-dojo-type" = 'lsmb/DateTextBox',
     'data-dojo-props' = "constraints: {datePattern: '$USER.dojo_dateformat'},placeholder: '$USER.dateformat'"
     size = '8',
-  }
+  };
 
   # textarea
   element_defaults.textarea = {
     rows = '1',
     cols = '60',
     "data-dojo-type" = "lsmb/ResizingTextarea"
-  }
+  };
 
   #button
   element_defaults.button = {
     type = 'submit',
     "data-dojo-type" = "dijit/form/Button"
-  }
+  };
 
   #select
   element_defaults.select = {
     "data-dojo-type" = "dijit/form/Select"
-  }
+  };
 
   #multiselect
   element_defaults.multiselect = {
     "data-dojo-type" = "dijit/form/MultiSelect"
     "multiple" = "true"
-  }
+  };
 
   #toggle
   element_defaults.toggle = {
     type = 'submit',
     "data-dojo-type"  = "dijit/form/ToggleButton"
     "data-dojo-props" = "iconClass:'dijitCheckBoxIcon'"
-  }
+  };
 
-%]
-
-[% # INPUT ELEMENT %]
-[% BLOCK input %]
-  [% IF label_pos != 1 and label_pos != -1; label_pos = -1; END;
+ # INPUT ELEMENT
+ BLOCK input ;
+     IF label_pos != 1 and label_pos != -1; label_pos = -1; END;
      IF element_data;  # Only process element if one exists.
          DEFAULT
              element_data.title = element_data.label
@@ -135,12 +133,12 @@
          IF label_pos == 1;
            PROCESS auto_label;
          END;
-     END; -%]
-[% END %]
+     END;
+  END;
 
-[% # TEXTAREA ELEMENT %]
-[% BLOCK textarea %]
-  [% IF element_data;
+ # TEXTAREA ELEMENT
+ BLOCK textarea ;
+     IF element_data;
         DEFAULT element_data.title = element_data.label;
 
         PROCESS auto_id element_type = 'textarea';
@@ -153,12 +151,12 @@
         PROCESS auto_label;
 
         "<textarea$all_attributes >" _ element_data.text _ "</textarea>";
-     END %]
-[% END %]
+     END ;
+   END ;
 
-[% # SELECT ELEMENT %]
-[% BLOCK select %]
-   [% IF element_data;
+ # SELECT ELEMENT
+   BLOCK select ;
+      IF element_data;
         DEFAULT element_data.title = element_data.label;
 
         text_attr     = element_data.text_attr or 'text';
@@ -198,12 +196,12 @@
                value_attr  = value_attr;
         END;
         "</select></span>";
-      END %]
-[% END %]
+      END ;
+   END ;
 
-[% # OPTION ELEMENT %]
-[% BLOCK option %]
-  [% # Selected is a special case
+ # OPTION ELEMENT
+   BLOCK option ;
+     # Selected is a special case
      # -- no attribute key, so it is handled here by looking for the option value in the default_values list.
      option_selected = "";
      FOREACH test_val IN element_data.default_values;
@@ -223,12 +221,11 @@
 
      "<option$all_attributes >" _ ((option_data.$text_attr == '_!lsmb!empty!_')
                            ? "" : option_data.$text_attr) _ "</option>";
-  %]
-[% END %]
+   END ;
 
-[% # BUTTON ELEMENT %]
-[% BLOCK button %]
-  [% IF element_data;
+ # BUTTON ELEMENT
+   BLOCK button ;
+     IF element_data;
 
         PROCESS auto_id element_type = 'button';
         PROCESS attributes
@@ -246,12 +243,12 @@
                 position => element_data.tooltip.position,
                 msg      => element_data.tooltip.msg };
         END;
-     END; %]
-[% END %]
+     END;
+   END ;
 
-[% # TOGGLE ELEMENT %]
-[% BLOCK toggle %]
-  [% IF element_data;
+   # TOGGLE ELEMENT
+   BLOCK toggle ;
+     IF element_data;
 
         PROCESS auto_id element_type = 'toggle';
         PROCESS attributes
@@ -262,12 +259,12 @@
 
         PROCESS auto_label  # Process element label.
         "<button$all_attributes >" _ element_data.text _ "</button>";
-     END; %]
-[% END %]
+     END;
+   END;
 
-[% # LABEL ELEMENT %]
-[% BLOCK label %]
-  [% IF element_data.text;
+   # LABEL ELEMENT
+   BLOCK label ;
+     IF element_data.text;
 
         PROCESS auto_id element_type = 'label';
         PROCESS attributes
@@ -277,12 +274,12 @@
             custom_attribute_data = element_data.attributes;
 
         "<label $all_attributes >" _ element_data.text _ "</label>";
-     END; %]
-[% END %]
+     END;
+   END;
 
-[% # REGULAR ATTRIBUTE PROCESSING -- all explicitly allowed attributes are processed here. %]
-[% BLOCK attributes %]
-  [% all_attributes = "";
+   # REGULAR ATTRIBUTE PROCESSING -- all explicitly allowed attributes are processed here.
+   BLOCK attributes ;
+     all_attributes = "";
      FOREACH element_attribute IN element_keys;  # Loop through each allowed attribute.
        IF attribute_data.item(element_attribute).defined() and (attribute_data.item(element_attribute) != "");
           all_attributes =
@@ -296,11 +293,10 @@
     FOREACH element_attribute IN custom_attribute_data;
        all_attributes = all_attributes _ " " _ element_attribute.key _ '="' _ element_attribute.value _ '"';
     END;
-%]
-[% END %]
+   END;
 
-[% BLOCK auto_id  # Automatically builds the id tag for the element if possible. %]
-  [% UNLESS element_data.id.defined();
+   BLOCK auto_id ; # Automatically builds the id tag for the element if possible.
+     UNLESS element_data.id.defined();
         # id attribute should always be set, so auto-set it if it is not defined.
         element_id = "";
         # Label ids default to [for]-label.
@@ -320,11 +316,11 @@
         IF element_id;
            element_data.id = element_id.replace('[^\p{IsAlnum}]', '-');
         END;
-     END %]
-[% END %]
+     END;
+   END;
 
-[% BLOCK auto_label  # Sets a label for a form element if the special 'label' key is passed. %]
-  [% IF element_data.label.defined() and element_data.label != '_none_';
+   BLOCK auto_label ; # Sets a label for a form element if the special 'label' key is passed.
+     IF element_data.label.defined() and element_data.label != '_none_';
         # Add a 'for' attribute for the label if possible.
         IF element_data.id.defined();
            label_id = ' id="' _ element_data.id _ '-label"';
@@ -341,16 +337,16 @@
            label_class = "";
         END;
      "<label $label_id $label_for $label_class >" _ text(element_data.label) _ "</label>";
-     END; %]
-[% END %]
+     END;
+   END;
 
-[% BLOCK decorated_text;
+   BLOCK decorated_text;
   IF element_data && element_data.msg.defined();
     element_data.msg.replace('&lt;((/?[ibup]|br))&gt;','<$1>');
   END;
-END %]
+END;
 
-[% BLOCK tooltip;
+   BLOCK tooltip;
    IF element_data && element_data.msg.defined();
       ref_if = element_data.ref_id;
       position = (element_data.position.defined() ?
@@ -360,20 +356,19 @@ END %]
       INCLUDE decorated_text element_data = { msg => element_data.msg };
       "</div>";
    END;
-END %]
+END;
 
-[% BLOCK select_language;
+   BLOCK select_language;
     IF ! element_data.default_values || element_data.default_values.size == 0 ;
        element_data.default_values = [ SETTINGS.default_language ] ;
     END ;
     PROCESS select element_data=element_data ;
   END ;
-   %]
 
-[% BLOCK select_country;
+   BLOCK select_country;
     IF ! element_data.default_values || element_data.default_values.size == 0 ;
        element_data.default_values = [ SETTINGS.default_country ] ;
     END ;
     PROCESS select element_data=element_data ;
   END ;
-   %]
+-%]


### PR DESCRIPTION
Because of the separate blocks, the whitespace in between ends up in the including template. This is both ugly and unnecessarily copying data around.
