### PR TITLE
Fix comparison reports csv

### DIFF
--- a/templates/demo/PNL.csv
+++ b/templates/demo/PNL.csv
@@ -9,7 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
-account,description,is_heading,heading_account<?lsmb
+account,description,is_heading<?lsmb
  FOREACH col IN report.sorted_col_ids -?>
 ,"<?lsmb report.cheads.ids.$col.props.description ?>"<?lsmb END; ?>
 <?lsmb FOREACH row IN report.sorted_row_ids ; -?>

--- a/templates/demo/balance_sheet.csv
+++ b/templates/demo/balance_sheet.csv
@@ -9,7 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
-account,description,is_heading,heading_account<?lsmb
+account,description,is_heading<?lsmb
  FOREACH col IN report.sorted_col_ids -?>
 ,"<?lsmb report.cheads.ids.$col.props.description ?>"<?lsmb END; ?>
 <?lsmb FOREACH row IN report.sorted_row_ids ; -?>

--- a/templates/demo/balance_sheet.csv
+++ b/templates/demo/balance_sheet.csv
@@ -16,7 +16,7 @@ account,description,is_heading<?lsmb
 <?lsmb report.rheads.ids.$row.props.account_number -?>,"<?lsmb report.rheads.ids.$row.props.account_description ?>",<?lsmb IF report.rheads.ids.$row.props.account_type == 'H' -?>Y<?lsmb ELSE ?>N<?lsmb END ?>,<?lsmb
 PARENT = report.rheads.ids.$row.parent_id ;
 report.rheads.ids.$PARENT.props.account_number ?><?lsmb
- FOREACH col IN report.cheads.ids.keys ; -?>
+ FOREACH col IN report.sorted_col_ids ; -?>
 ,<?lsmb report.cells.$row.$col -?><?lsmb
 END; ?>
 <?lsmb END; -?>


### PR DESCRIPTION
This removes a spurious heading from Balance Sheet & PNL csv reports.
It also properly sorts the comparison columns on Balance Sheet csv reports.