### PR TITLE
Use centrally managed list of available documents

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -958,15 +958,9 @@ qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id
     my $wf = $form->{_wire}->get( 'workflows' )->fetch_workflow( 'AR/AP', $form->{workflow_id} );
     if ( $wf and grep { $_ eq 'print' } $wf->get_current_actions ) {
         my $printops = &print_options;
-        my $formname = {
-            name => 'formname',
-            options => [
-                {text=> $locale->text('Product Receipt'), value => 'product_receipt'},
-                ]
-        };
 
         print "<br /><br />";
-        print_select($form, $formname);
+        print_select($form, $printops->{formname});
         print_select($form, $printops->{lang});
         print_select($form, $printops->{format});
         print_select($form, $printops->{media});

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1030,18 +1030,8 @@ qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="memo_$i" 
     my $wf = $form->{_wire}->get( 'workflows' )->fetch_workflow( 'AR/AP', $form->{workflow_id} );
     if ( $wf and grep { $_ eq 'print' } $wf->get_current_actions ) {
         my $printops = &print_options;
-        my $formname = {
-            name => 'formname',
-            options => [
-                {text=> $locale->text('Sales Invoice'), value => 'invoice'},
-                {text=> $locale->text('Packing List'),  value => 'packing_list'},
-                {text=> $locale->text('Envelope'),      value => 'envelope'},
-                {text=> $locale->text('Shipping Label'), value=> 'shipping_label'},
-                ]
-        };
-
         print "<br /><br />";
-        print_select($form, $formname);
+        print_select($form, $printops->{formname});
         print_select($form, $printops->{lang});
         print_select($form, $printops->{format});
         print_select($form, $printops->{media});

--- a/old/bin/printer.pl
+++ b/old/bin/printer.pl
@@ -44,10 +44,18 @@ sub print_options {
 
     # SC: Option values extracted from other old/bin/ scripts
     if ($form->{type} && $form->{type} eq 'invoice') {
-    push @{$options{formname}{options}}, {
-        text => $locale->text('Invoice'),
-        value => 'invoice',
-        };
+        if ($form->{vc} && $form->{vc} eq 'customer') {
+            push @{$options{formname}{options}}, {
+                text => $locale->text('Invoice'),
+                value => 'invoice',
+            };
+        }
+        elsif ($form->{vc} && $form->{vc} eq 'vendor') {
+            push @{$options{formname}{options}}, {
+                text=> $locale->text('Product Receipt'),
+                value => 'product_receipt'
+            };
+        }
     }
     if ($form->{type} && $form->{type} eq 'sales_quotation') {
         push @{$options{formname}{options}}, {


### PR DESCRIPTION
Each screen has a list of documents that can be printed -- the list is centrally stored but locally overridden. Remove the overrides.
