### PR TITLE
Fix Math::BigFloat@1.999831+ upgrade improvements breakage

### DIFF
--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -41,6 +41,9 @@ $accuracy = $precision = undef;
 $round_mode = 'even';
 $div_scale = 40;
 
+# Prevent downgrading to Math::BigInt
+$Math::BigFloat::downgrade = undef;
+
 =head1 INHERITS
 
 =over


### PR DESCRIPTION
Before, apparently, we depended on Math::BigFloat /not/ downgrading on many operations. That behaviour (bug) has been fixed in 1.999831, which is included in Perl 5.36. This commit explicitly forbids Math::BigFloat from downgrading.
