### PR TITLE
Increase max-num comparison periods for reports

### DIFF
--- a/UI/Reports/filters/balance_sheet.html
+++ b/UI/Reports/filters/balance_sheet.html
@@ -140,11 +140,11 @@
                    value = 0
                    size = '3'
                    "data-dojo-type"="dijit/form/NumberSpinner"
-                   "data-dojo-props"="constraints:{min:0,max:9,places:0},intermediateChanges:true,style:'width:7ex'"
+                   "data-dojo-props"="constraints:{min:0,max:13,places:0},intermediateChanges:true,style:'width:7ex'"
                    };
                    %]</legend>
         <div id="comparison_dates">
-          [% FOREACH c IN [1 .. 9]; %]
+          [% FOREACH c IN [1 .. 13]; %]
           <div class="input_row">
             <div id="comparison_dates_[% c %]" style="display:none">
               [%

--- a/UI/Reports/filters/income_statement.html
+++ b/UI/Reports/filters/income_statement.html
@@ -158,12 +158,12 @@
                    value = 0
                    size = '3'
                    "data-dojo-type" = "dijit/form/NumberSpinner"
-                   "data-dojo-props" = "intermediateChanges:true, constraints:{min:0, max:9, places:0}, smallDelta:1, style:'width:7ex'"
+                   "data-dojo-props" = "intermediateChanges:true, constraints:{min:0, max:13, places:0}, smallDelta:1, style:'width:7ex'"
                    };
                    %]</legend>
 
         <div id="comparison_dates" style="display:none">
-          [% FOREACH c IN [1 .. 9]; %]
+          [% FOREACH c IN [1 .. 13]; %]
           <div class="input_row" id="comparison_dates_[% c %]" style="display:none">
             <div class="input_group">
               [% PROCESS input element_data = {

--- a/UI/js-src/lsmb/reports/ComparisonSelector.js
+++ b/UI/js-src/lsmb/reports/ComparisonSelector.js
@@ -73,7 +73,7 @@ define([
                 } // invalid input
 
                 domStyle.set(dom.byId("comparison_dates"), "display", "");
-                for (var i = 1; i <= 9; i++) {
+                for (var i = 1; i <= 13; i++) {
                     domStyle.set(
                         dom.byId("comparison_dates_" + i),
                         "display",


### PR DESCRIPTION
When creating reports like Income Statement and Balance Sheet it is useful to be able to split the year into months to be able to compare a whole year. It may also be interesting to compare with the last month of the last year. To accommodate this usecase we increase the maximum number of comparison periods from 9 to 13.

