### PR TITLE
Don't create a new part when no parts match

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -1243,28 +1243,6 @@ sub update {
                       $form->format_amount( \%myconfig, $form->{"${_}_$i"} );
                 }
 
-            } else {
-
-                # ok, so this is a new part
-                # ask if it is a part or service item
-
-                if (   $form->{"partsgroup_$i"}
-                    && ( $form->{"partsnumber_$i"} eq "" )
-                    && ( $form->{"description_$i"} eq "" ) )
-                {
-                    $form->{rowcount}--;
-                    $form->{id} = $form_id;
-                    &display_form;
-                }
-                else {
-
-                    $form->{"id_$i"}   = 0;
-                    $form->{"unit_$i"} = $locale->text('ea');
-
-                    $form->{id} = $form_id;
-                    &new_item;
-
-                }
             }
         }
     }

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1361,28 +1361,6 @@ sub update {
                       $form->format_amount( \%myconfig, $form->{"${_}_$i"} );
                 }
 
-            } else {
-
-                # ok, so this is a new part
-                # ask if it is a part or service item
-
-                if (   $form->{"partsgroup_$i"}
-                    && ( $form->{"partsnumber_$i"} eq "" )
-                    && ( $form->{"description_$i"} eq "" ) )
-                {
-                    $form->{rowcount}--;
-                    $form->{id} = $form_id;
-                    &display_form;
-                }
-                else {
-
-                    $form->{"id_$i"}   = 0;
-                    $form->{"unit_$i"} = $locale->text('ea');
-
-                    $form->{id} = $form_id;
-                    &new_item;
-
-                }
             }
         }
     }

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1223,25 +1223,6 @@ sub update {
                 }
 
             }
-            else {
-
-            # ok, so this is a new part
-            # ask if it is a part or service item
-
-                if (   $form->{"partsgroup_$i"}
-                    && ( $form->{"partsnumber_$i"} eq "" )
-                    && ( $form->{"description_$i"} eq "" ) )
-                {
-                    $form->{rowcount}--;
-                    &display_form;
-                }
-                else {
-
-                    $form->{"id_$i"}   = 0;
-                    $form->{"unit_$i"} = $locale->text('ea');
-                    &new_item;
-                }
-            }
         }
     }
     $form->all_vc(\%myconfig, $form->{vc}, $form->{transdate}, 1) if ! @{$form->{"all_$form->{vc}"}};


### PR DESCRIPTION
Note that the "no parts match" condition *only* occurs when the system holds *no* other parts, because the UI will fill in the first part's number when there *are* parts defined.

To prevent setting the expectation that this is how parts are created, don't do it for the first one either.

Closes #6530
