### PR TITLE
Remove version number from cookies

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -18,12 +18,11 @@ about: Tracking the progress on preparing a new release branch
   * [ ] package.json
   * [ ] In setup.pm, add support to create databases of the version that 'master' becomes
   * [ ] In LedgerSMB.pm, increase the $VERSION variable
-  * [ ] In bin/ledgersmb-server.psgi adjust the version-check regex and the cookie name in the `__DATA__` section
+  * [ ] In bin/ledgersmb-server.psgi adjust the version-check regex
   * [ ] In locale/LedgerSMB.pot, adjust the Project-Id
   * [ ] In t/data/Is_LSMB_running.html, increase the version text
   * [ ] Update README.md reference to `docker-compose` file (both on the branch and on master)
   * [ ] Create a new docker-compose branch
-  * [ ] Update the cookie's version number in the default config files `doc/conf/ledgersmb.yaml.*`
 * [ ] Add the new version to renovate.json baseBranches
 
 ## General preparation

--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -178,7 +178,7 @@ $builder->to_app(
 
 __DATA__
 cookie:
-  name: LedgerSMB-1.12
+  name: LedgerSMB
 db:
   $class: LedgerSMB::Database::Factory
   connect_data:

--- a/doc/conf/ledgersmb.yaml
+++ b/doc/conf/ledgersmb.yaml
@@ -1,6 +1,9 @@
 
 cookie:
-  name: LedgerSMB-1.12
+  # To run multiple LedgerSMB versions in parallel on the same domain,
+  # set the value of the cookie to 'LedgerSMB-<version>'; e.g. for version
+  # 1.1, that would become 'LedgerSMB-1.1'
+  name: LedgerSMB
   # Leaving the secret empty causes a secret to be dynamically generated
   # secret:
 

--- a/lib/LedgerSMB/Routes/ERP/API.pm
+++ b/lib/LedgerSMB/Routes/ERP/API.pm
@@ -117,7 +117,7 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: LedgerSMB-1.10
+      name: LedgerSMB
       description: |
         The authenticating cookie can be obtained by sending a `POST` request
         to `login.pl?__action=authenticate&company=<url-encoded-company` with a
@@ -137,3 +137,8 @@ components:
 
         **Note 2**: the validity of the cookie is as long the user's timeout
         when logged into the application (default: 90 minutes).
+
+        **Note 3**: Sites may customize the name of the cookie in order to run
+        multiple versions in parallel. The advice is to append the version name
+        to the cookie, resulting in cookie name `LedgerSMB-1.1` for LedgerSMB
+        version 1.1.


### PR DESCRIPTION
Without the version number, we don't need to rename the cookie on each release, removing a major maintenance nuisance.

[ci skip]
