### PR TITLE
Move/introduce closing tags so INPUTs appear inside cells

### DIFF
--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -555,8 +555,6 @@ sub form_header {
   </tr>
   <tr>
     <td>
-    </td>
-  </tr>
 |;
 
     $form->hide_form(
@@ -566,6 +564,13 @@ sub form_header {
     foreach my $item ( split / /, $form->{taxaccounts} ) {
         $form->hide_form( "${item}_rate", "${item}_taxnumber" );
     }
+
+    print q|
+    </td>
+  </tr>
+|;
+
+
     if ( !$form->{readonly} ) {
         print "<tr><td>";
 

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -758,8 +758,8 @@ sub form_header {
     for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button ) {
         $form->print_button( \%button, $_ );
     }
-    print "</td></tr>";
     $form->hide_form(qw(defaultcurrency workflow_id));
+    print "</td></tr>";
 }
 
 sub form_footer {
@@ -2007,11 +2007,13 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" id="serialnumber_$i" name="ser
 
         for (@column_index) { print "\n$column_data{$_}" }
 
-        print qq|
-        </tr>
+        print q|
+        <td style="display:none">
 |;
         $form->hide_form( "orderitems_id_$i", "id_$i", "partsgroup_$i" );
-
+        print q|
+        </tr>
+|;
     }
 
     print qq|


### PR DESCRIPTION
Because INPUT tags *between* cells (or rows) heavily confuses Chrome...
