### PR TITLE
Add unbalanced dates to help resolve undated acc_trans lines

### DIFF
--- a/UI/setup/upgrade/describe.html
+++ b/UI/setup/upgrade/describe.html
@@ -1,6 +1,4 @@
 <div class="description">
-  <h1>[% title %]</h1>
-
   <p>
     [% description %]
   </p>

--- a/UI/setup/upgrade/wrapper.html
+++ b/UI/setup/upgrade/wrapper.html
@@ -9,7 +9,9 @@ include_stylesheet=["system/setup.css"] %]
     <input type="hidden" name="database" value="[% database %]">
     <input type="hidden" name="check_id" value="[% check_id %]">
 
-  [% validation_html %]
+    <h1>[% title %]</h1>
+
+    [% validation_html %]
 
   </form>
 </body>

--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -69,6 +69,7 @@ sub _wrap_html {
                                      database => $request->{database},
                                      resubmit_action => $request->{resubmit_action},
                                      action_url => $request->{_uri}->as_string,
+                                     title => $failing_check->{title}
                                  },
                                  {
                                      validation_html => join("\n", @HTML)
@@ -113,9 +114,7 @@ sub _format_describe {
     push @HTML, $template->render_string(
         $request,
         'setup/upgrade/describe',
-        {
-            title => $check->{title},
-        },
+        { }, # no template variables which need HTML encoding
         {
             description => markdown($msg),
         });

--- a/t/16-prechecks/1.8/constrain-transaction-tables.precheck
+++ b/t/16-prechecks/1.8/constrain-transaction-tables.precheck
@@ -114,6 +114,27 @@
                   101, 100.00, 100.00, 100.00, 100.00
              ]
          ],
+         failure_session => [
+             {
+                 statement => q{
+            SELECT trans_id, transdate, sum(amount_bc) AS amount
+              FROM acc_trans
+             WHERE trans_id IN (
+                      select trans_id
+                        from acc_trans
+                       where transdate is null
+                   )
+               AND transdate IS NOT NULL
+             GROUP BY trans_id, transdate
+               HAVING sum(amount_bc) <> 0.00
+             ORDER BY trans_id, transdate
+},
+                 results => [
+                     [ qw( trans_id transdate amount ) ],
+                     [ 10795, '2020-01-01', -100 ]
+                 ],
+             }
+         ],
          response => {
              confirm => 'save',
              'acc_trans' => [

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -187,8 +187,9 @@ $out = html_formatter_context {
 $out = filter_js_src($out);
 
 my $check = qq{
+<h1>title</h1>
+
 <div class="description">
-  <h1>title</h1>
   <p>
     <p>a description</p>
   </p>
@@ -197,7 +198,7 @@ my $check = qq{
 $check =~ s|\n+\s*|\n|g;
 
 ok( (index($out,$check)>0), 'Render the description && title')
-    or diff([ split /\n/, $out ], [ split /\n/, $check ],{ STYLE => 'Table', CONTEXT => 1 });
+    or diag diff([ split /\n/, $out ], [ split /\n/, $check ],{ STYLE => 'Table', CONTEXT => 1 });
 
 
 ###############################################
@@ -240,8 +241,9 @@ $out = html_formatter_context {
 } test_request();
 
 $out = filter_js_src($out);
-$check = qq{<div class="description">
+$check = qq{
   <h1>title</h1>
+<div class="description">
   <p>
     <p>another description</p>
   </p>


### PR DESCRIPTION
By providing a list of dates per transaction (trans_id) on which the transaction is unbalanced, the user hopefully finds which dates the transaction lines belong to.
