### PR TITLE
Fix/stylelint 15.10.1

### DIFF
--- a/UI/css/gnome.css
+++ b/UI/css/gnome.css
@@ -13,20 +13,20 @@ This package is free software; you can redistribute it and/or modify it under th
 /* general stuff */
 
 a:link {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:visited {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:active {
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 a:hover {
     background-color: transparent;
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 body {
@@ -382,13 +382,13 @@ body.admin {
 
 .submenu a {
     color: #004a80;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .submenu a:hover {
     background: #004a80;
     color: #eee;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listtop {
@@ -408,7 +408,7 @@ body.admin {
 a.listheading:link,
 a.listheading:active,
 a.listheading:visited {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listrow1,

--- a/UI/css/gnome2.css
+++ b/UI/css/gnome2.css
@@ -13,20 +13,20 @@ This package is free software; you can redistribute it and/or modify it under th
 /* general stuff */
 
 a:link {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:visited {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:active {
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 a:hover {
     background-color: transparent;
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 body {
@@ -382,13 +382,13 @@ body.admin {
 
 .submenu a {
     color: #004a80;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .submenu a:hover {
     background: #004a80;
     color: #eee;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listtop {
@@ -408,7 +408,7 @@ body.admin {
 a.listheading:link,
 a.listheading:active,
 a.listheading:visited {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listrow1,

--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -298,26 +298,26 @@ body {
 #PNL a {
     background-color: inherit;
     color: inherit;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 #PNL a:link {
     background-color: inherit;
     color: inherit;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 #PNL a:visited {
     background-color: inherit;
     color: inherit;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 #PNL a:hover {
     background-color: inherit;
     border-bottom: thin dashed;
     color: inherit;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 #PNL td.amount {

--- a/UI/css/system/ledgersmb-common.css
+++ b/UI/css/system/ledgersmb-common.css
@@ -32,20 +32,20 @@ th.header {
 /* general stuff */
 
 a:link {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:visited {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:active {
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 a:hover {
     background-color: var(--a-hover-bg-clr);
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 #pwfeedback.success {
@@ -236,13 +236,13 @@ body.menu,
 
 .submenu a {
     color: var(--submenu-a-clr);
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .submenu a:hover {
     background: var(--submenu-a-hover-clr);
     color: var(--submenu-a-clr);
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listtop {
@@ -269,7 +269,7 @@ thead th {
 thead a:link {
     color: var(--thead-a-link-clr);
     font-weight: bold;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a.listheading:link,
@@ -277,7 +277,7 @@ a.listheading:active,
 a.listheading:visited {
     color: var(--a-listheading-link-clr);
     font-weight: bold;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listrow1,
@@ -546,7 +546,7 @@ span.indicator {
 .financial-statement a,
 .financial-statement a:visited {
     color: var(--financial-statement-a-clr);
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .financial-statement .heading3.H {

--- a/UI/css/test-environment.css
+++ b/UI/css/test-environment.css
@@ -11,20 +11,20 @@ td.money {
 /* general stuff */
 
 a:link {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:visited {
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a:active {
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 a:hover {
     background-color: transparent;
-    text-decoration: underline;
+    text-decoration-line: underline;
 }
 
 body {
@@ -188,13 +188,13 @@ body.menu a:visited {
 
 .submenu a {
     color: #004a80;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .submenu a:hover {
     background: #004a80;
     color: #eee;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listtop {
@@ -216,7 +216,7 @@ thead th {
 thead a:link {
     color: white;
     font-weight: bold;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 a.listheading:link,
@@ -224,7 +224,7 @@ a.listheading:active,
 a.listheading:visited {
     color: white;
     font-weight: bold;
-    text-decoration: none;
+    text-decoration-line: none;
 }
 
 .listrow1,
@@ -460,5 +460,5 @@ span.indicator {
 .financial-statement a,
 .financial-statement a:visited {
     color: black;
-    text-decoration: none;
+    text-decoration-line: none;
 }

--- a/UI/package.json
+++ b/UI/package.json
@@ -35,7 +35,7 @@
     "fails to exclude Edge 16-18"
   ],
   "browserslist": [
-    "supports es6-module and supports async-functions and supports xhr2 and supports bloburls and supports css-variables and supports css3-boxsizing and supports border-radius and supports fetch and supports classlist and supports multicolumn and not edge <= 18"
+    "supports es6-module and supports async-functions and supports xhr2 and supports bloburls and supports css-variables and supports css3-boxsizing and supports border-radius and supports fetch and supports classlist and supports multicolumn and not edge <= 18 and supports css-display-contents"
   ],
   "bugs": "https://github.com/ledgersmb/LedgerSMB/issues",
   "repository": {

--- a/UI/package.json
+++ b/UI/package.json
@@ -408,7 +408,6 @@
     ],
     "rules": {
       "declaration-block-no-duplicate-custom-properties": null,
-      "indentation": 4,
       "order/order": [
         "custom-properties",
         "declarations"


### PR DESCRIPTION
- Remove deprecated indentation rule in stylelint
- Fix unsupported mdn-text-decoration-shorthand not supported on some browsers
- Fix unsupported css-display-contents on some very old browsers 