### PR TITLE
Create new workflows for recurring items

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1503,12 +1503,6 @@ sub print_form {
 
             $trans_wf = $form->{_wire}->get('workflows')
                 ->fetch_workflow( 'AR/AP', $wf_id );
-            if (grep { $_ eq 'save' } $trans_wf->get_current_actions) {
-                $trans_wf->execute_action( 'save' );
-            }
-            if (grep { $_ eq 'post' } $trans_wf->get_current_actions) {
-                $trans_wf->execute_action( 'post' );
-            }
         }
 
         $trans_wf->context->param( '_email_data' => $email_data );


### PR DESCRIPTION
Each time a new items is spawned from a recurring item, that item needs to have a workflow of its own.  However, before this commit, the items all shared the same one which results in problems with the state management of the spawned items.
