### PR TITLE
Include only our static html in the cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: UI/js
-          key: dojo-${{ hashFiles('UI/js-src/**', 'UI/src/**', 'UI/css/**','UI/**/*.html','doc/sources/**') }}
+          key: dojo-${{ hashFiles('UI/js-src/**',
+                                  'UI/src/**',
+                                  'UI/css/**',
+                                  'UI/!(js|.node_modules)/**/*.html',
+                                  'doc/sources/**') }}
 
       - name: Build Dojo
         run: |


### PR DESCRIPTION
Make sure to exclude Vue locales from the Dojo cache to prevent invalidation between github steps.