### PR TITLE
Restrict stylelint < 16

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,7 @@
             "matchUpdateTypes": [
                 "major"
             ],
+            "allowedVersions": "<16",
             "automerge": false,
             "groupName": "all stylelint related dependencies",
             "groupSlug": "stylelint-major"


### PR DESCRIPTION
Stylelint has been rewritten to use ESM; it seems webpack doesn't support that.
