### PR TITLE
Fix empty triggers

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -510,8 +510,6 @@ sub load_base_schema {
     die 'Base schema failed to load'
         if ! $success;
 
-    $self->_load_module($dbh, 'triggers.sql');
-
     if (opendir(LOADDIR, "$self->{source_dir}/on_load")) {
         while (my $fname = readdir(LOADDIR)) {
             $self->run_file(

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -2376,6 +2376,7 @@ $$
 BEGIN
   -- dummy; actual function defined in modules/triggers.sql
   -- exists here in order to be able to create the triggers below
+  RETURN new;
 END;
 $$ LANGUAGE PLPGSQL;
 
@@ -2418,6 +2419,7 @@ CREATE FUNCTION prevent_closed_transactions() RETURNS trigger
 BEGIN
   -- dummy; actual function defined in modules/triggers.sql
   -- exists here in order to be able to create the triggers below
+  RETURN new;
 END;
 $$;
 
@@ -2437,6 +2439,11 @@ $$
 BEGIN
   -- dummy; actual function defined in modules/triggers.sql
   -- exists here in order to be able to create the triggers below
+  IF tg_op = 'INSERT' OR tg_op = 'UPDATE' THEN
+    RETURN new;
+  ELSE
+    RETURN NULL;
+  END IF;
 END;
 $$ language plpgsql security definer;
 
@@ -2504,6 +2511,7 @@ AS
 BEGIN
   -- dummy; actual function defined in modules/triggers.sql
   -- exists here in order to be able to create the triggers below
+  RETURN new;
 END;
 ' LANGUAGE PLPGSQL;
 -- end function


### PR DESCRIPTION
Migration from previous versions should be independent of modules and only rely on schema.
This PR fixes the empty triggers in the database schema and removes the dependency on the trigger module.