### PR TITLE
Fix importing CoA non-empty 'links' field

### DIFF
--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -371,7 +371,7 @@ sub _process_chart {
         elsif ($settings{charttype} eq 'H') {
             $settings{type} = 'heading';
         }
-        $settings{link} = split /:/, $settings{link};
+        $settings{link} = [ split /:/, $settings{link} ];
 
         die "Unable to resolve heading $settings{heading} to its id; available: " . join(' ', sort keys %imported)
             if ($settings{heading}


### PR DESCRIPTION
When importing a CoA where the 'links' field is not empty, an error about an incorrectly formatted array value was thrown.

Fixes #7910