### PR TITLE
Work around Locale::CLDR::Locales::* loading 'bignum'

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -233,6 +233,8 @@ use List::Util qw( pairgrep );
 use Locale::CLDR;
 use Locales unicode => 1;
 use Log::Any;
+use Math::BigFloat;
+use Math::BigInt;
 use PGObject;
 use Plack;
 use URI;
@@ -626,6 +628,8 @@ sub enabled_languages {
 sub enabled_countries {
     my ($self) = @_;
 
+    local $Math::BigInt::upgrade = undef;
+    local $Math::BigFloat::downgrade = undef;
     my $regions = Locale::CLDR->new($self->{_user}->{language})->all_regions;
     return [
         map {

--- a/lib/LedgerSMB/Database/Config.pm
+++ b/lib/LedgerSMB/Database/Config.pm
@@ -19,6 +19,8 @@ use namespace::autoclean;
 use File::Find::Rule;
 use File::Spec;
 use Locale::CLDR;
+use Math::BigFloat;
+use Math::BigInt;
 
 =head1 SYNOPSIS
 
@@ -125,8 +127,12 @@ sub charts_of_accounts {
     ###TODO: Define a parameter to the SQL directory!!
     my $basedir = File::Spec->catfile('.', 'locale', 'coa');
     my $countries = _list_directory($basedir);
-    my %regions = %{Locale::CLDR->new($self->language)
-                        ->all_regions};
+    my $cldr = do {
+        local $Math::BigInt::upgrade = undef;
+        local $Math::BigFloat::downgrade = undef;
+        Locale::CLDR->new($self->language);
+    };
+    my %regions = %{$cldr->all_regions};
 
     return {
         map {

--- a/lib/LedgerSMB/I18N.pm
+++ b/lib/LedgerSMB/I18N.pm
@@ -21,6 +21,8 @@ we look only to the current locale.
 
 use Locale::CLDR;
 use Locales unicode => 1;
+use Math::BigFloat;
+use Math::BigInt;
 use Moose::Role;
 use namespace::autoclean;
 use LedgerSMB::App_State;
@@ -127,7 +129,11 @@ Get a country localized list to allow user selection
 
 sub get_country_list {
     my $language = shift;
-    my %regions = Locale::CLDR->new($language)->all_regions->%*;
+    my %regions = do {
+        local $Math::BigInt::upgrade = undef;
+        local $Math::BigFloat::downgrade = undef;
+        Locale::CLDR->new($language)->all_regions->%*
+    };
     return [
         sort { $a->{text} cmp $b->{text} }
         map { +{ value => uc($_),

--- a/old/lib/LedgerSMB/DBObject/User.pm
+++ b/old/lib/LedgerSMB/DBObject/User.pm
@@ -12,6 +12,8 @@ use warnings;
 use base qw(LedgerSMB::PGOld);
 
 use Locale::CLDR;
+use Math::BigFloat;
+use Math::BigInt;
 
 use Carp;
 use Log::Any;
@@ -87,7 +89,11 @@ Sets the options for the user preference screen.
 sub get_option_data {
     my $self = shift @_;
     # Load localized data from current locale
-    my $locale = Locale::CLDR->new($self->{prefs}{language});
+    my $locale = do {
+        local $Math::BigInt::upgrade = undef;
+        local $Math::BigFloat::downgrade = undef;
+        Locale::CLDR->new($self->{prefs}{language});
+    };
     $self->{dateformats} = [];
     $self->{numberformats} = [];
     for my $opt (qw(mm-dd-yyyy mm/dd/yyyy dd-mm-yyyy dd/mm/yyyy dd.mm.yyyy yyyy-mm-dd)){


### PR DESCRIPTION
Loading 'bignum' causes $Math::BigInt::upgrade and $Math::BigFloat::downgrade to be overwritten. However, we want to make sure these values stay as they are set by LedgerSMB::PGNumber (which is: no downgrading!)

This is necessary for Perl 5.36+ compatibility.
