### PR TITLE
Complete migrating to injected UI processor

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -245,7 +245,6 @@ use LedgerSMB::Company_Config;
 use LedgerSMB::PSGI::Util qw( template_response );
 use LedgerSMB::Setting;
 use LedgerSMB::Template;
-use LedgerSMB::Template::UI;
 
 our $VERSION = '1.11.0-dev';
 
@@ -633,7 +632,7 @@ sub enabled_countries {
 
 sub report_renderer_ui {
   my ($request) = @_;
-  my $ui = LedgerSMB::Template::UI->new_UI;
+  my $ui = $request->{_wire}->get('ui');
   my $uri = $request->{_uri}->clone;
   if (not pairgrep { $a eq 'company' } $uri->query_form) {
       $uri->query_form(

--- a/lib/LedgerSMB/PSGI/Preloads.pm
+++ b/lib/LedgerSMB/PSGI/Preloads.pm
@@ -46,7 +46,6 @@ use LedgerSMB::Scripts::login;
 use LedgerSMB::Setting;
 use LedgerSMB::Setting::Sequence;
 use LedgerSMB::Tax;
-use LedgerSMB::Template::UI;
 
 
 =head1 LICENSE AND COPYRIGHT

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -26,7 +26,6 @@ use Log::Any;
 use Feature::Compat::Try;
 
 use LedgerSMB;
-use LedgerSMB::Template::UI;
 
 
 =item new_account
@@ -263,7 +262,7 @@ sub _display_account_screen {
         funcname => 'person__list_languages'
     );
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'accounts/edit', {
         form => $account,
         gifis => [ $request->call_procedure(funcname => 'gifi__list') ],
@@ -283,7 +282,7 @@ sub yearend_info {
     my ($closed_date) = map {
         $_->{end_date}
     } $request->call_procedure(funcname => 'eoy__latest_checkpoint');
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request, 'accounts/yearend',
         {
@@ -321,7 +320,7 @@ sub post_yearend {
             $request->{description},
             $request->{retention_acc_id}
         ]);
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'accounts/yearend_complete', {});
 }
 

--- a/lib/LedgerSMB/Scripts/admin.pm
+++ b/lib/LedgerSMB/Scripts/admin.pm
@@ -19,7 +19,6 @@ This module provides the workflow scripts for managing users and permissions.
 
 use LedgerSMB::Entity::User;
 use LedgerSMB::Report::Listings::User;
-use LedgerSMB::Template::UI;
 
 
 use Log::Any;
@@ -74,7 +73,7 @@ sub edit_user {
         args => [ $request->{id} ]
         );
     my $user_data = LedgerSMB::Entity::User->get($user->{entity_id});
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Contact/divs/user', {
         stand_alone => 1,
         user        => $user_data,
@@ -117,7 +116,7 @@ sub list_sessions {
         $s->{drop} = '[' . $request->{_locale}->text('delete') . ']';
         $s->{row_id} = $s->{id};
     }
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Reports/display_report', {
         name    => $request->{_locale}->text('Active Sessions'),
         columns => $columns,

--- a/lib/LedgerSMB/Scripts/asset.pm
+++ b/lib/LedgerSMB/Scripts/asset.pm
@@ -25,7 +25,6 @@ use LedgerSMB::PGNumber;
 use LedgerSMB::Report::Assets::Net_Book_Value;
 use LedgerSMB::Report::Listings::Asset_Class;
 use LedgerSMB::Report::Listings::Asset;
-use LedgerSMB::Template::UI;
 
 
 our $default_dep_account = '5010'; # Override in custom/asset.pl
@@ -67,7 +66,7 @@ sub asset_category_screen {
     }
 
     $ac //= {};
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'asset/edit_class',
                              {
                                  request => $request,
@@ -108,7 +107,7 @@ Displays the asset category search screen
 sub asset_category_search {
     my ($request) = @_;
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'asset/search_class',
                              { request => $request,
                                asset_class => _asset_class_get_metadata($request) });
@@ -203,7 +202,7 @@ can be used to set defaults.
 sub asset_screen {
     my ($request, $asset) = @_;
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request, 'asset/edit_asset',
         {
@@ -227,7 +226,7 @@ Any inputs for asset_results can be used here to set defaults.
 
 sub asset_search {
     my ($request) = @_;
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request, 'asset/search_asset',
         {
@@ -352,7 +351,7 @@ sub _asset_report_get_metadata {
 sub new_report {
     my ($request) = @_;
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'asset/begin_report',
                              { request => $request,
                                report => {
@@ -566,7 +565,7 @@ sub display_report {
     {
         $hiddens->{$hide} = $request->{$hide};
     }
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Reports/display_report', {
         FORM_ID => $request->{form_id},
         HIDDENS => $hiddens,
@@ -593,7 +592,7 @@ sub search_reports {
     my ($request) = @_;
     $request->{title} = $request->{_locale}->text('Search reports');
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'asset/begin_approval',
                              { request => $request,
                                asset_report => _asset_report_get_metadata($request) });
@@ -713,7 +712,7 @@ sub report_results {
                    },
         ];
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Reports/display_report', {
          FORM_ID => $request->{form_id},
          HIDDENS => $hiddens,
@@ -827,7 +826,7 @@ sub report_details {
                    value => 'report_details_approve'
                    },
     ];
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Reports/display_report', {
         FORM_ID => $request->{form_id},
         HIDDENS => { id => $report->{id} },
@@ -929,7 +928,7 @@ sub partial_disposal_details {
                    },
         ];
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Reports/display_report', {
         SCRIPT  => $request->{script},
         HIDDENS => {
@@ -1036,7 +1035,7 @@ sub disposal_details {
         ];
     my $title = $locale->text('Disposal Report [_1] on date [_2]',
                      $report->{id}, $report->{report_date});
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Reports/display_report', {
         SCRIPT  => $request->{script},
         HIDDENS => {
@@ -1141,7 +1140,7 @@ No inputs required.
 
 sub begin_import {
     my ($request) = @_;
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'asset/import_asset', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/budgets.pm
+++ b/lib/LedgerSMB/Scripts/budgets.pm
@@ -18,7 +18,6 @@ use LedgerSMB::Budget;
 use LedgerSMB::Business_Unit;
 use LedgerSMB::Business_Unit_Class;
 use LedgerSMB::Magic qw( EDIT_BUDGET_ROWS NEW_BUDGET_ROWS );
-use LedgerSMB::Template::UI;
 
 =head1 REQUIRES
 
@@ -136,7 +135,7 @@ sub _render_screen {
            rowcount => $budget->{rowcount},
                  id => $budget->{id},
     };
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'budgetting/budget_entry', $budget);
 }
 

--- a/lib/LedgerSMB/Scripts/business_unit.pm
+++ b/lib/LedgerSMB/Scripts/business_unit.pm
@@ -26,7 +26,6 @@ use LedgerSMB::Business_Unit_Class;
 use LedgerSMB::PGDate;
 use LedgerSMB::Report::Listings::Business_Unit;
 use LedgerSMB::Setting::Sequence;
-use LedgerSMB::Template::UI;
 
 =head1 FUNCTIONS
 
@@ -44,7 +43,7 @@ sub list_classes {
     my $lsmb_modules = LedgerSMB::App_Module->new(%$request);
     @{$request->{classes}} = $bu_class->list;
     @{$request->{modules}} = $lsmb_modules->list;
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'business_units/list_classes',
                              {request => $request});
 }
@@ -94,7 +93,7 @@ sub edit {
 
 sub _display {
     my ($request, $bu) = @_;
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'business_units/edit', $bu);
 
 }

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -25,7 +25,6 @@ use warnings;
 
 use LedgerSMB::I18N;
 use LedgerSMB::Setting::Sequence;
-use LedgerSMB::Template::UI;
 
 sub _default_settings {
     my ($request) = @_;
@@ -317,7 +316,7 @@ sub defaults_screen {
         },
     );
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Configuration/settings', {
         form => $request,
         # hiddens => \%hiddens,
@@ -348,7 +347,7 @@ sub sequence_screen {
         }
         ++$count;
     }
-    return LedgerSMB::Template::UI->new_UI
+    return $request->{_wire}->get('ui')
         ->render($request, 'Configuration/sequence', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -37,7 +37,6 @@ use LedgerSMB::I18N;
 use LedgerSMB::Magic qw( EC_EMPLOYEE );
 use LedgerSMB::Part;
 use LedgerSMB::Setting;
-use LedgerSMB::Template::UI;
 
 use LedgerSMB::old_code qw(dispatch);
 
@@ -322,7 +321,7 @@ sub _main_screen {
     $roles = $user->list_roles if $user;
 
     # Template info and rendering
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Contact/contact', {
                      DIVS => \@DIVS,
                 DIV_LABEL => \%DIV_LABEL,
@@ -817,7 +816,7 @@ sub get_pricelist {
     my $pricelist = $credit->get_pricematrix;
     $request->merge($credit) if $credit;
     $request->merge($pricelist) if $pricelist;
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Contact/pricelist', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -23,7 +23,6 @@ use LedgerSMB::Currency;
 use LedgerSMB::Exchangerate;
 use LedgerSMB::Exchangerate_Type;
 use LedgerSMB::Setting;
-use LedgerSMB::Template::UI;
 
 use Log::Any;
 use Text::CSV;
@@ -77,7 +76,7 @@ sub list_currencies {
         push @$rows, $s;
     }
     my $title = $request->{_locale}->text('Defined currencies');
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Configuration/currency', {
         name    => $title,
         request => $request,
@@ -162,7 +161,7 @@ sub list_exchangerate_types {
         push @$rows, $s;
     }
     my $title = $request->{_locale}->text('Defined exchange rate types');
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Configuration/ratetype', {
         name    => $title,
         request => $request,
@@ -274,7 +273,7 @@ sub _list_exchangerates {
         push @$rows, $s;
     }
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'Configuration/rate', {
         name       => $request->{title},
         request    => $request,

--- a/lib/LedgerSMB/Scripts/email.pm
+++ b/lib/LedgerSMB/Scripts/email.pm
@@ -24,7 +24,6 @@ use Log::Any;
 use URI::Escape qw(uri_unescape);
 
 
-use LedgerSMB::Template::UI;
 
 
 =head2 render
@@ -90,7 +89,7 @@ sub render {
     }
 
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'email', {
         id          => $wf->id,
         ( map { (s/^_//r) => scalar $wf->context->param($_) }

--- a/lib/LedgerSMB/Scripts/erp.pm
+++ b/lib/LedgerSMB/Scripts/erp.pm
@@ -18,7 +18,6 @@ This script contains the request handlers for returning the SPA.
 use strict;
 use warnings;
 
-use LedgerSMB::Template::UI;
 
 =item root
 
@@ -32,7 +31,7 @@ sub root {
     $request->{title} = "LedgerSMB $request->{version} -- ".
     "$request->{login} -- $request->{company}";
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'main', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/file.pm
+++ b/lib/LedgerSMB/Scripts/file.pm
@@ -39,7 +39,6 @@ use LedgerSMB::File::Reconciliation;
 use LedgerSMB::Magic qw(  FC_TRANSACTION FC_ORDER FC_PART FC_ENTITY FC_ECA
     FC_INTERNAL FC_INCOMING FC_EMAIL FC_RECONCILIATION );
 use LedgerSMB::Request::Helper::ParameterMap qw( input_map spec_for_dynatable );
-use LedgerSMB::Template::UI;
 
 our $fileclassmap = {
    FC_TRANSACTION()    => 'LedgerSMB::File::Transaction',
@@ -148,7 +147,7 @@ sub list_internal_files {
         $f->{row_id}                = $f->{id};
         $f->{file_name_href_suffix} = $f->{id};
     }
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'file/internal-file-list',
                              {
                                  files => \@files,
@@ -165,7 +164,7 @@ Show the attachment or upload screen.
 sub show_attachment_screen {
     my ($request) = @_;
     my @flds = split/\s/, $request->{additional};
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'file/attachment_screen', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -33,7 +33,6 @@ use LedgerSMB::IR;
 use LedgerSMB::IS;
 use LedgerSMB::Magic qw( EC_VENDOR EC_CUSTOMER );
 use LedgerSMB::Setting::Sequence;
-use LedgerSMB::Template::UI;
 use LedgerSMB::Timecard;
 
 use List::MoreUtils qw{ any };

--- a/lib/LedgerSMB/Scripts/inventory.pm
+++ b/lib/LedgerSMB/Scripts/inventory.pm
@@ -20,7 +20,6 @@ use LedgerSMB::Inventory::Adjust;
 use LedgerSMB::Inventory::Adjust_Line;
 use LedgerSMB::Report::Inventory::Search_Adj;
 use LedgerSMB::Scripts::reports;
-use LedgerSMB::Template::UI;
 
 =over
 
@@ -32,7 +31,7 @@ This entry point specifies the screen for setting up an inventory adjustment.
 
 sub begin_adjust {
     my ($request) = @_;
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'inventory/adjustment_setup', $request);
 }
 
@@ -44,7 +43,7 @@ This entry point specifies the screen for entering an inventory adjustment.
 
 sub enter_adjust {
     my ($request) = @_;
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'inventory/adjustment_entry', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/login.pm
+++ b/lib/LedgerSMB/Scripts/login.pm
@@ -22,7 +22,6 @@ use HTTP::Status qw( HTTP_OK );
 use JSON::MaybeXS;
 
 use LedgerSMB::PSGI::Util;
-use LedgerSMB::Template::UI;
 
 our $VERSION = 1.0;
 
@@ -38,7 +37,7 @@ sub __default {
     $request->{_req}->env->{'lsmb.session.expire'} = 1;
     $request->{stylesheet} = 'ledgersmb.css';
     $request->{titlebar} = "LedgerSMB $request->{version}";
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'login', $request);
 }
 
@@ -105,7 +104,7 @@ sub logout {
     $request->{callback}   = '';
 
     $request->{_logout}->();
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'logout', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -62,7 +62,6 @@ use LedgerSMB::PGNumber;
 use LedgerSMB::Report::Invoices::Payments;
 use LedgerSMB::Request::Helper::ParameterMap;
 use LedgerSMB::Template;
-use LedgerSMB::Template::UI;
 
 
 # CT:  A few notes for future refactoring of this code:
@@ -103,7 +102,7 @@ sub payments {
     my $payment = LedgerSMB::DBObject::Payment->new(%$payment_data);
     $payment->get_metadata();
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'payments/payments_filter',
                              { request => $request,
                                        payment => $payment });
@@ -141,7 +140,7 @@ sub get_search_criteria {
     my $payment = LedgerSMB::DBObject::Payment->new(%$payment_data);
     $payment->get_metadata();
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request,
         'Reports/filters/payments',
@@ -278,7 +277,7 @@ sub pre_bulk_post_report {
     }];
     delete $request->{$_}
        for qw(action dbh);
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request,
         'Reports/display_report',
@@ -696,7 +695,7 @@ sub display_payments {
         ];
     $payment->{can_print} = scalar @{$payment->{format_options}};
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'payments/payments_detail',
                              { request => $request,
                                        payment => $payment });
@@ -765,7 +764,7 @@ sub payment {
         }
     };
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'payments/payment1', $select);
 }
 
@@ -826,7 +825,7 @@ sub payment1_5 {
                                text =>  $request->{_locale}->text('Continue')}
         };
 
-        my $template = LedgerSMB::Template::UI->new_UI;
+        my $template = $request->{_wire}->get('ui');
         return $template->render($request, 'payments/payment1_5', $select);
     }
 }
@@ -1218,7 +1217,7 @@ sub payment2 {
 
     $select->{selected_account} = $vc_options[0]->{cash_account_id}
       unless defined $select->{selected_account};
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'payments/payment2', $select);
 }
 
@@ -1546,7 +1545,7 @@ sub use_overpayment {
         value => 'use_overpayment2',
         text => $locale->text('Continue')
     };
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'payments/use_overpayment1', $ui);
 }
 
@@ -1870,7 +1869,7 @@ sub use_overpayment2 {
 
     $ui->{hiddens} = \@hiddens;
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'payments/use_overpayment2', $ui);
 }
 

--- a/lib/LedgerSMB/Scripts/payroll.pm
+++ b/lib/LedgerSMB/Scripts/payroll.pm
@@ -23,7 +23,6 @@ use warnings;
 use LedgerSMB::I18N;
 use LedgerSMB::Payroll::Income_Type;
 use LedgerSMB::Report::Payroll::Income_Types;
-use LedgerSMB::Template::UI;
 
 =head1 METHODS
 
@@ -49,7 +48,7 @@ sub show_income_type {
        funcname => 'payroll_pic__list', args => [$request->{country_id}]
     ) if $request->{country_id};
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'payroll/income', $request);
 }
 
@@ -89,7 +88,7 @@ sub search_income_type {
     my ($request) = @_;
     my @country_list = $request->enabled_countries->@*;
 
-    return LedgerSMB::Template::UI->new_UI
+    return $request->{_wire}->get('ui')
         ->render($request, 'payroll/income_search', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -24,7 +24,6 @@ use LedgerSMB::File;
 use LedgerSMB::Magic qw( FC_RECONCILIATION );
 use LedgerSMB::PGNumber;
 use LedgerSMB::Report::Reconciliation::Summary;
-use LedgerSMB::Template::UI;
 
 =over
 
@@ -128,7 +127,7 @@ sub submit_recon_set {
         {allowed_roles => ['reconciliation_approve']}
     );
     if ( !$can_approve ) {
-        my $template = LedgerSMB::Template::UI->new_UI;
+        my $template = $request->{_wire}->get('ui');
         return $template->render($request, 'reconciliation/submitted',
                                  $recon);
     }
@@ -193,7 +192,7 @@ sub search {
     $recon->set_dbh($request->{dbh});
     $recon->get_accounts();
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request,
         'Reports/filters/reconciliation_search',
@@ -284,7 +283,7 @@ sub _display_report {
         $recon->{$field} = $recon->{$field}->to_output(money => 1);
     }
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'reconciliation/report', $recon);
 }
 
@@ -308,7 +307,7 @@ sub new_report {
     $recon->set_dbh($request->{dbh});
     $recon->get_accounts();
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request,
         'reconciliation/new_report',
@@ -415,7 +414,7 @@ sub approve {
     my $code = $recon->approve;
     my $template = $code == 0 ? 'reconciliation/approved'
         : 'reconciliation/report';
-    return LedgerSMB::Template::UI->new_UI
+    return $request->{_wire}->get('ui')
         ->render($request, $template, $recon);
 }
 
@@ -434,7 +433,7 @@ sub pending {
 
     my $recon = LedgerSMB::DBObject::Reconciliation->new(%$request);
 
-    my $template= LedgerSMB::Template::UI->new_UI;
+    my $template= $request->{_wire}->get('ui');
     return $template->render($request, 'reconciliation/pending', {});
 }
 

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -34,7 +34,6 @@ use LedgerSMB::Template;
 use LedgerSMB::Template::Sink::Email;
 use LedgerSMB::Template::Sink::Printer;
 use LedgerSMB::Template::Sink::Screen;
-use LedgerSMB::Template::UI;
 
 our $VERSION = '1.0';
 
@@ -174,7 +173,7 @@ sub _render_statement_batch {
         };
     }
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     my $rows = [ $results->@* ];
     for my $row ($rows->@*) {
         $row->{id_href_suffix} = $row->{id};

--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -28,7 +28,6 @@ use LedgerSMB::Report::Listings::SIC;
 use LedgerSMB::Report::Listings::Overpayments;
 use LedgerSMB::Report::Listings::Warehouse;
 use LedgerSMB::Setting;
-use LedgerSMB::Template::UI;
 
 our $VERSION = '1.0';
 
@@ -107,7 +106,7 @@ sub start_report {
         );
 
     $request->{earn_id} = $request->setting->get('earn_id');
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request,
                              'Reports/filters/' . $request->{report_name},
                              $request);

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -30,7 +30,6 @@ use LedgerSMB::Report::Taxform::Details;
 use LedgerSMB::Report::Taxform::List;
 use LedgerSMB::Setting;
 use LedgerSMB::Template;
-use LedgerSMB::Template::UI;
 
 our $VERSION = '1.0';
 
@@ -71,7 +70,7 @@ sub _taxform_screen
     $request->{default_country} =
         LedgerSMB::Setting->new(%$request)->get('default_country');
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'taxform/add_taxform', $request);
 }
 

--- a/lib/LedgerSMB/Scripts/template.pm
+++ b/lib/LedgerSMB/Scripts/template.pm
@@ -27,7 +27,6 @@ use warnings;
 use LedgerSMB;
 use LedgerSMB::Report::Listings::Templates;
 use LedgerSMB::Template::DB;
-use LedgerSMB::Template::UI;
 
 =head1 METHODS
 
@@ -57,7 +56,7 @@ Displays a template for review
 sub display {
     my ($request) = @_;
 
-    return LedgerSMB::Template::UI->new_UI
+    return $request->{_wire}->get('ui')
         ->render($request, 'templates/widget',
                  {
                      language       => $request->{language_code},

--- a/lib/LedgerSMB/Scripts/timecard.pm
+++ b/lib/LedgerSMB/Scripts/timecard.pm
@@ -33,7 +33,6 @@ use LedgerSMB::PGDate;
 use LedgerSMB::PGTimestamp;
 use LedgerSMB::Report::Timecards;
 use LedgerSMB::Template;
-use LedgerSMB::Template::UI;
 use LedgerSMB::Timecard;
 use LedgerSMB::Timecard::Type;
 
@@ -60,7 +59,7 @@ This begins the timecard workflow.  The following may be set as a default:
 sub new {
     my ($request) = @_;
     @{$request->{bu_class_list}} = LedgerSMB::Business_Unit_Class->list();
-    return LedgerSMB::Template::UI->new_UI
+    return $request->{_wire}->get('ui')
         ->render($request, 'timecards/entry_filter', $request);
 }
 
@@ -91,7 +90,7 @@ sub display {
         $request->setting->get_currencies;
     $tcard->{total} =
         ($tcard->{qty} // 0) + ($tcard->{non_billable} // 0);
-     my $template = LedgerSMB::Template::UI->new_UI;
+     my $template = $request->{_wire}->get('ui');
      return $template->render($request, 'timecards/timecard', $tcard);
 }
 
@@ -121,7 +120,7 @@ sub timecard_screen {
          }
          $request->{num_lines} = 1 unless $request->{num_lines};
          $request->{transdates} = \@dates;
-         my $template = LedgerSMB::Template::UI->new_UI;
+         my $template = $request->{_wire}->get('ui');
          return
              $template->render($request, 'timecards/timecard-week', $request);
     }

--- a/lib/LedgerSMB/Scripts/user.pm
+++ b/lib/LedgerSMB/Scripts/user.pm
@@ -32,7 +32,6 @@ use DateTime::Format::Duration::ISO8601;
 use Locale::CLDR;
 
 use LedgerSMB::Locale;
-use LedgerSMB::Template::UI;
 use LedgerSMB::User;
 
 our $VERSION = 1.0;
@@ -122,7 +121,7 @@ sub preference_screen {
     my $pwe = $format->parse_duration(
         $pw_expiration->{user__check_my_expiration});
     my $login = $request->{_req}->env->{'lsmb.session'}->{login};
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render(
         $request,
         'users/preferences',

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -28,7 +28,6 @@ use LedgerSMB::Report::Unapproved::Batch_Detail;
 use LedgerSMB::Scripts::payment;
 use LedgerSMB::Scripts::reports;
 use LedgerSMB::Setting;
-use LedgerSMB::Template::UI;
 
 use LedgerSMB::old_code qw(dispatch);
 
@@ -71,7 +70,7 @@ sub create_batch {
 
     $batch->get_search_results({mini => 1});
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'create_batch',
                              { request => $request,
                                batch => $batch });

--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -26,7 +26,6 @@ use Digest::MD5 qw(md5_hex);
 use Text::Markdown qw(markdown);
 
 use LedgerSMB::Database::ChangeChecks qw/ run_with_formatters /;
-use LedgerSMB::Template::UI;
 
 our @EXPORT = ## no critic
     qw| html_formatter_context |;
@@ -61,7 +60,7 @@ sub _unpack_grid_data {
 sub _wrap_html {
     my ($request) = shift;
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     unshift @HTML, $template->render_string(
         $request,
         'setup/upgrade/preamble',
@@ -72,7 +71,7 @@ sub _wrap_html {
             action_url => $request->{_uri}->as_string,
         });
 
-    $template = LedgerSMB::Template::UI->new_UI;
+    $template = $request->{_wire}->get('ui');
     push @HTML, $template->render_string($request,
                                          'setup/upgrade/epilogue');
 
@@ -89,7 +88,7 @@ sub _format_confirm {
 
     my $seq = 0;
     while (@confirmations) {
-        my $template = LedgerSMB::Template::UI->new_UI;
+        my $template = $request->{_wire}->get('ui');
         push @HTML, $template->render_string(
             $request,
             'setup/upgrade/confirm',
@@ -112,7 +111,7 @@ sub _format_describe {
     $failing_check = $check;
 
     $msg //= $check->{description};
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     push @HTML, $template->render_string(
         $request,
         'setup/upgrade/describe',
@@ -181,7 +180,7 @@ sub _format_grid {
         id => $args{name},
     };
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $request->{_wire}->get('ui');
     push @HTML, $template->render_string(
         $request,
         'setup/upgrade/grid',

--- a/lib/LedgerSMB/Template/Sink/Email.pm
+++ b/lib/LedgerSMB/Template/Sink/Email.pm
@@ -45,7 +45,6 @@ use HTTP::Status qw(HTTP_OK HTTP_SEE_OTHER);
 use Workflow::Factory qw(FACTORY);
 
 
-use LedgerSMB::Template::UI;
 
 use Moose;
 use namespace::autoclean;

--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -39,7 +39,6 @@ use LedgerSMB::User;
 use LedgerSMB::GL;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::PGDate;
-use LedgerSMB::Template::UI;
 
 # end of main
 
@@ -170,7 +169,7 @@ sub display_taxes {
         $hiddens{$taxmodule};
     }
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $form->{_wire}->get('ui');
     LedgerSMB::Legacy_Util::render_psgi(
         $form,
         $template->render($form, 'am-taxes',
@@ -439,7 +438,7 @@ sub recurring_transactions {
         class => 'submit',
     };
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $form->{_wire}->get('ui');
     LedgerSMB::Legacy_Util::render_psgi(
         $form,
         $template->render($form, 'am-list-recurring',

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -48,7 +48,6 @@
 package lsmb_legacy;
 use LedgerSMB::GL;
 use LedgerSMB::PE;
-use LedgerSMB::Template::UI;
 use LedgerSMB::Setting::Sequence;
 use LedgerSMB::Legacy_Util;
 
@@ -292,7 +291,7 @@ sub display_form
       $form->{recurringset}=1;
   }
 
-    my $template = LedgerSMB::Template::UI->new_UI;
+    my $template = $form->{_wire}->get('ui');
     LedgerSMB::Legacy_Util::render_psgi(
         $form,
         $template->render($form, 'journal/journal_entry',

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -44,7 +44,6 @@ use LedgerSMB::IIAA;
 use LedgerSMB::OE;
 use LedgerSMB::Tax;
 use LedgerSMB::Template;
-use LedgerSMB::Template::UI;
 use LedgerSMB::Setting;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::File;

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -49,7 +49,6 @@ use LedgerSMB::IS;
 use LedgerSMB::PE;
 use LedgerSMB::Setting;
 use LedgerSMB::Tax;
-use LedgerSMB::Template::UI;
 use LedgerSMB::Legacy_Util;
 
 
@@ -1298,7 +1297,7 @@ sub _save {
 
     if ( !$form->{repost}  && $form->{id}) {
         $form->{repost} = 1;
-        my $template = LedgerSMB::Template::UI->new_UI;
+        my $template = $form->{_wire}->get('ui');
         return LedgerSMB::Legacy_Util::render_psgi(
             $form,
             $template->render($form, 'oe-save-warn',

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -38,6 +38,13 @@ sub test_request {
                     directory => './locale/po/',
                 }
             },
+            ui => {
+                class => 'LedgerSMB::Template::UI',
+                method => 'new_UI',
+                args => {
+                    root => './UI/',
+                }
+            }
         });
     $plack_req->env->{'lsmb.script'}   = 'script.pl';
     my $req = LedgerSMB->new($plack_req, $wire);


### PR DESCRIPTION
After enabling configuration of an alternative root, use dependency injection to provide the configured template processor to its users.
