### PR TITLE
Convert buttons on journal screen to workflow

### DIFF
--- a/UI/journal/journal_entry.html
+++ b/UI/journal/journal_entry.html
@@ -133,6 +133,9 @@
            END ;
       END %]
       </a>
+      <br />
+      <br />
+      [% text('Status:') %] [% form.status %]
     </td>
  </tr>
 
@@ -347,15 +350,6 @@
     type = "hidden"
     name = "media"
     value = "screen"
-  };
-  PROCESS button element_data = {
-    id = "btn_print"
-    name = "__action"
-    text = text('Print')
-    class = "submit"
-    value = "print"
-    "data-dojo-type" = "lsmb/PrintButton"
-    "data-dojo-props" = "minimalGET: false"
   };
 END;
 %]

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -89,11 +89,25 @@ sub edit_and_save {
     check_balanced($form);
     $form->call_procedure(funcname=>'draft_delete', args => [ $form->{id} ]);
     GL->post_transaction( \%myconfig, \%$form, $locale);
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
     edit();
 }
 
 sub approve {
     $form->call_procedure(funcname=>'draft_approve', args => [ $form->{id} ]);
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
     if ($form->{callback}){
         print "Location: $form->{callback}\n";
         print "Status: 302 Found\n\n";
@@ -108,23 +122,39 @@ sub approve {
 }
 
 sub new {
-     for my $row (0 .. $form->{rowcount}){
-         for my $fld(qw(accno projectnumber acc debit credit source memo)){
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
+    for my $row (0 .. $form->{rowcount}){
+        for my $fld(qw(accno projectnumber acc debit credit source memo)){
             delete $form->{"${fld}_${row}"};
-         }
-     }
-     delete $form->{description};
-     delete $form->{reference};
-     delete $form->{rowcount};
-     delete $form->{id};
-     add();
+        }
+    }
+    delete $form->{description};
+    delete $form->{reference};
+    delete $form->{rowcount};
+    delete $form->{id};
+    delete $form->{workflow_id};
+    add();
 }
 
 sub copy_to_new {
-     delete $form->{reference};
-     delete $form->{id};
-     delete $form->{approved};
-     update();
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflow')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
+    delete $form->{reference};
+    delete $form->{id};
+    delete $form->{approved};
+    delete $form->{workflow_id};
+    update();
 }
 
 sub add {
@@ -161,6 +191,13 @@ sub _reverse_amounts {
 
 sub reverse {
     $form->{title}     = "Reverse";
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
 
     &create_links; # runs GL->transaction()
     _reverse_amounts();
@@ -168,6 +205,7 @@ sub reverse {
     $form->{reversing} = delete $form->{id};
     $form->{reversing_reference} = $form->{reference};
     delete $form->{approved};
+    delete $form->{workflow_id};
 
     display_form();
 }
@@ -273,6 +311,22 @@ sub display_form
                $form->{colrownotes}=0;
     }
 
+    my $wf;
+    if($form->{workflow_id}) {
+        $wf = $form->{_wire}->get('workflows')
+            ->fetch_workflow( 'GL', $form->{workflow_id} );
+    }
+    else {
+        $wf = $form->{_wire}->get('workflows')
+            ->create_workflow( 'GL',
+                               Workflow::Context->new(
+                                   'batch-id' => $form->{batch_id},
+                                   'table_name' => 'gl'
+                               ) );
+        $form->{workflow_id} = $wf->id;
+    }
+    $wf->context->param( transdate => $form->{transdate} );
+    $form->{status} = $wf->state;
     $focus = ( $form->{focus} ) ? $form->{focus} : "debit_$form->{rowcount}";
     our %hiddens = (
         'direction' => $form->{direction},
@@ -288,7 +342,8 @@ sub display_form
         'form_id' => $form->{form_id},
         'separate_duties' => $form->{separate_duties},
         'reversing' => $form->{reversing},
-        'reversing_reference' => $form->{reversing_reference}
+        'reversing_reference' => $form->{reversing_reference},
+        'workflow_id' => $form->{workflow_id}
     );
 
 
@@ -308,92 +363,41 @@ sub display_form
   $transdate = $form->datetonum( \%myconfig, $form->{transdate} );
   my @buttons;
   if ( !$form->{readonly} ) {
-      my $i;
-
-      $i=1;
-      @buttons = (
-          { action => 'update',
-            value => $locale->text('Update') },
-          { action => 'post',
-            value =>
-                ($form->{separate_duties}
-                 ? $locale->text('Save') : $locale->text('Post')),
-            class => 'post' },
-          { action => 'approve', value => $locale->text('Post'),
-            class => 'post' },
-          { action => 'edit_and_save',
-            value => $locale->text('Save Draft') },
-          { action => 'post_reversing',
-            value => ($form->{separate_duties}
-                      ? $locale->text('Save') : $locale->text('Post')), },
-          { action => 'save_temp',
-            value => $locale->text('Save Template') },
-          { action => 'save_as_new',
-            value => $locale->text('Save as new') },
-          { action => 'schedule',
-            value => $locale->text('Schedule') },
-          { action => 'new',
-            value => $locale->text('New') },
-          { action => 'copy_to_new',
-            value => $locale->text('Copy to New') },
+      $wf->context->param( _is_closed => $form->is_closed( $transdate ) );
+      %button_types = (
+          print => 'lsmb/PrintButton'
           );
+      for my $action_name ( $wf->get_current_actions ) {
+          my $action = $wf->get_action( $action_name );
 
-      %a = ();
-      $a{'save_temp'} = not $form->{reversing};
-
-      if ( $form->{id}) {
-          for ( 'new', 'save_as_new', 'copy_to_new' ) {
-              $a{$_} = 1;
-          }
-          for ( 'schedule' ) {
-              $a{$_} = not $form->{reversing};
-          }
-          if (!$form->{approved} && !$form->{batch_id}) {
-            #   Need to check for draft_modify and draft_post
-            if ($form->is_allowed_role(['draft_post'])) {
-                $a{approve} = 1;
-            }
-            if ($form->is_allowed_role(['draft_modify'])) {
-                $a{edit_and_save} = not $form->{reversing};
-                $a{post_reversing} = $form->{reversing};
-            }
-            $a{update} = not $form->{reversing};
-          }
-      } else {
-          if ( not $form->is_closed( $transdate ) ) {
-              for ( 'post' ) { $a{$_} = not $form->{reversing} }
-              for ( 'post_reversing' ) { $a{$_} = $form->{reversing} }
-          }
-          for ( 'update', 'schedule' ) {
-              $a{$_} = not $form->{reversing};
-          }
+          next if ($action->ui // '') eq 'none';
+          push @buttons, {
+              ndx   => $action->order,
+              name  => $action->name,
+              text => $locale->maketext($action->text),
+              doing => ($action->doing ? $locale->maketext($action->doing) : ''),
+              done  => ($action->done ? $locale->maketext($action->done) : ''),
+              type  => $button_types{$action->ui},
+              tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
+          };
       }
 
-      $i=1;
       @buttons = map {
           {
               name => '__action',
-              value => $_->{action},
-              text => $_->{value},
+              value => $_->{name},
+              text => $_->{text},
               type => 'submit',
               class => $_->{class} // 'submit',
-              order => $i++
+              order => $_->{ndx},
+              'data-lsmb-doing' => $_->{doing},
+              'data-lsmb-done' => $_->{done},
+              'data-dojo-type' => $_->{type} // 'dijit/form/Button',
+              'data-dojo-props' => $_->{type} ? 'minimalGET: false' : '',
           }
       }
-      grep { $a{$_->{action}} } @buttons;
+      sort { $a->{ndx} <=> $b->{ndx} } @buttons;
   }
-
-    unless ($form->{reversed_by}) {
-        if ($form->{approved}) {
-            push @buttons, {
-                name  => '__action',
-                value => 'reverse',
-                text  => $locale->text('Reverse'),
-                type  => 'submit',
-                class => 'submit',
-            };
-        }
-    }
 
   $form->{recurringset}=0;
   if ( $form->{recurring} ) {
@@ -416,6 +420,13 @@ sub display_form
 sub save_temp {
     my ($department_name, $department_id) = split/--/, $form->{department};
 
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
     my @lines;
     for my $iter (0 .. $form->{rowcount}){
         if ($form->{"accno_$iter"} and
@@ -681,6 +692,13 @@ sub post {
         $form->finalize_request();
     };
     $form->isblank( "transdate", $locale->text('Transaction Date missing!') );
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
 
     $transdate = $form->datetonum( \%myconfig, $form->{transdate} );
 
@@ -701,9 +719,16 @@ sub post {
 
 }
 
-sub delete {
+sub del {
     $form->error($locale->text('Cannot delete posted transaction'))
        if ($form->{approved});
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
     $form->call_procedure(funcname=>'draft_delete', args => [ $form->{id} ]);
     delete $form->{id};
     delete $form->{reference};
@@ -738,6 +763,13 @@ sub check_balanced {
 
 sub save_as_new {
     for (qw(id printed emailed)) { delete $form->{$_} }
+    if ($form->{workflow_id}) {
+        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
+            'GL', $form->{workflow_id}
+            );
+        $wf->context->param( transdate => $form->{transdate} );
+        $wf->execute_action( $form->{__action} );
+    }
     delete $form->{approved};
     &post;
 }

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -681,7 +681,10 @@ sub update {
 }
 
 
-
+sub post_and_approve {
+    post();
+    $form->call_procedure(funcname=>'draft_approve', args => [ $form->{id} ]);
+}
 
 sub post {
     if ($form->{id}){

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -728,7 +728,7 @@ sub del {
     $form->call_procedure(funcname=>'draft_delete', args => [ $form->{id} ]);
     delete $form->{id};
     delete $form->{reference};
-    add();
+    new();
 }
 
 

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -117,18 +117,11 @@ sub approve {
                 . qq|here</a>.</body></html>|;
 
     } else {
-        $form->info($locale->text('Draft Posted'));
+        new();
     }
 }
 
 sub new {
-    if ($form->{workflow_id}) {
-        my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
-            'GL', $form->{workflow_id}
-            );
-        $wf->context->param( transdate => $form->{transdate} );
-        $wf->execute_action( $form->{__action} );
-    }
     for my $row (0 .. $form->{rowcount}){
         for my $fld(qw(accno projectnumber acc debit credit source memo)){
             delete $form->{"${fld}_${row}"};

--- a/old/lib/LedgerSMB/GL.pm
+++ b/old/lib/LedgerSMB/GL.pm
@@ -119,10 +119,10 @@ sub post_transaction {
             || $form->dberror($query);
 
         ( $form->{id} ) = $sth->fetchrow_array();
-        $query = q|UPDATE transactions SET reversing = ? WHERE id = ? AND workflow_id IS NULL|;
+        $query = q|UPDATE transactions SET workflow_id = ?, reversing = ? WHERE id = ? AND workflow_id IS NULL|;
         $sth   = $dbh->prepare($query);
         $form->{reversing} ||= undef; # convert empty string to NULL
-        $sth->execute( $form->{reversing}, $form->{id} )
+        $sth->execute( $form->{workflow_id}, $form->{reversing}, $form->{id} )
             || $form->dberror($query);
     }
 
@@ -274,7 +274,7 @@ sub transaction {
         @{$form->{currencies}} =
             (LedgerSMB::Setting->new(%$form))->get_currencies;
 
-        $query = qq|SELECT g.*, t.reversing, t.reversing_reference, t.reversed_by, t.reversed_by_reference
+        $query = qq|SELECT g.*, t.workflow_id, t.reversing, t.reversing_reference, t.reversed_by, t.reversed_by_reference
                  FROM gl g JOIN transactions_reversal t on g.id = t.id
                 WHERE g.id = ?|;
 

--- a/old/lib/LedgerSMB/GL.pm
+++ b/old/lib/LedgerSMB/GL.pm
@@ -82,9 +82,7 @@ sub post_transaction {
     my $sth;
 
     my $id = $dbh->quote( $form->{id} );
-    if ($form->{separate_duties}){
-        $form->{approved} = '0';
-    }
+    $form->{approved} = '0';
     if ( $form->{id} ) {
 
         $query = qq|SELECT id FROM gl WHERE id = $id|;

--- a/sql/changes/1.11/gl-workflows.sql
+++ b/sql/changes/1.11/gl-workflows.sql
@@ -1,0 +1,28 @@
+
+create temporary table workflow_transactions as
+  select gl.id as gl,
+         nextval('workflow_seq') as wf,
+         CASE WHEN approved THEN 'POSTED'
+         ELSE 'SAVED' END as state
+  from gl
+  where not exists (select from yearend y where y.trans_id = gl.id)
+  and not exists (select from payment p where p.gl_id = gl.id)
+  and not exists (select from inventory_report r where r.trans_id = gl.id)
+  and not exists (select from asset_report a where a.gl_id = gl.id);
+
+insert into workflow (workflow_id, type, state, last_update)
+select wf, 'GL', state, now()
+  from workflow_transactions;
+
+update transactions trn
+   set workflow_id = wf
+  from workflow_transactions wt
+ where trn.id = wt.gl;
+
+insert into workflow_history
+            (workflow_hist_id, workflow_id, action,
+            description, state, workflow_user, history_date)
+select nextval('workflow_history_seq'), wf, 'MIGRATE',
+       'Workflow created during migration', state,
+       CURRENT_USER, now()
+  from workflow_transactions;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -180,3 +180,4 @@ mc/delete-migration-validation-data.sql
 1.11/ar-ap-role-naming-consistency.sql
 1.11/aa-column-cleanup.sql
 1.11/rename-action-parameter.sql
+1.11/gl-workflows.sql

--- a/workflows/gl.actions.xml
+++ b/workflows/gl.actions.xml
@@ -112,6 +112,8 @@ TODO! Check workflow when 'separate duties' is false!
           group="main"
           order="21"
           text="Delete"
+          doing="Deleting..."
+          done="Deleted"
           short-help="Remove draft transaction"
           class="LedgerSMB::Workflow::Action::Null" />
 

--- a/workflows/gl.actions.xml
+++ b/workflows/gl.actions.xml
@@ -1,0 +1,129 @@
+<actions type="GL">
+  <!--
+
+Notes on actions for GL:
+
+* 'post' really is 'save' because 'approve' models the 'Post' button
+* 'copy_to_new' does the same thing as 'save_as_new' now that updating
+  saved invoices no longer clobbers the updated data
+
+
+TODO! Check workflow when 'separate duties' is false!
+(Do we get the correct state transitions?)
+
+  -->
+  <action name="update"
+          group="main"
+          order="01"
+          text="Update"
+          doing="Updating..."
+          done="Updated"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="copy_to_new"
+          group="main"
+          order="02"
+          text="Copy to New"
+          short-help="Create a new transaction with the current data"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="print"
+          group="output"
+          order="03"
+          ui="print"
+          text="Print"
+          history-text="Printed"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="approve"
+          group="main"
+          order="04"
+          text="Post"
+          doing="Posting..."
+          done="Posted"
+          history-text="Posted"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <!--action name="batch-approve"
+          group="main"
+          ui="none"
+          class="LedgerSMB::Workflow::Action::Null" / -->
+  <action name="post_and_approve"
+          group="main"
+          order="05"
+          text="Post"
+          doing="Posting..."
+          done="Posted"
+          history-text="Posted"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="post_reversing"
+          group="main"
+          order="06"
+          text="Post"
+          doing="Posting..."
+          done="Posted"
+          history-text="Posted"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="post"
+          group="main"
+          order="07"
+          text="Save"
+          doing="Saving..."
+          done="Saved"
+          history-text="Saved"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="edit_and_save"
+          group="main"
+          order="08"
+          text="Save"
+          doing="Saving..."
+          done="Saved"
+          history-text="Saved"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="save_temp"
+          group="main"
+          order="09"
+          text="Save Template"
+          doing="Saving..."
+          done="Saved"
+          history-text="Saved"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="schedule"
+          group="main"
+          order="14"
+          text="Schedule"
+          short-help="Make transaction recurring"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <action name="reverse"
+          group="main"
+          order="18"
+          text="Reverse"
+          history-text="Reversed"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <!-- action name="save_info"
+          group="main"
+          order="19"
+          text="Save Info"
+          class="LedgerSMB::Workflow::Action::Null" / -->
+  <action name="new"
+          group="main"
+          order="20"
+          text="New"
+          short-help="Create a new (empty) transaction"
+          class="LedgerSMB::Workflow::Action::Null" />
+  <!-- 'delete' is a reserved keyword; we better not use it: it'll need to be the name of a sub -->
+  <action name="del"
+          group="main"
+          order="21"
+          text="Delete"
+          short-help="Remove draft transaction"
+          class="LedgerSMB::Workflow::Action::Null" />
+
+  <action name="save_as_new"
+          group="main"
+          text="Save as New"
+          history-text="Created new"
+          class="LedgerSMB::Workflow::Action::RecordSpawnedWorkflow" />
+
+  <!-- these do not have a button in the UI at all -->
+  <action name="batch-delete"
+          group="main"
+          ui="none"
+          class="LedgerSMB::Workflow::Action::Null" />
+</actions>

--- a/workflows/gl.conditions.xml
+++ b/workflows/gl.conditions.xml
@@ -1,0 +1,9 @@
+<conditions>
+  <type>GL</type>
+  <condition name="complete"
+             test="$context->{transdate}"
+             class="Workflow::Condition::Evaluate"/>
+  <condition name="is-batch-member"
+             test="$context->{'batch-id'}"
+             class="Workflow::Condition::Evaluate" />
+</conditions>

--- a/workflows/gl.persisters.xml
+++ b/workflows/gl.persisters.xml
@@ -1,0 +1,8 @@
+<persisters>
+  <persister name="JournalEntry"
+             class="LedgerSMB::Workflow::Persister::JournalEntry"
+             date_format="%Y-%m-%d %H:%M:%S"
+             driver="Pg"
+             extra_table="transactions"
+             extra_data_field="id,table_name,transdate" />
+</persisters>

--- a/workflows/gl.workflow.xml
+++ b/workflows/gl.workflow.xml
@@ -1,0 +1,51 @@
+<workflow>
+  <type>GL</type>
+  <persister>JournalEntry</persister>
+  <description>Manage the life cycle of a GL document (excluding year-end, inventory adjustment and fixed assets transactions)</description>
+  <state name="INITIAL">
+    <action name="update" resulting_state="NOCHANGE" />
+    <action name="post" resulting_state="SAVED" />
+    <action name="post_and_approve" resulting_state="POSTED">
+      <condition name="!separate-duties" />
+      <condition name="!period-closed" />
+      <condition name="complete" />
+    </action>
+  </state>
+  <state name="SAVED">
+    <!-- action name="save_temp" resulting_state="NOCHANGE">
+      <condition name="!is_invoice" />
+    </action -->
+    <!-- action name="save_info" resulting_state="NOCHANGE" / -->
+    <action name="edit_and_save" resulting_state="NOCHANGE">
+      <condition name="acl-draft-modify" />
+    </action>
+    <action name="copy_to_new" resulting_state="NOCHANGE" />
+    <action name="update" resulting_state="NOCHANGE" />
+    <action name="schedule" resulting_state="NOCHANGE">
+      <condition name="!is-batch-member" />
+    </action>
+    <action name="approve" resulting_state="POSTED">
+      <condition name="complete" />
+      <condition name="!period-closed" />
+      <condition name="acl-draft-post" />
+    </action>
+    <action name="del" resulting_state="DELETED">
+      <condition name="!is-batch-member" />
+    </action>
+    <action name="batch-delete" resulting_state="DELETED">
+      <condition name="is-batch-member" />
+    </action>
+  </state>
+  <state name="POSTED">
+    <!-- action name="save_info" resulting_state="NOCHANGE" / -->
+    <action name="copy_to_new" resulting_state="NOCHANGE" />
+    <action name="reverse" resulting_state="REVERSED" />
+    <action name="schedule" resulting_state="NOCHANGE" />
+    <action name="print" resulting_state="NOCHANGE" />
+  </state>
+  <state name="REVERSED">
+    <!-- action name="save_info" resulting_state="NOCHANGE" / -->
+    <action name="copy_to_new" resulting_state="NOCHANGE" />
+  </state>
+  <state name="DELETED" />
+</workflow>


### PR DESCRIPTION
Relates to #7457; demystifies when to show which buttons.

~~Missing migration of existing transactions.~~

Thoughts on migrating existing transactions:
* Don't migrate:
  * Year-end transactions [table: `yearend`]
  * Fixed assets transactions [table: `asset_report`]
  * Payment transactions [table: `payment`]
  * Inventory adjustment reports [table: `inventory_report`]
* What how to correctly initialize GL transactions that are part of a batch of some kind?
