### PR TITLE
Fix generated HTML to include closing 'html' tag

### DIFF
--- a/UI/lib/ui-header.html
+++ b/UI/lib/ui-header.html
@@ -73,6 +73,5 @@
     ${htmlWebpackPlugin.tags.bodyTags}
     <meta name="robots" content="noindex,nofollow" />
 </head>
-[% BLOCK end_html %]
+[% content %]
 </html>
-[% END %]

--- a/UI/login.html
+++ b/UI/login.html
@@ -1,4 +1,4 @@
-[% INCLUDE 'ui-header.html'
+[% WRAPPER 'ui-header.html'
         title = "LedgerSMB $version"
         include_stylesheet = ["system/login.css", "ledgersmb.css"];
 
@@ -8,4 +8,4 @@
   <center id="login">
   </center>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/logout.html
+++ b/UI/logout.html
@@ -1,4 +1,4 @@
-[% INCLUDE 'ui-header.html' %]
+[% WRAPPER 'ui-header.html' %]
 [% PROCESS elements.html %]
 <body class="lsmb [% dojo_theme %]">
 <h1 class="info">
@@ -9,4 +9,4 @@
           END; %]</h1>
 <p><a target="_top" href="login.pl">[% text('Return to the login screen.') %]</a>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/main.html
+++ b/UI/main.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html" %]
+[% WRAPPER "ui-header.html" %]
 <body id="app-main"
       class="lsmb [% dojo_theme %]">
   <div id="main" style="width:100%;height:100%">
@@ -49,4 +49,4 @@
       <Toaster />
   </div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/begin_backup.html
+++ b/UI/setup/begin_backup.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"] %]
 [% PROCESS elements.html %]
@@ -73,4 +73,4 @@ disabled = "disabled"
 </form>
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/complete.html
+++ b/UI/setup/complete.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
           stylesheet="ledgersmb.css"
           include_stylesheet=["system/setup.css"]
        %]
@@ -33,4 +33,4 @@
 [% END %]
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/complete_migration_revert.html
+++ b/UI/setup/complete_migration_revert.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"]
        %]
@@ -11,4 +11,4 @@ include_stylesheet=["system/setup.css"]
 <p><a href="setup.pl">[% text('Return to setup') %]</a></p>
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/confirm_operation.html
+++ b/UI/setup/confirm_operation.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"] %]
 [% PROCESS elements.html %]
@@ -136,4 +136,4 @@ INCLUDE input element_data = {
 [% END %]
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/consistency_results.html
+++ b/UI/setup/consistency_results.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
           stylesheet="ledgersmb.css"
           include_stylesheet=["system/setup.css"]
        %]
@@ -29,4 +29,4 @@
 
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
        stylesheet="ledgersmb.css"
        include_stylesheet=["system/setup.css"];
        PROCESS elements.html -%]
@@ -87,4 +87,4 @@
     </div>
   </div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/edit_user.html
+++ b/UI/setup/edit_user.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"];
        PROCESS "elements.html";
@@ -161,4 +161,4 @@ include_stylesheet=["system/setup.css"];
 [% END %]
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/list_databases.html
+++ b/UI/setup/list_databases.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"];
        PROCESS "elements.html";
@@ -17,4 +17,4 @@ include_stylesheet=["system/setup.css"];
               id = 'db_list' %]
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/list_users.html
+++ b/UI/setup/list_users.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
                stylesheet="ledgersmb.css"
                include_stylesheet=["system/setup.css"];
        PROCESS "elements.html";
@@ -18,4 +18,4 @@
         %]
     </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/migration_step.html
+++ b/UI/setup/migration_step.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
        stylesheet="ledgersmb.css";
        PROCESS elements.html;
        PROCESS 'dynatable.html' %]
@@ -32,4 +32,4 @@
     </form>
   </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/mismatch.html
+++ b/UI/setup/mismatch.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
           stylesheet="ledgersmb.css"
           include_stylesheet=["system/setup.css"]
        %]
@@ -13,4 +13,4 @@
 
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/new_user.html
+++ b/UI/setup/new_user.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"] %]
 [% PROCESS elements.html %]
@@ -177,4 +177,4 @@ include_stylesheet=["system/setup.css"] %]
     </div>
   </div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/select_coa.html
+++ b/UI/setup/select_coa.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"] %]
 [% PROCESS elements.html %]
@@ -104,4 +104,4 @@ END %]
 </form>
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/system_info.html
+++ b/UI/setup/system_info.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
           stylesheet="ledgersmb.css"
           include_stylesheet=["system/setup.css"]
        %]
@@ -45,4 +45,4 @@
 
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/template_info.html
+++ b/UI/setup/template_info.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
        stylesheet="ledgersmb.css"
        include_stylesheet=["system/setup.css"] ;
     PROCESS "elements.html"
@@ -31,4 +31,4 @@ PROCESS select element_data = {
 </form>
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/UI/setup/upgrade/epilogue.html
+++ b/UI/setup/upgrade/epilogue.html
@@ -1,5 +1,0 @@
-
-
-   </form>
-</body>
-</html>

--- a/UI/setup/upgrade/wrapper.html
+++ b/UI/setup/upgrade/wrapper.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"] %]
 <body class="[% dojo_theme %]">
@@ -9,3 +9,8 @@ include_stylesheet=["system/setup.css"] %]
     <input type="hidden" name="database" value="[% database %]">
     <input type="hidden" name="check_id" value="[% check_id %]">
 
+  [% validation_html %]
+
+  </form>
+</body>
+[% END %]

--- a/UI/setup/upgrade_info.html
+++ b/UI/setup/upgrade_info.html
@@ -1,4 +1,4 @@
-[% INCLUDE "ui-header.html"
+[% WRAPPER "ui-header.html"
 stylesheet="ledgersmb.css"
 include_stylesheet=["system/setup.css"] %]
 [% PROCESS elements.html %]
@@ -106,4 +106,4 @@ END %]
 </form>
 </div></div>
 </body>
-[% end_html %]
+[% END %]

--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -61,21 +61,19 @@ sub _wrap_html {
     my ($request) = shift;
 
     my $template = $request->{_wire}->get('ui');
-    unshift @HTML, $template->render_string(
-        $request,
-        'setup/upgrade/preamble',
-        {
-            check_id => _check_hashid( $failing_check ),
-            database => $request->{database},
-            resubmit_action => $request->{resubmit_action},
-            action_url => $request->{_uri}->as_string,
-        });
-
-    $template = $request->{_wire}->get('ui');
-    push @HTML, $template->render_string($request,
-                                         'setup/upgrade/epilogue');
-
-    return \@HTML;
+    return [
+        $template->render_string($request,
+                                 'setup/upgrade/wrapper',
+                                 {
+                                     check_id => _check_hashid( $failing_check ),
+                                     database => $request->{database},
+                                     resubmit_action => $request->{resubmit_action},
+                                     action_url => $request->{_uri}->as_string,
+                                 },
+                                 {
+                                     validation_html => join("\n", @HTML)
+                                 })
+        ];
 }
 
 sub _format_confirm {

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -366,7 +366,7 @@ $check =~ s|\s*\n+\s*|\n|g;
 
 
 ok( index($out,$check)>0, 'Render multiple confirmations')
-    or diff([ split /\n/, $out ],[ split /\n/, $check ],{ STYLE => 'Table', CONTEXT => 2 });
+    or diag diff([ split /\n/, $out ],[ split /\n/, $check ],{ STYLE => 'Table', CONTEXT => 2 });
 
 
 ###############################################


### PR DESCRIPTION
By making the header into a wrapper, appending the html closing tag (and other epilogue stuff) is ensured to happen.

The old code expected to add a closing tag, but really didn't, because '[% end_html %]' is a variable insertion command, not a block execution... Resulting in broken HTML being returned.
