### PR TITLE
Show posted AA transaction after "Post"

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -120,8 +120,6 @@ sub new_screen {
 sub add {
     $form->{title} = "Add";
 
-    $form->{callback} = "$form->{script}?__action=add"
-      unless $form->{callback};
     if (defined $form->{type}
         and $form->{type} eq "credit_note"){
         $form->{reverse} = 1;
@@ -1329,7 +1327,7 @@ sub approve {
                 . qq|here</a>.</body></html>|;
 
     } else {
-        $form->info($locale->text('Draft Posted'));
+        update();
     }
 }
 


### PR DESCRIPTION
When separation of duties is disabled, the transaction is shown after clicking "Post". When enabled, the resulting page shows "Draft posted".

With this change, the posted transaction is shown in both cases.
