### PR TITLE
Fix column title overlap in General Ledger Report

### DIFF
--- a/lib/LedgerSMB/Report/GL.pm
+++ b/lib/LedgerSMB/Report/GL.pm
@@ -109,7 +109,7 @@ sub columns {
      pwidth => '3', },
 
     {col_id => 'eca_name',
-       name => $self->Text('Vendor/Customer'),
+       name => $self->Text('Vendor Customer'),
        type => 'text',
      pwidth => '3', },
 


### PR DESCRIPTION
Fixes #7823

Separate the "Vendor/Customer" header into two words so that it will wrap.
