### PR TITLE
Fix encoding of the column data, including col_id

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -576,11 +576,13 @@ sub _render {
             new_heads       => $replace_hnames,
             name            => $self->name,
             hlines          => $self->header_lines,
-            columns         => \@columns,
             order_url       => $self->order_url,
             buttons         => $self->buttons,
             options         => $self->options,
             rows            => \@rows,
+        },
+        {
+            columns         => \@columns
         });
 }
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -497,11 +497,12 @@ sub _render {
     if ($escape) {
         $cleanvars = {
             %{ preprocess($vars, sub { $self->{format_plugin}->escape(@_) } ) },
-              %{$self->{additional_vars} // {}},
-              %$cvars,
-              text => sub {
-                  return $self->{format_plugin}->escape($self->_maketext(@_));
-              },
+            %{$self->{additional_vars} // {}},
+            %$cvars,
+            escape => $escape,
+            text => sub {
+                return $self->{format_plugin}->escape($self->_maketext(@_));
+            },
         };
     }
     else {
@@ -509,6 +510,7 @@ sub _render {
             ( %$vars,
               %{$self->{additional_vars} // {}},
               %$cvars,
+              escape => sub { $_[0] },
               text => sub { return $self->_maketext(@_); },
             )
         };

--- a/templates/lib/dynatable.html
+++ b/templates/lib/dynatable.html
@@ -1,12 +1,19 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.1
-   Date:     2021-01-07
+   Version:  1.2
+   Date:     2023-12-01
    File:     dynatable.html
    Set:      none; shared
 
 Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
+
+Version   Changes
+1.2       Encode data from the 'columns' input, because the caller stopped its
+          encoding to fix GitHub issue #7739.
+1.1       Simplified version which also works without columns of pre-declared
+          width by using tabular environments to capture 'intentionally multi-
+          line output' into a single cell.
 
 -?>
 <?lsmb# HTML Snippet, for import only ?>
@@ -85,7 +92,7 @@ releases. No explicit versioning was applied before 2021-01-04.
    <tr>
    <?lsmb- FOREACH COL IN columns;
    IF COL.type != 'hidden'; -?>
-   <th class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type ?>"><?lsmb COL.name ?>
+   <th class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type | html ?>"><?lsmb COL.name | html ?>
    </th>
    <?lsmb- END; END; -?>
    </tr>
@@ -116,7 +123,7 @@ releases. No explicit versioning was applied before 2021-01-04.
             END;
 
             NEXT IF TYPE == 'hidden'; -?>
-      <td class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type ?>"<?lsmb ROWSPAN ?>>
+      <td class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type | html ?>"<?lsmb ROWSPAN ?>>
           <?lsmb- IF TYPE == 'boolean_checkmark' OR TYPE == 'checkbox' OR TYPE == 'radio';
                    IF ROW.${COL.col_id};
                       '✓';
@@ -131,8 +138,8 @@ releases. No explicit versioning was applied before 2021-01-04.
                   OPTION_LIST = COL.options(ROW);
 
                   FOREACH option IN OPTION_LIST;
-                    IF option.value == ROW.${COL.col_id};
-                       option.text;
+                    IF (option.value | html) == ROW.${COL.col_id};
+                       option.text | html;
                     END;
                   END;
                  ELSE -?>
@@ -166,7 +173,7 @@ releases. No explicit versioning was applied before 2021-01-04.
              <?lsmb END;
        NEXT IF TYPE == 'hidden';
        -?>
-       <td class="<?lsmb COL.col_id ?>">
+       <td class="<?lsmb COL.col_id | html ?>">
           <?lsmb- IF TYPE == 'boolean_checkmark' OR TYPE == 'checkbox' OR TYPE == 'radio';
                    IF ROW.${COL.col_id};
                        '✓';

--- a/templates/lib/dynatable.tex
+++ b/templates/lib/dynatable.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.1
-   Date:     2022-07-27
+   Version:  1.2
+   Date:     2023-12-01
    File:     dynatable.tex
    Set:      none; shared
 
@@ -9,6 +9,8 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
+1.2       Encode data from the 'columns' input, because the caller stopped its
+          encoding to fix GitHub issue #7739.
 1.1       Simplified version which also works without columns of pre-declared
           width by using tabular environments to capture 'intentionally multi-
           line output' into a single cell.
@@ -74,7 +76,7 @@ FOREACH COL IN columns;
         UNLESS loop.first() ;
            ' & ';
         END;
-        COL.name;
+        escape(COL.name);
     END;
 END;
 -?>\tabularnewline


### PR DESCRIPTION
Due to the fact that all column data was encoded for output-format-safety, the CoA and Trial Balance reports didn't show some columns in PDF format (with LaTeX intermediate representation). The column *keys* in the ROW data do *not* get encoded, whereas the column keys (stored in the column data as values) *do* get encoded. Due to this mismatch, the column name 'credit_balance' differed between the row data and the column data (the latter containing the encoded value 'credit\_balance').

Fixes #7739.
