### PR TITLE
Show reversing reference when reversal is posted

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -174,6 +174,7 @@ sub edit {
 
 sub reverse {
     $form->{title}     = $locale->text('Add');
+    $form->{reversing_reference} = $form->{invnumber};
     $form->{invnumber} .= '-VOID';
 
     &create_links;
@@ -738,7 +739,7 @@ $form->open_status_div($status_div_id) . qq|
         </table>
       </td>
       <td style="vertical-align:middle">| .
-         ($form->{reversing} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversing}">| . ($form->{approved} ? $locale->text('This transaction reverses transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing}) : $locale->text('This transaction will reverse transaction [_1]', $form->{reversing})) .q|</a><br />| : '') .
+         ($form->{reversing} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversing}">| . ($form->{approved} ? $locale->text('This transaction reverses transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing}) : $locale->text('This transaction will reverse transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing})) .q|</a><br />| : '') .
          ($form->{reversed_by} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversed_by}"> | . $locale->text('This transaction is reversed by transaction [_1] with ID [_2]', $form->{reversed_by_reference}, $form->{reversed_by}) . q|</a>| : '') .
     qq|</td>
       <td align=right>

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -189,6 +189,7 @@ sub post_reversing {
             local $form->{notes};
             local $form->{description};
             local $form->{reference};
+            local $form->{reversing_reference} = $form->{reference};
             local $form->{approved};
 
             &create_links; # create_links overwrites 'reversing'
@@ -286,7 +287,8 @@ sub display_form
         'callback' => $form->{callback},
         'form_id' => $form->{form_id},
         'separate_duties' => $form->{separate_duties},
-        'reversing' => $form->{reversing}
+        'reversing' => $form->{reversing},
+        'reversing_reference' => $form->{reversing_reference}
     );
 
 

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -461,7 +461,7 @@ sub form_header {
         </table>
       </td>
       <td style="vertical-align:middle">| .
-        ($form->{reversing} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversing}">|. ($form->{approved} ? $locale->text('This transaction reverses transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing}) : $locale->text('This transaction will reverse transaction [_1]', $form->{reversing})) . q|</a><br />| : '') .
+        ($form->{reversing} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversing}">|. ($form->{approved} ? $locale->text('This transaction reverses transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing}) : $locale->text('This transaction will reverse transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing})) . q|</a><br />| : '') .
         ($form->{reversed_by} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversed_by}"> | . $locale->text('This transaction is reversed by transaction [_1] with ID [_2]', $form->{reversed_by_reference}, $form->{reversed_by}) . q|</a>| : '') .
       qq|</td>
       <td align=right>
@@ -551,6 +551,7 @@ sub reverse {
         delete $form->{paid_1};
     }
     $form->{reversing} = delete $form->{id};
+    $form->{reversing_reference} = $form->{invnumber};
 
     my $wf = $form->{_wire}->get('workflows')
         ->fetch_workflow( 'AR/AP', $form->{workflow_id} );

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -518,7 +518,7 @@ sub form_header {
         </table>
       </td>
       <td style="vertical-align:middle">| .
-        ($form->{reversing} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversing}">|. ($form->{approved} ? $locale->text('This transaction reverses transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing}) : $locale->text('This transaction will reverse transaction [_1]', $form->{reversing})) . q|</a><br />| : '') .
+        ($form->{reversing} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversing}">|. ($form->{approved} ? $locale->text('This transaction reverses transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing}) : $locale->text('This transaction will reverse transaction [_1] with ID [_2]', $form->{reversing_reference}, $form->{reversing})) . q|</a><br />| : '') .
         ($form->{reversed_by} ? qq|<a href="$form->{script}?action=edit&amp;id=$form->{reversed_by}"> | . $locale->text('This transaction is reversed by transaction [_1] with ID [_2]', $form->{reversed_by_reference}, $form->{reversed_by}) . q|</a>| : '') .
       qq|</td>
       <td align=right>
@@ -612,6 +612,7 @@ sub form_header {
 }
 
 sub void {
+    $form->{reversing_reference} = $form->{invnumber};
     my $invnumber = $form->{invnumber} . '-VOID';
     $form->{reverse} = not $form->{reverse};
     $form->{paidaccounts} = 1;


### PR DESCRIPTION
I noticed an issue when playing around with the new reverse transaction. When a reversing transaction is created the GUI shows the reference and ID of the reversed transaction. If the user presses "save" only the ID is shown. When the user presses "save" the only reference LedgerSMB has to the reversed transaction is the transaction ID from the database. To show the reference it needs to be collected.

so instead of:
> this transaction will reverse transaction X with ID Y
it shows:
> this transaction will reverse transaction with ID Y

I haven't added any test, I'm not sure how tests are setup or if there are any test for these things. At least I don't think I broke any existing tests as they still passed when running them.

The reason why the reference show in the first step, but not in the second, seems to be two-fold:

1. The reference data is not passed to the next view when pressing "save".
2. The form data is reset once in the post subroutine (which is called on pressing "save") so the data doesn't reach the display subroutine.

When the user press "reverse" the form data needed in the next view is passed as hidden form fields in the HTML. To preserve other form data it is scoped to be local to a do{...} block. Without this it would be overwritten with data from the database and since the references to the reversing has not been saved the unscoped fields will be reset or undefined. As this happens before rendering the form the displayed form will not have the expected data.