### PR TITLE
Simplify setup.pl's login page using CSS grid

### DIFF
--- a/UI/css/system/setup.css
+++ b/UI/css/system/setup.css
@@ -34,6 +34,10 @@ form#loginform {
 }
 
 .login_form {
+    column-gap: 0.3em;
+    display: grid;
+    grid-template-columns: auto auto;
+    row-gap: 0.3em;
     text-align: left;
 }
 
@@ -62,19 +66,11 @@ caption {
 }
 
 label {
-    border-width: 1px;
-    float: left;
     margin: 0;
-    margin-top: 0.5em;
-    padding-right: 0.5em;
     width: 10em;
 }
 
 input {
-    border-width: 3px;
-    float: left;
-    margin: 0;
-    margin-top: 0.5em;
     text-align: left;
     width: 14em;
 }

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -29,69 +29,59 @@
                     </div>
                 </div>
                 <form id="loginform"
-                    name="credentials"
-                    style="margin-top:1em">
-                    <div class="login_form">
-                        <div class="tabular col-1">
-                            <div id="userpass">
-                                <div class="inputrow">
-                                    [% select_hint = text('Select or Enter User');
-                                        INCLUDE select element_data = {
-                                        name = 's_user'
-                                            id = 's-user'
-                                        options =  [ { value = 'lsmb_dbadmin',
-                                                        text = 'lsmb_dbadmin'},
-                                                    { value = 'postgres',
-                                                    text  = 'postgres'} ]
-                                        size = '15'
-                                        class = 'username'
-                                        tabindex = 1
-                                        label = text('DB admin login') #'
-                                            "data-dojo-type" = "dijit/form/ComboBox"
-                                            "data-dojo-props" = "value:'$s_user', placeHolder:'$select_hint'"
-                                        attributes = { autocomplete = 'off'}
-                                    } %]
-                                </div>
-                                <div class="inputrow">
-                                    [% INCLUDE input element_data = {
-                                            name = 's_password'
-                                                id = 's-password'
-                                            value = s_password
-                                            type = 'password'
-                                            size = '15'
-                                            class = 'password'
-                                        tabindex = 2
-                                            label = text('Password')
-                                            attributes = { autocomplete = 'off'}
-                                            } %]
-                                </div>
-                            </div>
-                            <div class="inputrow">
-                                [% INCLUDE input element_data = {
-                                        name = 'database'
-                                        value = database
-                                        type = 'text'
-                                        size = '15'
+                      name="credentials"
+                      style="margin-top:1em">
+                  <div class="login_form">
+                    [% select_hint = text('Select or Enter User');
+                       INCLUDE select element_data = {
+                                   name = 's_user'
+                                   id = 's-user'
+                                   options =  [ { value = 'lsmb_dbadmin',
+                                                  text = 'lsmb_dbadmin'},
+                                                { value = 'postgres',
+                                                  text  = 'postgres'} ]
+                                   size = '15'
+                                   class = 'username'
+                                   tabindex = 1
+                                   label = text('DB admin login')
+                                   "data-dojo-type" = "dijit/form/ComboBox"
+                                   "data-dojo-props" = "value:'$s_user', placeHolder:'$select_hint'"
+                                    attributes = { autocomplete = 'off'}
+                       };
+                       INCLUDE input element_data = {
+                                    name = 's_password'
+                                    id = 's-password'
+                                    value = s_password
+                                    type = 'password'
+                                    size = '15'
+                                    class = 'password'
+                                    tabindex = 2
+                                    label = text('Password')
+                                    attributes = { autocomplete = 'off'}
+                       };
+                       INCLUDE input element_data = {
+                                    name = 'database'
+                                    value = database
+                                    type = 'text'
+                                    size = '15'
                                     class = 'database'
                                     tabindex = 3
-                                        label = text('Database')
-                                    } %]
-                            </div>
-                        </div>
-                        <div class="inputrow"
-                            style="text-align:right; padding-right: 4ex; margin-top: 1ex">
-                            <button data-dojo-type="lsmb/SetupLoginButton"
-                                    class="submit"
-                                    data-dojo-props="action:'login'"
-                                    tabindex="4"
-                                >[% text('Login') %]</button>
-                            <button data-dojo-type="lsmb/SetupLoginButton"
-                                    class="submit"
-                                    data-dojo-props="action:'create_db'"
-                                    tabindex="5"
-                                >[% text('Create') %]</button>
-                        </div>
-                    </div>
+                                    label = text('Database')
+                       } %]
+                  </div>
+                  <div class="inputrow"
+                       style="text-align:right; padding-right: 4ex; margin-top: 1ex">
+                    <button data-dojo-type="lsmb/SetupLoginButton"
+                            class="submit"
+                            data-dojo-props="action:'login'"
+                            tabindex="4"
+                            >[% text('Login') %]</button>
+                    <button data-dojo-type="lsmb/SetupLoginButton"
+                            class="submit"
+                            data-dojo-props="action:'create_db'"
+                            tabindex="5"
+                            >[% text('Create') %]</button>
+                  </div>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
By removing the margins from "input" and "label", styling of all setup pages becomes more predictable; by using the grid system, the rendering of the front page ends up in a table-like structure, preventing unnecessary (and unwanted) word wrapping.