### PR TITLE
Remove login list size

### DIFF
--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -40,7 +40,6 @@
                                                   text = 'lsmb_dbadmin'},
                                                 { value = 'postgres',
                                                   text  = 'postgres'} ]
-                                   size = '15'
                                    class = 'username'
                                    tabindex = 1
                                    label = text('DB admin login')


### PR DESCRIPTION
Let the login form display only the 2 db admin login options instead of providing for 15 