### PR TITLE
Disable vue/no-setup-props-destructure rule

### DIFF
--- a/UI/package.json
+++ b/UI/package.json
@@ -197,7 +197,8 @@
           "jest/prefer-expect-assertions": "off",
           "jest/no-commented-out-tests": "off",
           "no-console": "off",
-          "camelcase": "off"
+          "camelcase": "off",
+          "vue/no-setup-props-destructure": "off"
         }
       }
     ],


### PR DESCRIPTION
Unfortunately, the only way forward is to disable the rule, as the author stubbornly refuses to accept any of the other solutions to split up the rule.

For context, read vuejs/eslint-plugin-vue#2259 and vuejs/eslint-plugin-vue#2244.
