### PR TITLE
1099 tax form printing fixed

### DIFF
--- a/lib/LedgerSMB/Company_Config.pm
+++ b/lib/LedgerSMB/Company_Config.pm
@@ -34,7 +34,7 @@ use strict;
 use warnings;
 use LedgerSMB::Setting;
 
-my @company_settings = qw(templates businessnumber weightunit curr
+my @company_settings = qw(templates weightunit curr
                           default_email_from default_email_to
                           default_email_bcc  default_email_cc
                           default_language default_country papersize

--- a/lib/LedgerSMB/Report/Taxform/Details.pm
+++ b/lib/LedgerSMB/Report/Taxform/Details.pm
@@ -137,11 +137,12 @@ sub buttons {
     my ($self) = @_;
     return [{name => '__action',
              type => 'submit',
+             'data-dojo-type' => 'lsmb/PrintButton',
+             'data-dojo-props' => 'minimalGET: false',
              text => $self->Text('Print'),
             value => 'print'}];
 }
 
-=head1 METHODS
 =head1 METHODS
 
 =head2 run_report

--- a/lib/LedgerSMB/Report/Taxform/Summary.pm
+++ b/lib/LedgerSMB/Report/Taxform/Summary.pm
@@ -145,6 +145,8 @@ sub buttons {
     my ($self) = @_;
     return [{name => '__action',
              type => 'submit',
+             'data-dojo-type' => 'lsmb/PrintButton',
+             'data-dojo-props' => 'minimalGET: false',
              text => $self->Text('Print'),
             value => 'print'}];
 }

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -129,24 +129,41 @@ sub generate_report {
         $request->call_procedure(
             funcname => 'tax_form__get', args => [$request->{tax_form_id}]);
 
+    my $params = {
+        from_date   => $request->parse_date( $request->{from_date} ),
+        to_date     => $request->parse_date( $request->{to_date} ),
+        tax_form_id => $request->{tax_form_id},
+        is_accrual  => $tf->{is_accrual},
+        media       => 'screen',
+    };
+    my @options = (
+        {
+            name     => 'form_name',
+            required => 1,
+            options  => [
+                {},
+                { text => '1099-INT',  value => '1099-INT' },
+                { text => '1099-MISC', value => '1099-MISC' },
+                ]
+        }
+    );
     my $report;
     if ($request->{meta_number}){
         $report = LedgerSMB::Report::Taxform::Details->new(
             %$request,
-            from_date  => $request->parse_date( $request->{from_date} ),
-            to_date  => $request->parse_date( $request->{to_date} ),
+            %$params,
+            options => \@options,
             formatter_options => $request->formatter_options,
-            taxform    => $tf->{form_name},
-            is_accrual => $tf->{is_accrual});
+            );
     } else {
         $report = LedgerSMB::Report::Taxform::Summary->new(
             %$request,
-            from_date  => $request->parse_date( $request->{from_date} ),
-            to_date  => $request->parse_date( $request->{to_date} ),
+            %$params,
+            options => \@options,
             formatter_options => $request->formatter_options,
-            taxform    => $tf->{form_name},
-            is_accrual => $tf->{is_accrual});
+            );
     }
+    $request->{hiddens} = $params;
     return $request->render_report($report);
 }
 
@@ -203,6 +220,7 @@ sub print {
        }
        $report->rows(\@rows);
     }
+    $request->{results} = $report->rows;
 
     # Business settings for 1099
     #
@@ -216,7 +234,8 @@ sub print {
         user     => $request->{_user},
         locale   => $request->{_locale},
         path     => 'DB',
-        template => $request->{taxform_name},
+        template => $request->{form_name},
+        formatter_options => $request->formatter_options,
         format_plugin   =>
            $request->{_wire}->get( 'output_formatter' )->get( $request->{format}),
     );

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -225,6 +225,7 @@ sub print {
     # Business settings for 1099
     #
     my $cc = $request->{_company_config};
+    $request->{SETTINGS}          = $cc;
     $request->{company_name}      = $cc->{company_name};
     $request->{company_address}   = $cc->{company_address};
     $request->{company_telephone} = $cc->{company_phone};

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -239,7 +239,7 @@ sub print {
         format_plugin   =>
            $request->{_wire}->get( 'output_formatter' )->get( $request->{format}),
     );
-    $template->render($request);
+    $template->render({ %$request, SETTINGS => $cc });
 
     my $body = $template->{output};
     utf8::encode($body) if utf8::is_utf8($body);  ## no critic

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -226,10 +226,6 @@ sub print {
     #
     my $cc = $request->{_company_config};
     $request->{SETTINGS}          = $cc;
-    $request->{company_name}      = $cc->{company_name};
-    $request->{company_address}   = $cc->{company_address};
-    $request->{company_telephone} = $cc->{company_phone};
-    $request->{my_tax_code}       = $cc->{businessnumber};
 
     my $template = LedgerSMB::Template->new( # printed document
         user     => $request->{_user},

--- a/sql/changes/1.12/reconciliation-workflow.sql
+++ b/sql/changes/1.12/reconciliation-workflow.sql
@@ -21,8 +21,12 @@ create function pg_temp.new_workflow(approved boolean, submitted boolean,
    returning workflow_id;
 $$ language sql;
 
+
+SET session_replication_role = replica; -- disable triggers
 update cr_report
    set workflow_id = pg_temp.new_workflow(approved, submitted, deleted);
+SET session_replication_role = DEFAULT; -- re-enable triggers
+
 
 insert into
  workflow_history (

--- a/sql/modules/1099_reports.sql
+++ b/sql/modules/1099_reports.sql
@@ -24,6 +24,13 @@ CREATE TYPE tax_form_report_item AS (
     meta_number character varying(32),
     tax_id text,
     sales_tax_id text,
+    line_one text,
+    line_two text,
+    line_three text,
+    city text,
+    state text,
+    mail_code text,
+    country_id integer,
     acc_sum numeric,
     invoice_sum numeric,
     total_sum numeric);
@@ -38,6 +45,13 @@ CREATE TYPE tax_form_report_detail_item AS (
     meta_number character varying(32),
     tax_id text,
     sales_tax_id text,
+    line_one text,
+    line_two text,
+    line_three text,
+    city text,
+    state text,
+    mail_code text,
+    country_id integer,
     acc_sum numeric,
     invoice_sum numeric,
     total_sum numeric,
@@ -53,6 +67,8 @@ RETURNS SETOF tax_form_report_item AS $BODY$
                      entity_credit_account.entity_class, entity.control_code,
                      entity_credit_account.meta_number,
                      company.tax_id, company.sales_tax_id,
+                     addr.line_one, addr.line_two, addr.line_three,
+                     addr.city, addr.state, addr.mail_code, addr.country_id,
                      sum(CASE WHEN gl.amount_bc = 0 THEN 0
                               WHEN relation = 'acc_trans'
                           THEN ac.reportable_amount_bc * pmt.amount_bc
@@ -116,8 +132,36 @@ RETURNS SETOF tax_form_report_item AS $BODY$
                 JOIN entity ON (entity.id = entity_credit_account.entity_id)
                 JOIN company ON (entity.id = company.entity_id)
                 JOIN country_tax_form ON (entity_credit_account.taxform_id = country_tax_form.id)
-               WHERE country_tax_form.id = in_tax_form_id
-             GROUP BY legal_name, meta_number, company.tax_id, company.sales_tax_id, company.entity_id, entity_credit_account.entity_class, entity.control_code, entity_credit_account.id
+  LEFT JOIN LATERAL (
+    SELECT * FROM (
+      select * from (
+      select entity_credit_account.entity_id, l.*
+        from eca_to_location eca2l
+               join location_class lc on lc.id = eca2l.location_class
+               join location l on l.id = eca2l.location_id
+       where eca2l.credit_id = entity_credit_account.id -- this is the LATERAL!
+         and lc.authoritative
+       order by lc.id, l.created
+      ) y
+       union all
+      select * from (
+      select entity.id, l.*
+        from entity_to_location e2l
+               join location_class lc on lc.id = e2l.location_class
+               join location l on l.id = e2l.location_id
+       where e2l.entity_id = entity.id -- this is the LATERAL!
+         and lc.authoritative
+       order by lc.id, l.created
+      ) z
+    ) x
+    LIMIT 1
+  ) addr ON addr.entity_id = entity.id
+  WHERE country_tax_form.id = in_tax_form_id
+  GROUP BY legal_name, meta_number, company.tax_id, company.sales_tax_id, company.entity_id,
+           entity_credit_account.entity_class, entity.control_code, entity_credit_account.id,
+           addr.line_one, addr.line_two, addr.line_three, addr.city, addr.state,
+           addr.mail_code, addr.country_id;
+
 $BODY$ LANGUAGE SQL;
 
 COMMENT ON FUNCTION tax_form_summary_report
@@ -133,6 +177,8 @@ RETURNS SETOF tax_form_report_detail_item AS $BODY$
                      entity_credit_account.entity_class, entity.control_code,
                      entity_credit_account.meta_number,
                      company.tax_id, company.sales_tax_id,
+                     addr.line_one, addr.line_two, addr.line_three,
+                     addr.city, addr.state, addr.mail_code, addr.country_id,
                      sum(CASE WHEN gl.amount_bc = 0 then 0
                               when relation = 'acc_trans'
                           THEN ac.reportable_amount_bc * pmt.amount_bc
@@ -195,8 +241,36 @@ RETURNS SETOF tax_form_report_detail_item AS $BODY$
                           AND transdate BETWEEN in_from_date AND in_to_date
                      group by ac.trans_id
                      ) pmt ON  (pmt.trans_id = gl.id)
+  LEFT JOIN LATERAL (
+    SELECT * FROM (
+      select * from (
+      select entity_credit_account.entity_id, l.*
+        from eca_to_location eca2l
+               join location_class lc on lc.id = eca2l.location_class
+               join location l on l.id = eca2l.location_id
+       where eca2l.credit_id = entity_credit_account.id -- this is the LATERAL!
+         and lc.authoritative
+       order by lc.id, l.created
+      ) y
+       union all
+      select * from (
+      select entity.id, l.*
+        from entity_to_location e2l
+               join location_class lc on lc.id = e2l.location_class
+               join location l on l.id = e2l.location_id
+       where e2l.entity_id = entity.id -- this is the LATERAL!
+         and lc.authoritative
+       order by lc.id, l.created
+      ) z
+    ) x
+    LIMIT 1
+  ) addr ON addr.entity_id = entity.id
                 WHERE country_tax_form.id = in_tax_form_id AND meta_number = in_meta_number
-                GROUP BY legal_name, meta_number, company.entity_id, company.tax_id, company.sales_tax_id, entity_credit_account.entity_class, entity.control_code, gl.invnumber, gl.duedate, gl.id, entity_credit_account.id
+  GROUP BY legal_name, meta_number, company.tax_id, company.sales_tax_id, company.entity_id,
+           entity_credit_account.entity_class, entity.control_code, entity_credit_account.id,
+           addr.line_one, addr.line_two, addr.line_three, addr.city, addr.state,
+           addr.mail_code, addr.country_id,
+           gl.invnumber, gl.duedate, gl.id
 $BODY$ LANGUAGE SQL;
 
 COMMENT ON FUNCTION tax_form_details_report
@@ -214,6 +288,8 @@ RETURNS SETOF tax_form_report_item AS $BODY$
                      entity_credit_account.entity_class, entity.control_code,
                      entity_credit_account.meta_number,
                      company.tax_id, company.sales_tax_id,
+                     addr.line_one, addr.line_two, addr.line_three,
+                     addr.city, addr.state, addr.mail_code, addr.country_id,
                      sum(CASE WHEN gl.amount_bc = 0 THEN 0
                               WHEN relation = 'acc_trans'
                           THEN ac.reportable_amount_bc
@@ -265,8 +341,32 @@ RETURNS SETOF tax_form_report_item AS $BODY$
                 JOIN entity ON (entity.id = entity_credit_account.entity_id)
                 JOIN company ON (entity.id = company.entity_id)
                 JOIN country_tax_form ON (entity_credit_account.taxform_id = country_tax_form.id)
-               WHERE country_tax_form.id = in_tax_form_id
-             GROUP BY legal_name, meta_number, company.entity_id, company.tax_id, company.sales_tax_id, entity_credit_account.entity_class, entity.control_code, entity_credit_account.id
+  LEFT JOIN LATERAL (
+    SELECT * FROM (
+      select * from (
+      select entity_credit_account.entity_id, l.* from eca_to_location eca2l
+                        join location_class lc on lc.id = eca2l.location_class
+                        join location l on l.id = eca2l.location_id
+       where eca2l.credit_id = entity_credit_account.id and lc.authoritative
+       order by lc.id, l.created
+      ) y
+       union all
+      select * from (
+      select entity.id, l.* from entity_to_location e2l
+                        join location_class lc on lc.id = e2l.location_class
+                        join location l on l.id = e2l.location_id
+       where e2l.entity_id = entity.id and lc.authoritative
+       order by lc.id, l.created
+      ) z
+    ) x
+    LIMIT 1
+  ) addr ON addr.entity_id = entity.id
+  WHERE country_tax_form.id = in_tax_form_id
+  GROUP BY legal_name, meta_number, company.tax_id, company.sales_tax_id, company.entity_id,
+           entity_credit_account.entity_class, entity.control_code, entity_credit_account.id,
+           addr.line_one, addr.line_two, addr.line_three, addr.city, addr.state,
+           addr.mail_code, addr.country_id;
+
 $BODY$ LANGUAGE SQL;
 
 COMMENT ON FUNCTION tax_form_summary_report_accrual
@@ -283,6 +383,8 @@ RETURNS SETOF tax_form_report_detail_item AS $BODY$
                      entity_credit_account.entity_class, entity.control_code,
                      entity_credit_account.meta_number,
                      company.tax_id, company.sales_tax_id,
+                     addr.line_one, addr.line_two, addr.line_three,
+                     addr.city, addr.state, addr.mail_code, addr.country_id,
                      sum(CASE WHEN gl.amount_bc = 0 then 0
                               when relation = 'acc_trans'
                           THEN ac.reportable_amount_bc
@@ -334,8 +436,32 @@ RETURNS SETOF tax_form_report_detail_item AS $BODY$
                 JOIN entity ON (entity.id = entity_credit_account.entity_id)
                 JOIN company ON (entity.id = company.entity_id)
                 JOIN country_tax_form ON (entity_credit_account.taxform_id = country_tax_form.id)
-                WHERE country_tax_form.id = in_tax_form_id AND meta_number = in_meta_number
-                GROUP BY legal_name, meta_number, company.entity_id, company.tax_id, company.sales_tax_id, entity_credit_account.entity_class, entity.control_code, gl.invnumber, gl.duedate, gl.id, entity_credit_account.id
+  LEFT JOIN LATERAL (
+    SELECT * FROM (
+      select * from (
+      select entity_credit_account.entity_id, l.* from eca_to_location eca2l
+                        join location_class lc on lc.id = eca2l.location_class
+                        join location l on l.id = eca2l.location_id
+       where eca2l.credit_id = entity_credit_account.id and lc.authoritative
+       order by lc.id, l.created
+      ) y
+       union all
+      select * from (
+      select entity.id, l.* from entity_to_location e2l
+                        join location_class lc on lc.id = e2l.location_class
+                        join location l on l.id = e2l.location_id
+       where e2l.entity_id = entity.id and lc.authoritative
+       order by lc.id, l.created
+      ) z
+    ) x
+    LIMIT 1
+  ) addr ON addr.entity_id = entity.id
+  WHERE country_tax_form.id = in_tax_form_id AND meta_number = in_meta_number
+  GROUP BY legal_name, meta_number, company.tax_id, company.sales_tax_id, company.entity_id,
+           entity_credit_account.entity_class, entity.control_code, entity_credit_account.id,
+           addr.line_one, addr.line_two, addr.line_three, addr.city, addr.state,
+           addr.mail_code, addr.country_id,
+           gl.invnumber, gl.duedate, gl.id
 $BODY$ LANGUAGE SQL;
 
 COMMENT ON FUNCTION tax_form_details_report_accrual

--- a/sql/modules/1099_reports.sql
+++ b/sql/modules/1099_reports.sql
@@ -135,23 +135,27 @@ RETURNS SETOF tax_form_report_item AS $BODY$
   LEFT JOIN LATERAL (
     SELECT * FROM (
       select * from (
-      select entity_credit_account.entity_id, l.*
-        from eca_to_location eca2l
-               join location_class lc on lc.id = eca2l.location_class
-               join location l on l.id = eca2l.location_id
-       where eca2l.credit_id = entity_credit_account.id -- this is the LATERAL!
-         and lc.authoritative
-       order by lc.id, l.created
+        -- entity_credit_account.id ensures a 1-1 join with the left side
+        select entity_credit_account.id, l.*
+          from eca_to_location eca2l
+                 join location_class lc on lc.id = eca2l.location_class
+                 join location l on l.id = eca2l.location_id
+         where eca2l.credit_id = entity_credit_account.id -- this is the LATERAL!
+           and lc.authoritative
+         order by lc.id, l.created
       ) y
        union all
       select * from (
-      select entity.id, l.*
-        from entity_to_location e2l
-               join location_class lc on lc.id = e2l.location_class
-               join location l on l.id = e2l.location_id
-       where e2l.entity_id = entity.id -- this is the LATERAL!
-         and lc.authoritative
-       order by lc.id, l.created
+        -- entity_credit_account.id ensures a 1-1 join with the left side
+        -- and due to the join on the left side,
+        -- entity_credit_account.entity_id = entity.id
+        select entity_credit_account.id, l.*
+          from entity_to_location e2l
+                 join location_class lc on lc.id = e2l.location_class
+                 join location l on l.id = e2l.location_id
+         where e2l.entity_id = entity.id -- this is the LATERAL!
+           and lc.authoritative
+         order by lc.id, l.created
       ) z
     ) x
     LIMIT 1

--- a/sql/modules/1099_reports.sql
+++ b/sql/modules/1099_reports.sql
@@ -136,7 +136,7 @@ RETURNS SETOF tax_form_report_item AS $BODY$
     SELECT * FROM (
       select * from (
         -- entity_credit_account.id ensures a 1-1 join with the left side
-        select entity_credit_account.id, l.*
+        select entity_credit_account.id as eca_id, l.*
           from eca_to_location eca2l
                  join location_class lc on lc.id = eca2l.location_class
                  join location l on l.id = eca2l.location_id
@@ -159,7 +159,7 @@ RETURNS SETOF tax_form_report_item AS $BODY$
       ) z
     ) x
     LIMIT 1
-  ) addr ON addr.entity_id = entity.id
+  ) addr ON addr.eca_id = entity_credit_account.id
   WHERE country_tax_form.id = in_tax_form_id
   GROUP BY legal_name, meta_number, company.tax_id, company.sales_tax_id, company.entity_id,
            entity_credit_account.entity_class, entity.control_code, entity_credit_account.id,

--- a/templates/demo/1099-INT.tex
+++ b/templates/demo/1099-INT.tex
@@ -1,6 +1,6 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.3
+   Version:  1.4
    Date:     2024-04-21
    File:     1099-INT.tex
    Set:      demo
@@ -9,6 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
+1.4       Correct values passed into 'taxformpart' block
 1.3       Document available variables; replace deprecated ones
 1.2       Fix syntax error
 1.1       Merged xelatex targetting templates with those targetting pdflatex
@@ -42,17 +43,16 @@ results:
     invnumber  (2)
     duedate    (2)
     invoice_id (2)
-    street1    (3)
-    street2    (3)
-    street3    (3)
-    city       (3)
-    state      (3)
-    mail_code  (3)
+    line_one
+    line_two
+    line_three
+    city
+    state
+    mail_code
 
 (1): Deprecated
 (2): These fields are only available when the report being printed
      is a detailed report (as opposed to a summary report).
-(3): Required, but not provided
 
 -?>
 <?lsmb FILTER latex { format="$FORMAT($PROCESSOR)" } ?>
@@ -81,9 +81,9 @@ Tel: <?lsmb SETTINGS.company_phone ?>
 
 \begin{textblock}{4}[0,1](1, 4)
 <?lsmb legal_name ?>\\
-<?lsmb IF street1 ?><?lsmb street1 ?>\\ <?lsmb END ?>
-<?lsmb IF street2 ?><?lsmb street2 ?>\\ <?lsmb END ?>
-<?lsmb IF street3 ?><?lsmb street3 ?>\\ <?lsmb END ?>
+<?lsmb IF line_one ?><?lsmb line_one ?>\\ <?lsmb END ?>
+<?lsmb IF line_two ?><?lsmb line_two ?>\\ <?lsmb END ?>
+<?lsmb IF line_three ?><?lsmb line_three ?>\\ <?lsmb END ?>
 <?lsmb city ?>, <?lsmb state ?> <?lsmb mail_code ?>
 \end{textblock}
 
@@ -105,10 +105,13 @@ Tel: <?lsmb SETTINGS.company_phone ?>
 \begin{document}
 <?lsmb FOR tf in results ?>
 <?lsmb INCLUDE taxform
-pay_to_name = tf.legal_name
-pay_to_line_one = tf.line_one
-pay_to_line_two = tf.line_two
-pay_to_line_three = tf.line_three
+legal_name = tf.legal_name
+line_one = tf.line_one
+line_two = tf.line_two
+line_three = tf.line_three
+city = tf.city
+state = tf.state
+mail_code = tf.mail_code
 taxnumber = tf.taxnumber
 total_sum = tf.total_sum ;
 END # FOR tf  ?>

--- a/templates/demo/1099-INT.tex
+++ b/templates/demo/1099-INT.tex
@@ -25,10 +25,6 @@ SETTINGS:
   company_fax
   company_email
   businessnumber
-company_name      (1)
-company_address   (1)
-company_telephone (1)
-my_tax_code       (1)
 results:
   - id
     legal_name
@@ -41,9 +37,9 @@ results:
     acc_sum
     invoice_sum
     total_sum
-    invnumber  (2)
-    duedate    (2)
-    invoice_id (2)
+    invnumber  (1)
+    duedate    (1)
+    invoice_id (1)
     line_one
     line_two
     line_three
@@ -51,8 +47,7 @@ results:
     state
     mail_code
 
-(1): Deprecated
-(2): These fields are only available when the report being printed
+(1): These fields are only available when the report being printed
      is a detailed report (as opposed to a summary report).
 
 -?>

--- a/templates/demo/1099-INT.tex
+++ b/templates/demo/1099-INT.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.2
-   Date:     2024-04-19
+   Version:  1.3
+   Date:     2024-04-21
    File:     1099-INT.tex
    Set:      demo
 
@@ -9,8 +9,50 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
+1.3       Document available variables; replace deprecated ones
 1.2       Fix syntax error
 1.1       Merged xelatex targetting templates with those targetting pdflatex
+
+
+This template has the following variables available:
+
+SETTINGS:
+  company_name
+  company_address
+  company_phone
+  company_fax
+  company_email
+  businessnumber
+company_name      (1)
+company_address   (1)
+company_telephone (1)
+my_tax_code       (1)
+results:
+  - id
+    legal_name
+    entity_id
+    entity_class
+    control_code
+    meta_number
+    tax_id
+    sales_tax_id
+    acc_sum
+    invoice_sum
+    total_sum
+    invnumber  (2)
+    duedate    (2)
+    invoice_id (2)
+    street1    (3)
+    street2    (3)
+    street3    (3)
+    city       (3)
+    state      (3)
+    mail_code  (3)
+
+(1): Deprecated
+(2): These fields are only available when the report being printed
+     is a detailed report (as opposed to a summary report).
+(3): Required, but not provided
 
 -?>
 <?lsmb FILTER latex { format="$FORMAT($PROCESSOR)" } ?>
@@ -25,12 +67,12 @@ Version   Changes
 <?lsmb BLOCK taxformpart ?>
 \begin{textblock}{4}[0,1](1, 1.5)
 <?lsmb SETTINGS.company_name ?>\\
-<?lsmb company_address ?>\\
-Tel: <?lsmb company_telephone ?>
+<?lsmb SETTINGS.company_address ?>\\
+Tel: <?lsmb SETTINGS.company_phone ?>
 \end{textblock}
 
 \begin{textblock}{2}[0,1](1, 3.5)
-<?lsmb my_tax_code ?>
+<?lsmb SETTINGS.businessnumber ?>
 \end{textblock}
 
 \begin{textblock}{2}[0,1](3, 3.5)
@@ -67,7 +109,6 @@ pay_to_name = tf.legal_name
 pay_to_line_one = tf.line_one
 pay_to_line_two = tf.line_two
 pay_to_line_three = tf.line_three
-my_tax_code = business_number
 taxnumber = tf.taxnumber
 total_sum = tf.total_sum ;
 END # FOR tf  ?>

--- a/templates/demo/1099-INT.tex
+++ b/templates/demo/1099-INT.tex
@@ -1,6 +1,6 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.4
+   Version:  1.5
    Date:     2024-04-21
    File:     1099-INT.tex
    Set:      demo
@@ -9,6 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
+1.5       Fix 'latexpdf' errors with missing data
 1.4       Correct values passed into 'taxformpart' block
 1.3       Document available variables; replace deprecated ones
 1.2       Fix syntax error
@@ -66,8 +67,8 @@ results:
 
 <?lsmb BLOCK taxformpart ?>
 \begin{textblock}{4}[0,1](1, 1.5)
-<?lsmb SETTINGS.company_name ?>\\
-<?lsmb SETTINGS.company_address ?>\\
+<?lsmb SETTINGS.company_name || 'No Company Name set in System Defaults' ?>\\
+<?lsmb SETTINGS.company_address || 'No Company Address set in System Defaults' ?>\\
 Tel: <?lsmb SETTINGS.company_phone ?>
 \end{textblock}
 
@@ -81,9 +82,13 @@ Tel: <?lsmb SETTINGS.company_phone ?>
 
 \begin{textblock}{4}[0,1](1, 4)
 <?lsmb legal_name ?>\\
-<?lsmb IF line_one ?><?lsmb line_one ?>\\ <?lsmb END ?>
+<?lsmb IF line_one ?>
+<?lsmb line_one ?>\\
 <?lsmb IF line_two ?><?lsmb line_two ?>\\ <?lsmb END ?>
 <?lsmb IF line_three ?><?lsmb line_three ?>\\ <?lsmb END ?>
+<?lsmb ELSE -?>
+No billing or physical address set \\
+<?lsmb END # line_one ?>
 <?lsmb city ?>, <?lsmb state ?> <?lsmb mail_code ?>
 \end{textblock}
 

--- a/templates/demo/1099-MISC.tex
+++ b/templates/demo/1099-MISC.tex
@@ -1,6 +1,6 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.2
+   Version:  1.3
    Date:     2024-04-21
    File:     1099-MISC.tex
    Set:      demo
@@ -9,6 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
+1.3       Correct values passed into 'taxformpart' block
 1.2       Document available variables; replace deprecated ones
 1.1       Merged xelatex targetting templates with those targetting pdflatex
 
@@ -41,17 +42,16 @@ results:
     invnumber  (2)
     duedate    (2)
     invoice_id (2)
-    street1    (3)
-    street2    (3)
-    street3    (3)
-    city       (3)
-    state      (3)
-    mail_code  (3)
+    line_one
+    line_two
+    line_three
+    city
+    state
+    mail_code
 
 (1): Deprecated
 (2): These fields are only available when the report being printed
      is a detailed report (as opposed to a summary report).
-(3): Required, but not provided
 
 -?>
 <?lsmb FILTER latex { format="$FORMAT($PROCESSOR)" } ?>
@@ -115,9 +115,12 @@ Tel: <?lsmb SETTINGS.company_phone ?>
    FOREACH tf IN results;
      INCLUDE taxform
        legal_name = tf.legal_name
-       street1 = tf.street1
-       street2 = tf.street2
-       street3 = tf.street3
+       street1 = tf.line_one
+       street2 = tf.line_two
+       street3 = tf.line_three
+       city = tf.city
+       state = tf.state
+       mail_code = tf.mail_code
        taxnumber = tf.taxnumber
        total_sum = tf.total_sum;
    END # FOR tf  ?>

--- a/templates/demo/1099-MISC.tex
+++ b/templates/demo/1099-MISC.tex
@@ -24,10 +24,6 @@ SETTINGS:
   company_fax
   company_email
   businessnumber
-company_name      (1)
-company_address   (1)
-company_telephone (1)
-my_tax_code       (1)
 results:
   - id
     legal_name
@@ -40,9 +36,9 @@ results:
     acc_sum
     invoice_sum
     total_sum
-    invnumber  (2)
-    duedate    (2)
-    invoice_id (2)
+    invnumber  (1)
+    duedate    (1)
+    invoice_id (1)
     line_one
     line_two
     line_three
@@ -50,8 +46,7 @@ results:
     state
     mail_code
 
-(1): Deprecated
-(2): These fields are only available when the report being printed
+(1): These fields are only available when the report being printed
      is a detailed report (as opposed to a summary report).
 
 -?>

--- a/templates/demo/1099-MISC.tex
+++ b/templates/demo/1099-MISC.tex
@@ -1,6 +1,6 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.3
+   Version:  1.4
    Date:     2024-04-21
    File:     1099-MISC.tex
    Set:      demo
@@ -9,6 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
+1.4       Fix 'latexpdf' errors with missing data
 1.3       Correct values passed into 'taxformpart' block
 1.2       Document available variables; replace deprecated ones
 1.1       Merged xelatex targetting templates with those targetting pdflatex
@@ -67,8 +68,8 @@ results:
  # Defines a repeatable block of TeX commands
 ?>
 \begin{textblock}{4}[0,1](1, 1.5)
-<?lsmb SETTINGS.company_name ?>\\
-<?lsmb SETTINGS.company_address ?>\\
+<?lsmb SETTINGS.company_name || 'No Company Name set in System Defaults' ?>\\
+<?lsmb SETTINGS.company_address || 'No Company Address set in System Defaults' ?>\\
 Tel: <?lsmb SETTINGS.company_phone ?>
 \end{textblock}
 
@@ -82,9 +83,13 @@ Tel: <?lsmb SETTINGS.company_phone ?>
 
 \begin{textblock}{4}[0,1](1, 4)
 <?lsmb legal_name ?>\\
-<?lsmb IF street1 ?><?lsmb street1 ?>\\ <?lsmb END ?>
+<?lsmb IF street1 ?>
+<?lsmb street1 ?>\\
 <?lsmb IF street2 ?><?lsmb street2 ?>\\ <?lsmb END ?>
 <?lsmb IF street3 ?><?lsmb street3 ?>\\ <?lsmb END ?>
+<?lsmb ELSE -?>
+No billing or physical address set \\
+<?lsmb END # street1 ?>
 <?lsmb city ?>, <?lsmb state ?> <?lsmb mail_code ?>
 \end{textblock}
 

--- a/templates/demo/1099-MISC.tex
+++ b/templates/demo/1099-MISC.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.1
-   Date:     2022-07-22
+   Version:  1.2
+   Date:     2024-04-21
    File:     1099-MISC.tex
    Set:      demo
 
@@ -9,7 +9,49 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 Version   Changes
+1.2       Document available variables; replace deprecated ones
 1.1       Merged xelatex targetting templates with those targetting pdflatex
+
+
+This template has the following variables available:
+
+SETTINGS:
+  company_name
+  company_address
+  company_phone
+  company_fax
+  company_email
+  businessnumber
+company_name      (1)
+company_address   (1)
+company_telephone (1)
+my_tax_code       (1)
+results:
+  - id
+    legal_name
+    entity_id
+    entity_class
+    control_code
+    meta_number
+    tax_id
+    sales_tax_id
+    acc_sum
+    invoice_sum
+    total_sum
+    invnumber  (2)
+    duedate    (2)
+    invoice_id (2)
+    street1    (3)
+    street2    (3)
+    street3    (3)
+    city       (3)
+    state      (3)
+    mail_code  (3)
+
+(1): Deprecated
+(2): These fields are only available when the report being printed
+     is a detailed report (as opposed to a summary report).
+(3): Required, but not provided
 
 -?>
 <?lsmb FILTER latex { format="$FORMAT($PROCESSOR)" } ?>
@@ -26,12 +68,12 @@ Version   Changes
 ?>
 \begin{textblock}{4}[0,1](1, 1.5)
 <?lsmb SETTINGS.company_name ?>\\
-<?lsmb company_address ?>\\
-Tel: <?lsmb company_telephone ?>
+<?lsmb SETTINGS.company_address ?>\\
+Tel: <?lsmb SETTINGS.company_phone ?>
 \end{textblock}
 
 \begin{textblock}{2}[0,1](1, 3.5)
-<?lsmb my_tax_code ?>
+<?lsmb SETTINGS.businessnumber ?>
 \end{textblock}
 
 \begin{textblock}{2}[0,1](3, 3.5)


### PR DESCRIPTION
Various fixes:

* The Print button didn't pass the right values in its request
* The Print button wasn't a PrintButton, failing to download the result
* Company parameters (name, etc) not passed to form templates
* Missing drop-down to select which form to print
* Missing address data in query feeding forms
* Incomprehensible pdflatex errors thrown when company configuration data missing ("no line to terminate") [replaced missing data with default values pointing the user to a solution to the problem]