### PR TITLE
Fix trial balance drill down showing partial results

### DIFF
--- a/lib/LedgerSMB/Report/Voided_Option.pm
+++ b/lib/LedgerSMB/Report/Voided_Option.pm
@@ -25,7 +25,7 @@ use Moose::Role;
 use namespace::autoclean;
 
 has is_voided => (is => 'ro', isa => 'Str',
-                  default => 'Y');
+                  default => 'All');
 has voided => (is => 'ro', lazy => 1,
                builder => '_voided');
 


### PR DESCRIPTION
Instead of showing *all* lines, the query only shows lines belonging to voided invoices and transactions.

Fixes #7656
