### PR TITLE
Remove 'lastname_used'

### DIFF
--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -725,16 +725,8 @@ sub retrieve {
         $form->get_recurring;
     }
     else {
-
-        # get last name used
-        $form->lastname_used($form->{vc})
-          unless $form->{"$form->{vc}_id"};
-
         delete $form->{notes};
-
     }
-
-
 }
 
 sub exchangerate_defaults {


### PR DESCRIPTION
This functionality was long forgotten and broken, even assumed removed already.  Cleaning it up now; might be added back when AR/AP get re-implemented.

Removal was triggered by manual tests showing it to kick in since the buttons being reworked -- and it to list AP eca-s on AR transactions.
