### PR TITLE
Complete removing of unused 'entity_id' and 'till' columns from AR/AP

### DIFF
--- a/sql/modules/Report.sql
+++ b/sql/modules/Report.sql
@@ -452,7 +452,7 @@ SELECT a.id, a.invoice, eeca.id, eca.meta_number::text, eeca.name, a.transdate,
          WHERE $1 = 2 and approved
          UNION
         SELECT id, transdate, invnumber, curr, amount_bc, netamount_bc, duedate,
-               notes, null, person_id, entity_credit_account, invoice,
+               notes, person_id, entity_credit_account, invoice,
                shippingpoint, shipvia, ordnumber, ponumber, description,
                on_hold, force_closed
           FROM ap
@@ -588,7 +588,7 @@ SELECT a.id, a.invoice, eeca.id, eca.meta_number::text, eeca.name,
          UNION
         SELECT id, transdate, invnumber, curr, amount_bc, netamount_bc, duedate,
                notes,
-               null, person_id, entity_credit_account, invoice, shippingpoint,
+               person_id, entity_credit_account, invoice, shippingpoint,
                shipvia, ordnumber, ponumber, description, on_hold, force_closed
           FROM ap
          WHERE $1 = 1


### PR DESCRIPTION
Remove leftover parameter. Fixes #7437