### PR TITLE
Add customer/vendor name to drill-down from PNL

### DIFF
--- a/UI/Reports/PNL.html
+++ b/UI/Reports/PNL.html
@@ -2,7 +2,7 @@
 account_data = report.account_data;
 
 FORMATS = LIST_FORMATS();
-DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
+DRILLBASE = 'journal.pl?sort=transdate&amp;col_eca_name=Y&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
        _ '&amp;col_accno=Y&amp;__action=search&amp;col_running_balance=Y';


### PR DESCRIPTION
Due to change in definition of the 'Description' column, the customer/vendor name is no longer shown in the drill-down from the PNL.  This commit restores that functionality by adding the correct column as per the change to the GL search screen.
