### PR TITLE
Change setup.pl's page to show the loader icon while it's loading

### DIFF
--- a/UI/css/system/setup.css
+++ b/UI/css/system/setup.css
@@ -8,9 +8,30 @@ div#loading {
     background: white;
     height: 100%;
     left: 0;
+    position: absolute;
     top: 0;
     width: 100%;
     z-index: 100;
+}
+
+div.setupconsole {
+    position: relative;
+}
+
+body:not([data-lsmb-done]) #loading {
+    display: block;
+}
+
+body:not([data-lsmb-done]) #logindiv {
+    visibility: hidden;
+}
+
+body[data-lsmb-done="true"] #loading {
+    display: none;
+}
+
+body[data-lsmb-done="true"] #logindiv {
+    visibility: visible;
 }
 
 div.setupconsole {

--- a/UI/lib/ui-header.html
+++ b/UI/lib/ui-header.html
@@ -70,7 +70,6 @@
             version: "[% version %]"
         };
     </script>
-    ${htmlWebpackPlugin.tags.bodyTags}
     <meta name="robots" content="noindex,nofollow" />
 </head>
 [% content %]

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -6,13 +6,13 @@
   <div style="width:100%;height:100%">
     <div>
         <div class="setupconsole">
-            <div id="loading">
-                <img style="display: block; margin: auto auto;"
+          <div id="loading">
+                <img style="display:block;position:absolute;margin:auto;top:50%;left:50%;transsform:translateX(-50%) translateY(-50%)"
                     src="js/dijit/icons/images/loadingAnimation.gif"
                     alt="If this text is showing, there's most likely a problem with the Dojo setup"
                     title="Loading ..."
-                    width="20" height="20" />
-            </div>
+                  width="20" height="20" />
+          </div>
             <div id="logindiv">
                 <div class="login" align="center">
                     <a href="http://www.ledgersmb.org/"

--- a/UI/webpack.config.js
+++ b/UI/webpack.config.js
@@ -304,7 +304,7 @@ if (TARGET !== "readme") {
 
         // Handle HTML
         new HtmlWebpackPlugin({
-            inject: false, // Tags are injected manually in the content below
+            inject: 'body', // Tags are injected manually in the content below
             minify: false, // Adjust t/16-schema-upgrade-html.t if prodMode is used,
             filename: "ui-header.html",
             mode: prodMode ? "production" : "development",


### PR DESCRIPTION
To achieve this, loading the JS code needs to be moved to the body; however, since the HtmlWebpackPlugin doesn't distinguish LINK and SCRIPT tags, this also moves the 'bootstrap.css' stylesheet link to the body...

Fixes #7710
