### PR TITLE
Add visual feedback of payment line being unapproved

### DIFF
--- a/UI/css/system/ledgersmb-common.css
+++ b/UI/css/system/ledgersmb-common.css
@@ -581,6 +581,10 @@ span.indicator {
     font-size: 105%;
 }
 
+.invoice-payment.unapproved {
+    background-color: var(--unapproved-payment-bgcolor, orange);
+}
+
 #plDebug .plDebugPanelContent {
     left: 207px;
     right: 207px;

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -1019,12 +1019,13 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
 
         $form->hide_form("cleared_$i");
 
-        my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
-        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Pending approval');
+        my ($title, $approval_status, $icon) =
+            $form->{"paid_${i}_approved"} ? ('', 'approved', '')
+            : $form->{"datepaid_$i"} ? ($locale->text('Pending approval'), 'unapproved', '&#x23F2;')
+            : ('', '', '');
         $title = qq|title="$title"| if $title;
-        my $icon = $form->{"paid_${i}_approved"} ? '' : '&#x23F2;';
         print qq|
-        <tr class="invoice-payment $approval_status" $title><td style="text-align:center;vertical-align:middle">$icon</td>
+        <tr class="invoice-payment $approval_status" $title>
 |;
 
         $form->{"select$form->{ARAP}_paid_$i"} =
@@ -1060,6 +1061,8 @@ qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" size=10 val
         $form->{"datepaid_$i"} //= '';
         $form->{"source_$i"} //= '';
         $form->{"memo_$i"} //= '';
+
+        $column_data{status} = qq|<td style="text-align:center;vertical-align:middle">$icon</td>|;
         $column_data{paid} =
 qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size=11 value=$form->{"paid_$i"} $readonly></td>|;
         $column_data{ARAP_paid} =

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -369,7 +369,9 @@ sub create_links {
                 $form->{"$form->{ARAP}_paid_$i"} =
 "$form->{acc_trans}{$key}->[$i-1]->{accno}--$form->{acc_trans}{$key}->[$i-1]->{description}";
                 $form->{"paid_$i"} =
-                  $form->{acc_trans}{$key}->[ $i - 1 ]->{amount} * -1 * $ml;
+                    $form->{acc_trans}{$key}->[ $i - 1 ]->{amount} * -1 * $ml;
+                $form->{"paid_${i}_approved"} =
+                    $form->{acc_trans}{$key}->[ $i - 1 ]->{approved};
                 $form->{"datepaid_$i"} =
                   $form->{acc_trans}{$key}->[ $i - 1 ]->{transdate};
                 $form->{"source_$i"} =
@@ -1016,8 +1018,11 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
 
         $form->hide_form("cleared_$i");
 
-        print q|
-        <tr class="invoice-payment">
+        my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
+        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Unapproved');
+        $title = qq|title="$title"| if $title;
+        print qq|
+        <tr class="invoice-payment $approval_status" $title>
 |;
 
         $form->{"select$form->{ARAP}_paid_$i"} =

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -982,12 +982,13 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
 |;
 
     if ( $form->{currency} eq $form->{defaultcurrency} ) {
-        @column_index = qw(datepaid source memo paid ARAP_paid);
+        @column_index = qw(status datepaid source memo paid ARAP_paid);
     }
     else {
-        @column_index = qw(datepaid source memo paid exchangerate paidfx ARAP_paid);
+        @column_index = qw(status datepaid source memo paid exchangerate paidfx ARAP_paid);
     }
 
+    $column_data{status}       = "<th></th>";
     $column_data{datepaid}     = "<th>" . $locale->text('Date') . "</th>";
     $column_data{paid}         = "<th>" . $locale->text('Amount') . "</th>";
     $column_data{exchangerate} = "<th>" . $locale->text('Exch') . "</th>";
@@ -1019,10 +1020,11 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         $form->hide_form("cleared_$i");
 
         my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
-        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Unapproved');
+        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Pending approval');
         $title = qq|title="$title"| if $title;
+        my $icon = $form->{"paid_${i}_approved"} ? '' : '&#x23F2;';
         print qq|
-        <tr class="invoice-payment $approval_status" $title>
+        <tr class="invoice-payment $approval_status" $title><td style="text-align:center;vertical-align:middle">$icon</td>
 |;
 
         $form->{"select$form->{ARAP}_paid_$i"} =

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -240,6 +240,8 @@ sub invoice_links {
                 # reverse paid
                 $form->{"paid_$i"} =
                   $form->{acc_trans}{$key}->[ $i - 1 ]->{amount};
+                $form->{"paid_${i}_approved"} =
+                    $form->{acc_trans}{$key}->[ $i - 1 ]->{approved};
                 $form->{"datepaid_$i"} =
                   $form->{acc_trans}{$key}->[ $i - 1 ]->{transdate};
                 $form->{"forex_$i"} = $form->{"exchangerate_$i"} =
@@ -859,8 +861,11 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
 
         $form->hide_form("cleared_$i");
 
+        my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
+        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Unapproved');
+        $title = qq|title="$title"| if $title;
         print qq|
-    <tr class="invoice-payment">
+        <tr class="invoice-payment $approval_status" $title>
 |;
 
         $form->{"selectAP_paid_$i"} = $form->{selectAP_paid};

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -862,12 +862,13 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
 
         $form->hide_form("cleared_$i");
 
-        my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
-        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Pending approval');
+        my ($title, $approval_status, $icon) =
+            $form->{"paid_${i}_approved"} ? ('', 'approved', '')
+            : $form->{"datepaid_$i"} ? ($locale->text('Pending approval'), 'unapproved', '&#x23F2;')
+            : ('', '', '');
         $title = qq|title="$title"| if $title;
-        my $icon = $form->{"paid_${i}_approved"} ? '' : '&#x23F2;';
         print qq|
-        <tr class="invoice-payment $approval_status" $title><td style="text-align:center">$icon</td>
+        <tr class="invoice-payment $approval_status" $title>
 |;
 
         $form->{"selectAP_paid_$i"} = $form->{selectAP_paid};
@@ -903,6 +904,7 @@ qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchang
 |;
 
         $form->{"${_}_$i"} //= '' for (qw(memo source datepaid));
+        $column_data{"status_$i"} = qq|<td style="text-align:center">$icon</td>|;
         $column_data{"paid_$i"} =
 qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size=11 value=$form->{"paid_$i"} $readonly></td>|;
         $column_data{"exchangerate_$i"} =

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -829,12 +829,13 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
 |;
 
     if ( $form->{currency} eq $form->{defaultcurrency} ) {
-        @column_index = qw(datepaid source memo paid AP_paid);
+        @column_index = qw(status datepaid source memo paid AP_paid);
     }
     else {
-        @column_index = qw(datepaid source memo paid exchangerate paidfx AP_paid);
+        @column_index = qw(status datepaid source memo paid exchangerate paidfx AP_paid);
     }
 
+    $column_data{status}       = "<th></th>";
     $column_data{datepaid}     = "<th>" . $locale->text('Date') . "</th>";
     $column_data{paid}         = "<th>" . $locale->text('Amount') . "</th>";
     $column_data{exchangerate} = "<th>" . $locale->text('Exch') . "</th>";
@@ -862,10 +863,11 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
         $form->hide_form("cleared_$i");
 
         my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
-        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Unapproved');
+        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Pending approval');
         $title = qq|title="$title"| if $title;
+        my $icon = $form->{"paid_${i}_approved"} ? '' : '&#x23F2;';
         print qq|
-        <tr class="invoice-payment $approval_status" $title>
+        <tr class="invoice-payment $approval_status" $title><td style="text-align:center">$icon</td>
 |;
 
         $form->{"selectAP_paid_$i"} = $form->{selectAP_paid};

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -908,12 +908,13 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
 |;
 
     if ( $form->{currency} eq $form->{defaultcurrency} ) {
-        @column_index = qw(datepaid source memo paid AR_paid);
+        @column_index = qw(status datepaid source memo paid AP_paid);
     }
     else {
-        @column_index = qw(datepaid source memo paid exchangerate paidfx AR_paid);
+        @column_index = qw(status datepaid source memo paid exchangerate paidfx AP_paid);
     }
 
+    $column_data{status}       = "<th></th>";
     $column_data{datepaid}     = "<th>" . $locale->text('Date') . "</th>";
     $column_data{paid}         = "<th>" . $locale->text('Amount') . "</th>";
     $column_data{exchangerate} = "<th>" . $locale->text('Exch') . "</th>";
@@ -938,10 +939,11 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
         $form->hide_form("cleared_$i");
 
         my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
-        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Unapproved');
+        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Pending approval');
         $title = qq|title="$title"| if $title;
+        my $icon = $form->{"paid_${i}_approved"} ? '' : '&#x23F2;';
         print qq|
-        <tr class="invoice-payment $approval_status" $title>
+        <tr class="invoice-payment $approval_status" $title><td style="text-align:center">$icon</td>
 |;
 
         $form->{"selectAR_paid_$i"} = $form->{selectAR_paid};

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -231,6 +231,8 @@ sub invoice_links {
                     # reverse paid
                     $form->{"paid_$i"} =
                         $form->{acc_trans}{$key}->[ $i - 1 ]->{amount} * -1;
+                    $form->{"paid_${i}_approved"} =
+                        $form->{acc_trans}{$key}->[ $i - 1 ]->{approved};
                     $form->{"datepaid_$i"} =
                         $form->{acc_trans}{$key}->[ $i - 1 ]->{transdate};
                     $form->{"forex_$i"} = $form->{"exchangerate_$i"} =
@@ -935,8 +937,12 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
 
         $form->hide_form("cleared_$i");
 
-        print qq{
-        <tr class="invoice-payment">\n};
+        my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
+        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Unapproved');
+        $title = qq|title="$title"| if $title;
+        print qq|
+        <tr class="invoice-payment $approval_status" $title>
+|;
 
         $form->{"selectAR_paid_$i"} = $form->{selectAR_paid};
         $form->{"selectAR_paid_$i"} =~

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -938,12 +938,13 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
 
         $form->hide_form("cleared_$i");
 
-        my $approval_status = $form->{"paid_${i}_approved"} ? 'approved' : 'unapproved';
-        my $title = $form->{"paid_${i}_approved"} ? '' : $locale->text('Pending approval');
+        my ($title, $approval_status, $icon) =
+            $form->{"paid_${i}_approved"} ? ('', 'approved', '')
+            : $form->{"datepaid_$i"} ? ($locale->text('Pending approval'), 'unapproved', '&#x23F2;')
+            : ('', '', '');
         $title = qq|title="$title"| if $title;
-        my $icon = $form->{"paid_${i}_approved"} ? '' : '&#x23F2;';
         print qq|
-        <tr class="invoice-payment $approval_status" $title><td style="text-align:center">$icon</td>
+        <tr class="invoice-payment $approval_status" $title>
 |;
 
         $form->{"selectAR_paid_$i"} = $form->{selectAR_paid};
@@ -977,6 +978,7 @@ qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" id="exchang
 <input type="hidden" name="forex_$i" value="$form->{"forex_$i"}">
 |;
 
+        $column_data{status} = qq|<td style="text-align:center">$icon</td>|;
         $column_data{paid} =
 qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size="11" value="$form->{"paid_$i"}" $readonly></td>|;
         $column_data{exchangerate} = qq|<td align="center">$exchangerate</td>|;

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2081,7 +2081,8 @@ sub create_links {
                                 array_agg(ARRAY[bul.class_id, bul.bu_id])
                                 AS bu_lines,
                (exists (select 1 from payment_links pl
-                         where a.entry_id = pl.entry_id)) AS payment_line
+                         where a.entry_id = pl.entry_id)) AS payment_line,
+               approved
             FROM acc_trans a
             JOIN account c ON (c.id = a.chart_id)
                    LEFT JOIN business_unit_ac bul ON a.entry_id = bul.entry_id

--- a/xt/lib/PageObject/App/Invoices/Payment.pm
+++ b/xt/lib/PageObject/App/Invoices/Payment.pm
@@ -14,12 +14,11 @@ extends 'PageObject';
 use PageObject::App;
 
 __PACKAGE__->self_register(
-              'invoice-payment',
-              './/tr[contains(@class,"invoice-payment")]',
-              tag_name => 'tr',
-              attributes => {
-                  'class' => 'invoice-payment',
-              });
+    'invoice-payment',
+    './/tr[contains(@class,"invoice-payment")]',
+    tag_name => 'tr',
+    classes => ['invoice-payment'],
+    );
 
 # counterparty_type IN ('customer', 'vendor')
 has counterparty_type => (is => 'ro', isa => 'Str', required => 1);


### PR DESCRIPTION
Payment lines which are part of a payment batch may be unapproved even if the transaction itself *is* approved.
