### PR TITLE
Remove 'entity_class' from the entity

### DIFF
--- a/UI/Contact/divs/company.html
+++ b/UI/Contact/divs/company.html
@@ -4,16 +4,12 @@
      [% IF request.target_div == 'company_div' %]data-dojo-props="selected:true"[% END %]
 
      >
-        <div class="listtop"><strong>[%
-    IF (entity_id && entity_class == 1) ;
-        text("Edit Vendor") ;
-    ELSIF (entity_class == 1) ;
-        text("Add Vendor") ;
-    ELSIF (entity_id && entity_class == 2) ;
-        text("Edit Customer") ;
-    ELSE ;
-        text("Add Customer") ;
-    END ;
+  <div class="listtop"><strong>[%
+      IF entity_id.defined ;
+      text("Edit");
+      ELSE ;
+      text("Add");
+      END;
     %]</strong></div>
 <form data-dojo-type="lsmb/Form" id="company" method="post" action="[% request.script %]">
 [% PROCESS input element_data = {
@@ -60,22 +56,6 @@
                 name = "control_code"
                 value = company.control_code
                 size = "20"
-        } %]
-        [% IF !created_as_class;
-                created_as_class = entity_class;
-        END; # IF !created_as_class %]
-        [% company_entity_class = company.entity_class;
-        IF !company_entity_class;
-              company_entity_class = request.entity_class;
-        END;
-        PROCESS select element_data = {
-                id = 'company-entity-class'
-                name = "entity_class"
-                options = entity_classes
-                default_values = [company_entity_class]
-                text_attr = 'class'
-                value_attr = 'id'
-                label = text('Class')
         } %]
         [% PROCESS input element_data = {
                 label = text('Name')

--- a/UI/Contact/divs/credit.html
+++ b/UI/Contact/divs/credit.html
@@ -53,6 +53,9 @@ PROCESS dynatable
                  ec=account_class;
                  IF !ec;
                     ec=entity_class;
+                    IF !ec;
+                       ec=2;
+                    END;
                  END;
               END;
         %]
@@ -70,8 +73,19 @@ PROCESS dynatable
            value_attr = 'id'
                 label = text('Class')
         } %]</td>
-
-
+        <td>
+          [%
+          INCLUDE button element_data = {
+          text = text('Update')
+          class="submit"
+          type="submit"
+          name="__action"
+          value="update_credit"
+          };
+          %]
+        </td>
+        </tr>
+        <tr>
         <td>
         [% PROCESS input element_data = {
                 title = text("Number"),

--- a/UI/Contact/divs/person.html
+++ b/UI/Contact/divs/person.html
@@ -3,17 +3,13 @@
      data-dojo-type="dijit/layout/ContentPane"
      [% IF request.target_div == 'person_div' %]data-dojo-props="selected:true"[% END %]
      >
-<div class="listtop"><strong>[%
-    IF (entity_id && entity_class == 1) ;
-        text("Edit Vendor") ;
-    ELSIF (entity_class == 1) ;
-        text("Add Vendor") ;
-    ELSIF (entity_id && entity_class == 2) ;
-        text("Edit Customer") ;
-    ELSE ;
-        text("Add Customer") ;
-    END ;
-    %]</strong></div>
+  <div class="listtop"><strong>[%
+      IF entity_id.defined ;
+      text("Edit");
+      ELSE ;
+      text("Add");
+      END ;
+      %]</strong></div>
 <form data-dojo-type="lsmb/Form" name="customer" method="post" action="[% request.script %]">
 [% PROCESS input element_data = { # Only for generate_control_code
                   id = 'person-target-div'
@@ -60,20 +56,6 @@
                 value = person.control_code
                 size = "20"
         } %]
-        [% IF !created_as_class;
-                created_as_class = entity_class;
-        END; # IF !created_as_class %]
-        [%
-        PROCESS select element_data = {
-                id = 'person-entity-class'
-                name = "entity_class"
-                options = entity_classes
-                default_values = [entity_class]
-                text_attr = 'class'
-                value_attr = 'id'
-                label = text('Class')
-        } %]
-
   [%
         PROCESS select element_data = {
                   label = text('Salutation')

--- a/UI/Contact/divs/person.html
+++ b/UI/Contact/divs/person.html
@@ -10,7 +10,7 @@
       text("Add");
       END ;
       %]</strong></div>
-<form data-dojo-type="lsmb/Form" name="customer" method="post" action="[% request.script %]">
+  <form data-dojo-type="lsmb/Form" name="customer" method="post" action="[% request.script %]">
 [% PROCESS input element_data = { # Only for generate_control_code
                   id = 'person-target-div'
                 type = "hidden"
@@ -148,10 +148,10 @@
                         name="__action"
                         value="save_person"
                 } %]
-</form>
+  </form>
 [% FOREACH n = notes %]
 <div class="note">
-<div class="note_contents">[% n.note %]</div>
+  <div class="note_contents">[% n.note %]</div>
 </div>
 [% END %]
 </div>

--- a/UI/tests/specs/data/Invoices.sql
+++ b/UI/tests/specs/data/Invoices.sql
@@ -1,7 +1,7 @@
-SELECT * FROM "xyz"."company__save"('C-0', '2', 'Customer 1', NULL, NULL, NULL, '1', NULL, NULL);
+SELECT * FROM "xyz"."company__save"('C-0', 'Customer 1', NULL, NULL, NULL, '1', NULL, NULL);
 SELECT * FROM "xyz"."eca__save"(NULL, '2', '2', NULL, NULL, NULL, NULL, NULL, NULL, 'Customer 1', NULL, NULL, NULL, 'USD', NULL, NULL, NULL, '3', NULL, NULL, NULL, NULL);
 
-SELECT * FROM "xyz"."company__save"('C-1', '2', 'Customer 2', NULL, NULL, NULL, '1', NULL, NULL);
+SELECT * FROM "xyz"."company__save"('C-1', 'Customer 2', NULL, NULL, NULL, '1', NULL, NULL);
 SELECT * FROM "xyz"."eca__save"(NULL, '2', '3', NULL, NULL, NULL, NULL, NULL, NULL, 'Customer 2', NULL, NULL, NULL, 'USD', NULL, NULL, NULL, '3', NULL, NULL, NULL, NULL);
 
 INSERT INTO parts (description,inventory_accno_id,expense_accno_id,sellprice,income_accno_id,partnumber,unit)

--- a/UI/tests/specs/data/Orders.sql
+++ b/UI/tests/specs/data/Orders.sql
@@ -1,7 +1,7 @@
-SELECT * FROM "xyz"."company__save"('C-0', '2', 'Customer 1', NULL, NULL, NULL, '1', NULL, NULL);
+SELECT * FROM "xyz"."company__save"('C-0', 'Customer 1', NULL, NULL, NULL, '1', NULL, NULL);
 SELECT * FROM "xyz"."eca__save"(NULL, '2', '2', NULL, NULL, NULL, NULL, NULL, NULL, 'Customer 1', NULL, NULL, NULL, 'USD', NULL, NULL, NULL, '3', NULL, NULL, NULL, NULL);
 
-SELECT * FROM "xyz"."company__save"('C-1', '2', 'Customer 2', NULL, NULL, NULL, '1', NULL, NULL);
+SELECT * FROM "xyz"."company__save"('C-1', 'Customer 2', NULL, NULL, NULL, '1', NULL, NULL);
 SELECT * FROM "xyz"."eca__save"(NULL, '2', '3', NULL, NULL, NULL, NULL, NULL, NULL, 'Customer 2', NULL, NULL, NULL, 'USD', NULL, NULL, NULL, '3', NULL, NULL, NULL, NULL);
 
 update defaults set value = 'USD' where setting_key = 'curr';

--- a/lib/LedgerSMB/Entity.pm
+++ b/lib/LedgerSMB/Entity.pm
@@ -67,17 +67,7 @@ Name of country (optional)
 
 has 'country_name' => (is => 'rw', isa => 'Str', required => 0);
 
-=item entity_class
-
-Primary class of entity.  This is mostly for reporting purposes.  See entity_class
-table in database for list of valid values, but 1 is for vendors, 2 for customers,
-3 for employees, etc.
-
 =back
-
-=cut
-
-has 'entity_class' => (is => 'rw', isa => 'Int', required => 1);
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -666,6 +666,19 @@ sub save_credit_new {
     return save_credit($request);
 }
 
+=item update_credit($request)
+
+Reload the drop-downs linked to the Class drop-down (customer/vendor)
+
+=cut
+
+
+sub update_credit {
+    my ($request) = @_;
+    $request->{target_div} = 'credit_div';
+    return get($request);
+}
+
 =item save_location
 
 Adds a location to the company as defined in the inherited object

--- a/sql/changes/1.12/drop-entity-class-entity-trigger.sql
+++ b/sql/changes/1.12/drop-entity-class-entity-trigger.sql
@@ -1,0 +1,4 @@
+
+DROP TRIGGER IF EXISTS eclass_perms_check ON entity;
+
+alter table entity drop column entity_class;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -185,3 +185,4 @@ mc/delete-migration-validation-data.sql
 # 1.12 changes
 1.12/migrate_to_identity.sql
 1.12/add-stored-order-quote-taxes.sql
+1.12/drop-entity-class-entity-trigger.sql

--- a/sql/modules/Company.sql
+++ b/sql/modules/Company.sql
@@ -14,7 +14,6 @@ DROP TYPE IF EXISTS company_entity CASCADE;
 
 CREATE TYPE company_entity AS(
   entity_id int,
-  entity_class int,
   legal_name text,
   tax_id text,
   sales_tax_id text,
@@ -363,7 +362,7 @@ RETURN QUERY EXECUTE $sql$
 LEFT JOIN entity_credit_account ec ON (ec.entity_id = e.id)
 LEFT JOIN business b ON (ec.business_id = b.id)
     WHERE ($1 is null
-           OR coalesce(ec.entity_class, e.entity_class) = $1)
+           OR ec.entity_class = $1)
           AND ($14 IS NULL
                OR e.control_code like $14 || '%')
           AND (($3 IS NULL AND $2 IS NULL)
@@ -614,7 +613,7 @@ entity class.$$;
 CREATE OR REPLACE FUNCTION company__get (in_entity_id int)
 RETURNS company_entity AS
 $$
-        SELECT c.entity_id, e.entity_class, c.legal_name, c.tax_id, c.sales_tax_id,
+        SELECT c.entity_id, c.legal_name, c.tax_id, c.sales_tax_id,
                c.license_number, c.sic_code, e.control_code, e.country_id
           FROM company c
           JOIN entity e ON e.id = c.entity_id
@@ -627,7 +626,7 @@ $$ Returns all attributes for the company attached to the entity.$$;
 CREATE OR REPLACE FUNCTION company__get_by_cc (in_control_code text)
 RETURNS company_entity AS
 $$
-        SELECT c.entity_id, e.entity_class, c.legal_name, c.tax_id, c.sales_tax_id,
+        SELECT c.entity_id, c.legal_name, c.tax_id, c.sales_tax_id,
                c.license_number, c.sic_code, e.control_code, e.country_id
           FROM company c
           JOIN entity e ON e.id = c.entity_id
@@ -727,8 +726,15 @@ DROP FUNCTION IF EXISTS company__save (
     in_sales_tax_id text, in_license_number text
 );
 
-CREATE OR REPLACE FUNCTION company__save (
+DROP FUNCTION IF EXISTS company__save (
     in_control_code text, in_entity_class int,
+    in_legal_name text, in_tax_id TEXT,
+    in_entity_id int, in_sic_code text,in_country_id int,
+    in_sales_tax_id text, in_license_number text
+);
+
+CREATE OR REPLACE FUNCTION company__save (
+    in_control_code text,
     in_legal_name text, in_tax_id TEXT,
     in_entity_id int, in_sic_code text,in_country_id int,
     in_sales_tax_id text, in_license_number text
@@ -746,7 +752,6 @@ BEGIN
 
         UPDATE entity
         SET name = in_legal_name,
-                entity_class = in_entity_class,
                 control_code = t_control_code,
                 country_id   = in_country_id
         WHERE id = in_entity_id;
@@ -754,8 +759,8 @@ BEGIN
         IF FOUND THEN
                 t_entity_id = in_entity_id;
         ELSE
-                INSERT INTO entity (name, entity_class, control_code,country_id)
-                VALUES (in_legal_name, in_entity_class, t_control_code,in_country_id);
+                INSERT INTO entity (name, control_code,country_id)
+                VALUES (in_legal_name, t_control_code,in_country_id);
                 t_entity_id := currval('entity_id_seq');
         END IF;
 
@@ -781,7 +786,7 @@ END;
 $$ LANGUAGE PLPGSQL;
 
 COMMENT ON  FUNCTION company__save (
-    in_control_code text, in_entity_class int,
+    in_control_code text,
     in_legal_name text, in_tax_id TEXT,
     in_entity_id int, in_sic_code text,in_country_id int,
     in_sales_tax_id text, in_license_number text

--- a/sql/modules/Company.sql
+++ b/sql/modules/Company.sql
@@ -25,6 +25,11 @@ CREATE TYPE company_entity AS(
 
 DROP TYPE IF EXISTS eca__pricematrix CASCADE;
 
+COMMENT ON TYPE company_entity IS
+  $$ Return type to query companies, combining data from the 'entity'
+  and 'company' tables.
+  $$;
+
 CREATE TYPE eca__pricematrix AS (
   parts_id int,
   int_partnumber text,

--- a/sql/modules/Payment.sql
+++ b/sql/modules/Payment.sql
@@ -44,7 +44,7 @@ BEGIN
 RETURN QUERY EXECUTE $sql$
               SELECT ec.id, coalesce(ec.pay_to_name, e.name ||
                      coalesce(':' || ec.description,'')) as name,
-                     e.entity_class, ec.discount_account_id, ec.meta_number
+                     ec.entity_class, ec.discount_account_id, ec.meta_number
                 FROM entity_credit_account ec
                 JOIN entity e ON (ec.entity_id = e.id)
                 WHERE ec.entity_class = $1
@@ -84,7 +84,7 @@ DECLARE
 BEGIN
 EXECUTE $sql$
  SELECT ec.id, coalesce(ec.pay_to_name, cp.name  || coalesce(':' || ec.description, ''), '') as name,
-        e.entity_class, ec.discount_account_id, ec.meta_number
+        ec.entity_class, ec.discount_account_id, ec.meta_number
  FROM entity_credit_account ec
  JOIN entity e ON (ec.entity_id = e.id)
  JOIN (
@@ -181,7 +181,7 @@ RETURN QUERY EXECUTE $sql$
                         e.name, ec.entity_class
                 FROM entity e
                 JOIN entity_credit_account ec ON (ec.entity_id = e.id)
-                                WHERE e.entity_class = $1
+                                WHERE ec.entity_class = $1
 $sql$
 USING in_account_class;
 END
@@ -1530,7 +1530,7 @@ CREATE OR REPLACE FUNCTION payment_get_open_overpayment_entities(in_account_clas
 $$
 BEGIN
 RETURN QUERY EXECUTE $sql$
-                SELECT DISTINCT entity_credit_id, legal_name, e.entity_class, null::int, o.meta_number
+                SELECT DISTINCT entity_credit_id, legal_name, ec.entity_class, null::int, o.meta_number
                 FROM overpayments o
                 JOIN entity e ON (e.id=o.entity_id)
                 WHERE available <> 0 AND $1 = payment_class

--- a/sql/modules/Person.sql
+++ b/sql/modules/Person.sql
@@ -47,7 +47,6 @@ CREATE TYPE person_entity AS (
     first_name text,
     middle_name text,
     last_name text,
-    entity_class int,
     birthdate date,
     personal_id text
 );
@@ -56,7 +55,7 @@ CREATE FUNCTION person__get(in_entity_id int)
 RETURNS person_entity AS
 $$
 SELECT e.id, e.control_code, e.name, e.country_id, c.name,
-       p.first_name, p.middle_name, p.last_name, e.entity_class,
+       p.first_name, p.middle_name, p.last_name,
        p.birthdate, p.personal_id
   FROM entity e
   JOIN country c ON c.id = e.country_id
@@ -68,7 +67,7 @@ CREATE FUNCTION person__get_by_cc(in_control_code text)
 RETURNS person_entity AS
 $$
 SELECT e.id, e.control_code, e.name, e.country_id, c.name,
-       p.first_name, p.middle_name, p.last_name, e.entity_class,
+       p.first_name, p.middle_name, p.last_name,
        p.birthdate, p.personal_id
   FROM entity e
   JOIN country c ON c.id = e.country_id
@@ -99,7 +98,7 @@ RETURNS INT AS $$
         p_id int;
     BEGIN
 
-    select * into e from entity where id = in_entity_id and entity_class = 3;
+    select * into e from entity where id = in_entity_id;
     e_id := in_entity_id;
 
     IF FOUND THEN
@@ -108,8 +107,8 @@ RETURNS INT AS $$
                country_id = in_country_id
          WHERE id = in_entity_id;
     ELSE
-        INSERT INTO entity (name, entity_class, country_id)
-        values (in_first_name || ' ' || in_last_name, 3, in_country_id);
+        INSERT INTO entity (name, country_id)
+        values (in_first_name || ' ' || in_last_name, in_country_id);
         e_id := currval('entity_id_seq');
 
     END IF;

--- a/sql/modules/Robot.sql
+++ b/sql/modules/Robot.sql
@@ -27,15 +27,14 @@ CREATE TYPE robot_entity AS (
     country_name text,
     first_name text,
     middle_name text,
-    last_name text,
-    entity_class int
+    last_name text
 );
 
 CREATE FUNCTION robot__get(in_entity_id int)
 RETURNS robot_entity AS
 $$
 SELECT e.id, e.control_code, e.name, e.country_id, c.name,
-       p.first_name, p.middle_name, p.last_name, e.entity_class
+       p.first_name, p.middle_name, p.last_name
   FROM entity e
   JOIN country c ON c.id = e.country_id
   JOIN robot p ON p.entity_id = e.id
@@ -46,7 +45,7 @@ CREATE FUNCTION robot__get_by_cc(in_control_code text)
 RETURNS robot_entity AS
 $$
 SELECT e.id, e.control_code, e.name, e.country_id, c.name,
-       p.first_name, p.middle_name, p.last_name, e.entity_class
+       p.first_name, p.middle_name, p.last_name
   FROM entity e
   JOIN country c ON c.id = e.country_id
   JOIN robot p ON p.entity_id = e.id
@@ -69,7 +68,7 @@ RETURNS INT AS $$
         p_id int;
     BEGIN
 
-    select * into e from entity where id = in_entity_id and entity_class = 3;
+    select * into e from entity where id = in_entity_id;
     e_id := in_entity_id;
 
     IF FOUND THEN
@@ -78,8 +77,8 @@ RETURNS INT AS $$
                country_id = in_country_id
          WHERE id = in_entity_id;
     ELSE
-        INSERT INTO entity (name, entity_class, country_id)
-        values (in_first_name || ' ' || in_last_name, 3, in_country_id);
+        INSERT INTO entity (name, country_id)
+        values (in_first_name || ' ' || in_last_name, in_country_id);
         e_id := currval('entity_id_seq');
 
     END IF;

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -2030,11 +2030,6 @@ END IF;
 END;
 $$ LANGUAGE PLPGSQL;
 
-DROP TRIGGER IF EXISTS eclass_perms_check ON entity;
-CREATE TRIGGER eclass_perms_check
-BEFORE INSERT OR UPDATE OR DELETE ON entity
-FOR EACH ROW EXECUTE PROCEDURE tg_enforce_perms_eclass();
-
 DROP TRIGGER IF EXISTS eclass_perms_check ON entity_credit_account;
 CREATE TRIGGER eclass_perms_check
 BEFORE INSERT OR UPDATE OR DELETE ON entity_credit_account

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -72,8 +72,8 @@ BEGIN;
            (-5, 'TS5', 'COGS Test Series 5', -5101, -5102, -5104, -5103),
            (-6, 'TS5/part2', 'COGS Test Series 5/part2', -6101, -6102, -6104, -6103);
 
-    INSERT INTO entity (id, name, country_id, entity_class)
-    VALUES (-1000, 'Test act', 232, 1);
+    INSERT INTO entity (id, name, country_id)
+    VALUES (-1000, 'Test act', 232);
 
     INSERT INTO entity_credit_account
             (id, entity_class, meta_number, entity_id, curr, ar_ap_account_id)

--- a/xt/42-company.pg
+++ b/xt/42-company.pg
@@ -24,7 +24,7 @@ BEGIN;
     SELECT has_function('company__get_by_cc',ARRAY['text']);
     SELECT has_function('company__get',ARRAY['integer']);
     SELECT has_function('company__next_id','{}'::text[]);
-    SELECT has_function('company__save',ARRAY['text','integer','text','text','integer','text','integer','text','text']);
+    SELECT has_function('company__save',ARRAY['text','text','text','integer','text','integer','text','text']);
     SELECT has_function('contact_class__list','{}'::text[]);
     SELECT has_function('contact__search',ARRAY['integer','text','text[]','text','text','text','text','text','text','date','date','integer','text','text','text','boolean']);
     SELECT has_function('eca__delete_contact',ARRAY['integer','integer','text']);
@@ -67,7 +67,7 @@ BEGIN;
 
     INSERT INTO sic (code, description) VALUES ('1234', '1234 Desc');
     PREPARE test AS SELECT
-        company__save ('TESTING...', 1,'TESTING', 'TESTING', NULL, '1234',
+        company__save ('TESTING...', 'TESTING', 'TESTING', NULL, '1234',
                         232, 'st-123', 'ubi-123-456-789')
                 IS NOT NULL;
     SELECT results_eq('test',ARRAY[true],'Saving Company');

--- a/xt/42-draft.pg
+++ b/xt/42-draft.pg
@@ -29,8 +29,8 @@ BEGIN;
 
     -- Set specific data
 
-    INSERT INTO entity (id, entity_class, name, country_id)
-    VALUES (-1000, 1, '__TEST', 243);
+    INSERT INTO entity (id, name, country_id)
+    VALUES (-1000, '__TEST', 243);
 
     INSERT INTO entity_credit_account (id, meta_number, entity_class, entity_id, ar_ap_account_id, curr)
     VALUES (-1000, '_testv', 1, -1000, -1000, 'XTS');

--- a/xt/42-goods.pg
+++ b/xt/42-goods.pg
@@ -119,8 +119,8 @@ BEGIN;
                 (-6, -8, 5),
                 (-9, -10, 7);
 
-    INSERT INTO entity (id, name, country_id, entity_class)
-    VALUES (-1000, 'Test act', 232, 1);
+    INSERT INTO entity (id, name, country_id)
+    VALUES (-1000, 'Test act', 232);
 
     INSERT INTO entity_credit_account
             (id, entity_class, meta_number, entity_id, curr, ar_ap_account_id)

--- a/xt/42-voucher.pg
+++ b/xt/42-voucher.pg
@@ -41,8 +41,8 @@ BEGIN;
     SELECT results_eq('test',ARRAY[true],'Batch Created');
     DEALLOCATE test;
 
-    INSERT INTO entity (id, name, entity_class, control_code, country_id)
-    values (-3, 'Test', 1, 'test', 242);
+    INSERT INTO entity (id, name, control_code, country_id)
+    values (-3, 'Test', 'test', 242);
     INSERT INTO entity_credit_account (entity_id, id, meta_number, entity_class, ar_ap_account_id, curr)
     values (-3, -1, 'Test', 1, -1000, 'XTS');
 

--- a/xt/45.2-ledgersmb-file-internal.t
+++ b/xt/45.2-ledgersmb-file-internal.t
@@ -74,12 +74,10 @@ $file = LedgerSMB::File::Internal->new(
 $dbh->do("
     INSERT INTO entity(
         name,
-        entity_class,
         control_code,
         country_id
     ) VALUES (
         'LSMB-FILE-TEST',
-        3, -- Employee
         'LSMB-FILE-TEST',
         1  -- Ascension Island
     )

--- a/xt/data/42-pg/Base.sql
+++ b/xt/data/42-pg/Base.sql
@@ -7,11 +7,11 @@ CREATE TEMPORARY TABLE test_result (
 INSERT INTO currency (curr, description)
 VALUES ('XTS', 'Code reserved for testing purposes');
 
-INSERT INTO entity (id, name, entity_class, control_code, country_id)
-VALUES (-100, 'Testing.....', 3, '_TESTING.....', 242);
+INSERT INTO entity (id, name, control_code, country_id)
+VALUES (-100, 'Testing.....', '_TESTING.....', 242);
 
-INSERT INTO entity (id, name, entity_class, control_code, country_id)
-VALUES (-101, 'Testing..... 2', 3, '_TEST2', 242);
+INSERT INTO entity (id, name, control_code, country_id)
+VALUES (-101, 'Testing..... 2', '_TEST2', 242);
 
 INSERT INTO person(id, entity_id, first_name, last_name)
 values (-100, -100, 'Test', 'User');
@@ -23,8 +23,8 @@ SELECT -100, CURRENT_USER;
 
 INSERT INTO entity_employee(entity_id) values (-100);
 
-INSERT INTO entity(name, id, entity_class, control_code, country_id)
-values ('test user 1', -200, 3, 'Test User 1', 242);
+INSERT INTO entity(name, id, control_code, country_id)
+values ('test user 1', -200, 'Test User 1', 242);
 
 select account_heading_save(NULL, '000000000000000000000', 'TEST', NULL);
 

--- a/xt/data/42-pg/Reconciliation.sql
+++ b/xt/data/42-pg/Reconciliation.sql
@@ -34,8 +34,8 @@ INSERT INTO account(id, accno, description, category, heading, contra)
 values (-201, '-11112', 'Test Act 2', 'A',
         (select id from account_heading WHERE accno  = '000000000000000000000'), false);
 
-INSERT INTO entity (id, control_code, name, entity_class, country_id)
-values (-201, '-11111', 'Test 1', 1, 242);
+INSERT INTO entity (id, control_code, name, country_id)
+values (-201, '-11111', 'Test 1', 242);
 
 INSERT INTO entity_credit_account (entity_id, id, meta_number, entity_class, ar_ap_account_id, curr)
 values (-201, -200, 'T-11111', 1, -1000, 'XTS');
@@ -197,8 +197,8 @@ values (-202, '-11113', 'Test Act 3', 'A',
         (select id from account_heading WHERE accno  = '000000000000000000000'), false);
 
 
-INSERT INTO entity (id, control_code, name, entity_class, country_id)
-values (-202, '-11113', 'Test 1', 1, 242);
+INSERT INTO entity (id, control_code, name, country_id)
+values (-202, '-11113', 'Test 1', 242);
 INSERT INTO entity_credit_account (entity_id, id, meta_number, entity_class, ar_ap_account_id, curr)
 values (-202, -202, 'T-11113', 1, -1000, 'XTS');
 

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -202,7 +202,7 @@ Given qr/an unpaid AP transaction with these values:$/, sub {
             entity_credit_account.entity_id = entity.id
         )
         WHERE entity.name = ?
-        AND entity.entity_class = 1
+        AND entity_credit_account.entity_class = 1
         LIMIT 1
         RETURNING ap.id
     ");


### PR DESCRIPTION
This removes the confusing point where entities are employees, customers or vendors, but they are not truely, because either an employee, customer or vendor (i.e. "accounts") still need to be created.