### PR TITLE
Fix creating an invoice from an order

### DIFF
--- a/lib/LedgerSMB/Workflow/Condition/PeriodClosed.pm
+++ b/lib/LedgerSMB/Workflow/Condition/PeriodClosed.pm
@@ -73,7 +73,8 @@ sub init {
 =head2 evaluate( $wf )
 
 Implements the C<Workflow::Condition> protocol, throwing a condition
-error in case separation of duties is I<not> enabled.
+error in case the workflow C<transdate> parameter is defined and not
+in a closed period.
 
 =cut
 

--- a/workflows/ar-ap.workflow.xml
+++ b/workflows/ar-ap.workflow.xml
@@ -7,8 +7,7 @@
     <action name="update" resulting_state="NOCHANGE" />
     <action name="post" resulting_state="SAVED">
       <condition name="!reversing" />
-      <condition name="!period-closed" />
-      <condition name="complete" />
+      <condition name="undefined-transdate-or-not-closed-period" />
     </action>
     <action name="post_and_approve" resulting_state="POSTED">
       <condition name="!reversing" />

--- a/workflows/conditions.xml
+++ b/workflows/conditions.xml
@@ -1,4 +1,12 @@
 <conditions>
+  <condition name="have-transdate"
+             test="$context->{transdate}"
+             class="Workflow::Condition::Evaluate"/>
+  <condition name="undefined-transdate-or-not-closed-period"
+             class="Workflow::Condition::LazyOR">
+    <param name="condition1" value="!have-transdate"/>
+    <param name="condition2" value="!period-closed" />
+  </condition>
   <condition name="separate-duties"
              class="LedgerSMB::Workflow::Condition::SeparateDuties" />
   <condition name="period-closed"


### PR DESCRIPTION
The 'period-closed' condition returns "true" when 'transdate' is missing, meaning that '!period-closed' returns "false" thus preventing the "post" (="save") action from being triggered when no 'transdate' has been set.

However: 'transdate' is explicitly empty when creating an invoice from an order to force the UI to apply its default vaule of "today" (instead of using the 'transdate' of the order, which is the order issue date).

Fixes #7855
