### PR TITLE
Fix schema upgrade script when removing recurring transactions

### DIFF
--- a/sql/changes/1.6/track-deleted-transactions.sql
+++ b/sql/changes/1.6/track-deleted-transactions.sql
@@ -6,6 +6,13 @@ delete from voucher v
                       and not exists (select 1 from gl where t.id = gl.id)
                       and v.trans_id = t.id);
 
+delete from recurring r
+ where exists (select 1 from transactions t
+                where not exists (select 1 from ap where t.id = ap.id)
+                      and not exists (select 1 from ar where t.id = ar.id)
+                      and not exists (select 1 from gl where t.id = gl.id)
+                      and r.id = t.id);
+
 update new_shipto ns
    set trans_id = null
  where exists (select 1 from transactions t


### PR DESCRIPTION
Note that we can change this script without increasing its version number, because its prior version isn't in any release yet.
