### PR TITLE
Make right-to-left locale always assigned

### DIFF
--- a/UI/src/i18n.js
+++ b/UI/src/i18n.js
@@ -51,11 +51,13 @@ export async function setI18nLanguage(lang) {
         }
     }
     if ( i18n.global.locale.value !== locale ){
-        document.querySelector("html").setAttribute("lang", locale);
-        if (rtlDetect.isRtlLang(locale)) {
-            document.querySelector("html").setAttribute("dir", "rtl");
-        }
         i18n.global.locale.value = locale;
+    }
+    document.querySelector("html").setAttribute("lang", locale);
+    if (rtlDetect.isRtlLang(locale)) {
+        document.querySelector("html").setAttribute("dir", "rtl");
+    } else {
+        document.querySelector("html").removeAttribute("dir");
     }
     return nextTick();
 }


### PR DESCRIPTION
Left-to-right and right-to-left indicators must always follow the assigned locale