### PR TITLE
Fix date filters on Cash > Receipt/Payment

### DIFF
--- a/sql/modules/Payment.sql
+++ b/sql/modules/Payment.sql
@@ -51,10 +51,16 @@ RETURN QUERY EXECUTE $sql$
                 AND (e.name ilike coalesce('%'||$2||'%','%%')
                     OR EXISTS (select 1 FROM company
                                 WHERE entity_id = e.id AND tax_id = $3))
-                AND (coalesce(ec.enddate, now()::date)
-                     >= coalesce($4, now()::date))
-                AND (coalesce(ec.startdate, now()::date)
-                     <= coalesce($5, now()::date))
+                AND (
+                  $4 is null
+                  or ec.enddate is null
+                  or ec.enddate >= $4
+                )
+                AND (
+                  $5 is null
+                  or ec.startdate is null
+                  or ec.startdate <= $5
+                )
 $sql$
 USING in_account_class, in_vc_name, in_vc_idn, in_datefrom, in_dateto;
 END
@@ -123,10 +129,16 @@ RETURN QUERY EXECUTE $sql$
                 FROM entity e
                 JOIN entity_credit_account ec ON (ec.entity_id = e.id)
                         WHERE ec.entity_class = $1
-                        AND (coalesce(ec.enddate, now()::date)
-                             <= coalesce($3, now()::date))
-                        AND (coalesce(ec.startdate, now()::date)
-                             >= coalesce($2, now()::date))
+                        AND (
+                          $2 is null
+                          or ec.enddate is null
+                          or ec.enddate >= $2
+                        )
+                        AND (
+                          $3 is null
+                          or ec.startdate is null
+                          or ec.startdate <= $3
+                        )
                         AND CASE WHEN $1 = 1 THEN
                                 ec.id IN
                                 (SELECT entity_credit_account

--- a/xt/42-payment.pg
+++ b/xt/42-payment.pg
@@ -5,7 +5,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(44);
+    SELECT plan(53);
 
     -- Add data
 
@@ -229,6 +229,61 @@ BEGIN;
     SELECT results_eq('test', ARRAY[true], 'Locked Invoice not in total');
     DEALLOCATE test;
 
+    UPDATE entity_credit_account SET enddate = '2022-01-01', startdate = null;
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, null, null);
+    SELECT results_eq('test', ARRAY[1], 'Open accounts(enddate), no startdate & no enddate');
+    DEALLOCATE test;
+
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, '2020-01-01', null);
+    SELECT results_eq('test', ARRAY[1], 'Open accounts(enddate), startdate(before enddate) & no enddate');
+    DEALLOCATE test;
+
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, '2023-01-01', null);
+    SELECT results_eq('test', ARRAY[0], 'Open accounts(enddate), startdate(after enddate) & no enddate');
+    DEALLOCATE test;
+
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, null, '2023-01-01');
+    SELECT results_eq('test', ARRAY[1], 'Open accounts(enddate), no startdate & enddate(after enddate)');
+    DEALLOCATE test;
+
+    UPDATE entity_credit_account SET enddate = null, startdate = '2022-01-01';
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, null, null);
+    SELECT results_eq('test', ARRAY[1], 'Open accounts(startdate), no startdate & no enddate');
+    DEALLOCATE test;
+
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, '2020-01-01', null);
+    SELECT results_eq('test', ARRAY[1], 'Open accounts(startdate), startdate(before startdate) & no enddate');
+    DEALLOCATE test;
+
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, '2023-01-01', null);
+    SELECT results_eq('test', ARRAY[1], 'Open accounts(startdate), startdate(after startdate) & no enddate');
+    DEALLOCATE test;
+
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, null, '2023-01-01');
+    SELECT results_eq('test', ARRAY[1], 'Open accounts(startdate), no startdate & enddate(after startdate)');
+    DEALLOCATE test;
+
+    PREPARE test AS
+      SELECT count(*)::int
+      FROM payment_get_open_accounts(1, null, '2020-01-01');
+    SELECT results_eq('test', ARRAY[0], 'Open accounts(startdate), no startdate & enddate(before startdate)');
+    DEALLOCATE test;
 
     -- Test vouchers (TODO)
 


### PR DESCRIPTION
Before, entities with open invoices *and* an end date were filtered out when no filter criteria were entered. This is counter-intuitive at best, but probably wrong, taking the remainder of the UI into account.