### PR TITLE
Reload GIFI/SIC table after successful csv import

### DIFF
--- a/UI/src/components/ImportCSV-Base.vue
+++ b/UI/src/components/ImportCSV-Base.vue
@@ -18,7 +18,8 @@ export default {
             default: true
         }
     },
-    setup() {
+    emits: [ "upload-success", "upload-error" ],
+    setup(props, { emit }) {
         const { t } = useI18n();
         let notify = inject("notify");
         let form = ref(null);
@@ -32,7 +33,10 @@ export default {
                         dismissReceiver
                     });
                 },
-                "success": () => { notify({ title: t("Uploaded") }); },
+                "success": () => {
+                    notify({ title: t("Uploaded") });
+                    emit("upload-success");
+                },
                 "submitError": (ctx, { event }) => {
                     notify({
                         title: t("Failure sending CSV"),

--- a/UI/src/views/GIFI.vue
+++ b/UI/src/views/GIFI.vue
@@ -27,7 +27,7 @@ const store = useGIFIsStore();
         createRole="gifi_create" />
     <div class="import-section">
         <h2 class="listheading">{{ $t("Import") }}</h2>
-        <ImportCsvGifi />
+        <ImportCsvGifi @upload-success="store.initialize()" />
     </div>
 </template>
 

--- a/UI/src/views/ImportCSV-GIFI.vue
+++ b/UI/src/views/ImportCSV-GIFI.vue
@@ -5,12 +5,13 @@ import ImportCSVBase from "@/components/ImportCSV-Base";
 
 export default {
     components: {
-       "import-csv": ImportCSVBase
+        "import-csv": ImportCSVBase
     },
+    emits: [ "upload-success", "upload-error" ],
     data() {
-       return {
-       };
-    }
+        return {
+        };
+    },
 };
 </script>
 
@@ -18,7 +19,9 @@ export default {
     <div id="import-gifi">
         <import-csv type="gifi"
                     :heading="false"
-                    :transactionFields="false" >
+                    :transactionFields="false"
+                    @upload-success="$emit('upload-success')"
+                    @upload-error="$emit('upload-error')">
             <template #title>Import
                 <abbr
                     title="General Index of Financial Information">GIFI</abbr> codes

--- a/UI/src/views/ImportCSV-SIC.vue
+++ b/UI/src/views/ImportCSV-SIC.vue
@@ -5,10 +5,11 @@ import ImportCSVBase from "@/components/ImportCSV-Base";
 
 export default {
     components: {
-       "import-csv": ImportCSVBase
+        "import-csv": ImportCSVBase
     },
+    emits: [ "upload-success", "upload-error" ],
     data() {
-       return {
+        return {
        };
     }
 };
@@ -18,7 +19,9 @@ export default {
     <div id="import-sic">
         <import-csv type="sic"
                     :heading="false"
-                    :transactionFields="false" >
+                    :transactionFields="false"
+                    @upload-success="$emit('upload-success')"
+                    @upload-error="$emit('upload-error')">
             <template #title>Import
                 <abbr
                     title="Standard Industrial Classification">SIC</abbr> codes</template>

--- a/UI/src/views/SIC.vue
+++ b/UI/src/views/SIC.vue
@@ -26,7 +26,7 @@ const store = useSICsStore();
         createRole="sic_create" />
     <div class="import-section">
         <h2 class="listheading">{{ t("Import") }}</h2>
-        <ImportCsvSic />
+        <ImportCsvSic @upload-success="store.initialize()" />
     </div>
 </template>
 

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -596,7 +596,7 @@ sub begin_import {
     if (ref($template_setup->{$request->{type}}) eq 'CODE') {
         $template_setup->{$request->{type}}($request);
     }
-    return [ 200, [ 'Content-Type' => 'text/plain' ], [ '' ] ];
+    return [ 200, [ 'Content-Type' => 'application/json' ], [ '{}' ] ];
 }
 
 


### PR DESCRIPTION
Before, the UI would say that the import was successful, showing an empty page.

Fixes #7513
