### PR TITLE
Consistent New button to GL/AR/AP transactions

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -107,7 +107,9 @@ sub copy_to_new{
 }
 
 sub new_screen {
-    my @reqprops = qw(ARAP vc dbh stylesheet batch_id script type _locale _wire);
+    my @reqprops = qw(
+        ARAP vc dbh stylesheet batch_id script type _locale _wire invdate
+        );
     $oldform = $form;
     $form = {};
     bless $form, 'Form';

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -143,7 +143,7 @@ sub new {
     }
     for my $fld (
         qw(description reference rowcount id workflow_id
-           transdate notes reversing reversing_reference )
+           notes reversing reversing_reference )
         ) {
         delete $form->{$fld};
     }

--- a/workflows/ar-ap.workflow.xml
+++ b/workflows/ar-ap.workflow.xml
@@ -77,6 +77,7 @@
   <state name="POSTED">
     <action name="save_info" resulting_state="NOCHANGE" />
     <action name="copy_to_new" resulting_state="NOCHANGE" />
+    <action name="new_screen" resulting_state="NOCHANGE" />
     <action name="void" resulting_state="VOIDED">
       <condition name="is_sales_invoice" />
     </action>

--- a/workflows/gl.workflow.xml
+++ b/workflows/gl.workflow.xml
@@ -32,6 +32,7 @@
       <condition name="acl-draft-modify" />
     </action>
     <action name="copy_to_new" resulting_state="NOCHANGE" />
+    <action name="new" resulting_state="NOCHANGE" />
     <action name="update" resulting_state="NOCHANGE" />
     <action name="schedule" resulting_state="NOCHANGE">
       <condition name="!is-batch-member" />
@@ -52,6 +53,7 @@
   <state name="POSTED">
     <action name="save_info" resulting_state="NOCHANGE" />
     <action name="copy_to_new" resulting_state="NOCHANGE" />
+    <action name="new" resulting_state="NOCHANGE" />
     <action name="reverse" resulting_state="REVERSED" />
     <action name="schedule" resulting_state="NOCHANGE" />
     <action name="print" resulting_state="NOCHANGE" />


### PR DESCRIPTION
AR/AP transactions have a New button in SAVED state, but not in POSTED state. GL transactions don't have a New button at all.

This change makes sure the New button is shown for all of GL/AR/AP transactions in SAVED *and* POSTED states.

Copy the transaction date from the current transaction to the new transaction; present an otherwise empty/clean entry screen.
