### PR TITLE
Fix cleared balances with overlapping reconciliations

### DIFF
--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -302,7 +302,7 @@ $$
                           join cr_report_line_links crll on crl.id = crll.report_line_id
                   where cr.approved
                     and cr.chart_id = in_chart_id
-                    and cr.end_date < in_report_date
+                    and cr.end_date <= in_report_date
                     and crl.cleared
                     and crll.entry_id = ac.entry_id)
     GROUP BY c.id, c.category;

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -6,7 +6,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(65);
+    SELECT plan(64);
 
     -- Add data
 
@@ -63,12 +63,6 @@ BEGIN;
 
     CREATE TEMPORARY TABLE test_parameters (id int);
     INSERT INTO test_parameters(id) VALUES(nextval('cr_report_id_seq'));
-
-    PREPARE test AS SELECT COUNT(*)::INT FROM acc_trans
-                    WHERE cleared
-                    AND entry_id NOT IN (SELECT entry_id FROM cr_report_line_links);
-    SELECT results_eq('test', Array[4], 'Transactions that should be in cr_report');
-    DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), now()::date);
     SELECT results_eq('test', ARRAY[]::cr_report[], 'No previous report');
@@ -174,7 +168,9 @@ BEGIN;
     update gl set approved = true where id = -214;
     update acc_trans set approved = true
      where trans_id = -214
-           and chart_id = test_get_account_id('-11112');
+       and chart_id = test_get_account_id('-11112');
+
+--    select reconciliation__pending_transactions
 
     PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
     SELECT results_eq('test',$$ SELECT id+3 FROM test_parameters $$,'1 Pending Transactions Ran');
@@ -199,8 +195,8 @@ BEGIN;
     SELECT results_eq('test',ARRAY[true],'1 Report Submitted');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = -10;
-    SELECT results_eq('test',ARRAY[true],'1 Cleared balance pre-approval is 10');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));
+    SELECT results_eq('test',ARRAY[-10]::numeric[],'1 Cleared balance pre-approval is 10');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;

--- a/xt/data/42-pg/Reconciliation.sql
+++ b/xt/data/42-pg/Reconciliation.sql
@@ -167,14 +167,21 @@ values (-203, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10,'1');
 
 
 -- Don't include cleared or unapproved transactions
+select reconciliation__new_report_id(test_get_account_id('-11112'), 10, '1000-01-04', false);
+  insert into cr_report_line (report_id, scn, their_balance, our_balance, "user", trans_type, cleared)
+  values (currval('cr_report_id_seq'), 'test', 10, 10, (select entity_id from users limit 1), '', true);
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared, approved)
 values (-200, test_get_account_id('-11112'), '1000-01-01', 10, 'XTS', 10, '1', true, false);
+insert into cr_report_line_links (report_line_id, entry_id, cleared)
+values (currval('cr_report_line_id_seq'), currval('acc_trans_entry_id_seq'), true);
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, cleared)
 values (-212, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1', true);
+insert into cr_report_line_links (report_line_id, entry_id, cleared)
+values (currval('cr_report_line_id_seq'), currval('acc_trans_entry_id_seq'), true);
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, approved)
 values (-214, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1', false);
-
-
+update cr_report set submitted = true where id = currval('cr_report_id_seq');
+update cr_report set approved = true where id = currval('cr_report_id_seq');
 
 insert into payment_links (payment_id, entry_id, type)
 select -201, entry_id, 1


### PR DESCRIPTION
The prior calculation did not work for scenarios where transactions from before the requested date were part of a reconciliation report *after* the requested date. Since the input parameter relates to the *report* date, ensure that lines from newer reports are excluded.
