### PR TITLE
Remove 'new_shipto'

### DIFF
--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -633,26 +633,18 @@ sub retrieve_invoice {
                    a.notes, a.intnotes, a.curr AS currency,
                    a.entity_credit_account as vendor_id, a.language_code,
                    a.ponumber, a.crdate, a.on_hold, a.reverse, a.description,
+                   a.shipto as locationid, l.line_one, l.line_two,
+                   l.line_three, l.city, l.state, l.country_id, l.mail_code,
                    tran.workflow_id
               FROM ap a
               JOIN transactions tran USING (id)
-             WHERE id = ?|;
+            LEFT JOIN location l on a.shipto = l.id
+             WHERE a.id = ?|;
         $sth = $dbh->prepare($query);
         $sth->execute( $form->{id} ) || $form->dberror($query);
 
         $ref = $sth->fetchrow_hashref(NAME_lc);
         $form->db_parse_numeric(sth=>$sth, hashref=>$ref);
-        for ( keys %$ref ) {
-            $form->{$_} = $ref->{$_};
-        }
-        $sth->finish;
-
-        # get shipto
-        $query = qq|SELECT ns.*, l.* FROM new_shipto ns JOIN location l ON ns.location_id = l.id WHERE ns.trans_id = ?|;
-        $sth   = $dbh->prepare($query);
-        $sth->execute( $form->{id} ) || $form->dberror($query);
-
-        $ref = $sth->fetchrow_hashref(NAME_lc);
         for ( keys %$ref ) {
             $form->{$_} = $ref->{$_};
         }

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1241,11 +1241,14 @@ sub retrieve_invoice {
                       a.reverse, a.entity_credit_account as customer_id,
                       a.language_code, a.ponumber, a.crdate,
                       a.on_hold, a.description, a.setting_sequence,
+                      a.shipto as locationid, l.line_one, l.line_two,
+                      l.line_three, l.city, l.state, l.country_id, l.mail_code,
                       tran.workflow_id
                  FROM ar a
                  JOIN transactions tran USING (id)
             LEFT JOIN entity_employee em ON (em.entity_id = a.person_id)
             LEFT JOIN entity e ON e.id = em.entity_id
+            LEFT JOIN location l on a.shipto = l.id
                 WHERE a.id = ?|;
 
         $sth = $dbh->prepare($query);
@@ -1275,18 +1278,6 @@ sub retrieve_invoice {
               $form->{"mt_memo_$taccno"}  = $taxref->{memo};
               $form->{"mt_ref_$taccno"}  = $taxref->{source};
         }
-
-
-        # get shipto
-        $query = qq|SELECT ns.*, l.* FROM new_shipto ns JOIN location l ON ns.location_id = l.id WHERE ns.trans_id = ?|;
-        $sth   = $dbh->prepare($query);
-        $sth->execute( $form->{id} ) || $form->dberror($query);
-
-        $ref = $sth->fetchrow_hashref(NAME_lc);
-        $ref->{locationid} = $ref->{id};
-        delete $ref->{id};
-        for ( keys %$ref ) { $form->{$_} = $ref->{$_} unless $_ eq 'id' };
-        $sth->finish;
 
         # retrieve individual items
         $query = qq|

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -183,11 +183,6 @@ sub save {
             $query = qq|DELETE FROM oe_tax WHERE oe_id = ?|;
             $sth   = $dbh->prepare($query);
             $sth->execute( $form->{id} ) || $form->dberror($query);
-
-            $query = qq|DELETE FROM new_shipto WHERE oe_id = ?|;
-            $sth   = $dbh->prepare($query);
-            $sth->execute( $form->{id} ) || $form->dberror($query);
-
         }
         else {    # id is not in the database
             delete $form->{id};
@@ -556,11 +551,6 @@ sub delete {
     $query = qq|DELETE FROM orderitems WHERE trans_id = ?|;
     $sth->finish;
 
-    $query = qq|DELETE FROM new_shipto WHERE oe_id = ?|;
-    $sth   = $dbh->prepare($query);
-    $sth->execute( $form->{id} ) || $form->dberror($query);
-    $sth->finish;
-
     $query = qq|DELETE FROM oe_tax WHERE oe_id = ?|;
     $sth   = $dbh->prepare($query);
     $sth->execute( $form->{id} ) || $form->dberror($query);
@@ -610,12 +600,11 @@ sub retrieve {
                 o.amount_tc AS invtotal, o.closed, o.reqdate,
                 o.quonumber, o.language_code,
                 o.ponumber, cr.entity_class,
-                ns.location_id as locationid
+                shipto as locationid
             FROM oe o
             JOIN entity_credit_account cr ON (cr.id = o.entity_credit_account)
             JOIN entity vc ON (cr.entity_id = vc.id)
             LEFT JOIN person pe ON (o.person_id = pe.entity_id)
-                        LEFT JOIN new_shipto ns ON ns.oe_id = o.id
             WHERE o.id = ?|;
         $sth = $dbh->prepare($query);
         $sth->execute( $form->{id} ) || $form->dberror($query);
@@ -630,14 +619,6 @@ sub retrieve {
         $form->{"$form->{vc}_id"} = $ref->{entity_credit_account};
         $form->db_parse_numeric(sth=>$sth, hashref=>$ref);
         for ( keys %$ref ) { $form->{$_} = $ref->{$_} }
-        $sth->finish;
-
-        $query = qq|SELECT * FROM new_shipto WHERE oe_id = ?|;
-        $sth   = $dbh->prepare($query);
-        $sth->execute( $form->{id} ) || $form->dberror($query);
-
-        $ref = $sth->fetchrow_hashref('NAME_lc');
-        for ( keys %$ref ) { $form->{$_} = $ref->{$_} unless ( $_ eq "id") }
         $sth->finish;
 
         # get printed, emailed

--- a/sql/changes/1.12/rm-new_shipto.sql
+++ b/sql/changes/1.12/rm-new_shipto.sql
@@ -1,0 +1,24 @@
+
+alter table oe
+  add column shipto int references location (id);
+alter table ar
+  add column shipto int references location (id);
+alter table
+  ap add column shipto int references location (id);
+
+update oe
+   set shipto = ns.location_id
+       from new_shipto ns
+ where oe.id = ns.oe_id;
+
+update ar
+   set shipto = ns.location_id
+       from new_shipto ns
+ where ar.id = ns.trans_id;
+
+update ap
+   set shipto = ns.location_id
+       from new_shipto ns
+ where ap.id = ns.trans_id;
+
+drop table new_shipto;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -187,3 +187,4 @@ mc/delete-migration-validation-data.sql
 1.12/add-stored-order-quote-taxes.sql
 1.12/drop-entity-class-entity-trigger.sql
 1.12/reconciliation-workflow.sql
+1.12/rm-new_shipto.sql

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -724,7 +724,7 @@ SELECT lsmb__create_role('ar_invoice_create',
 SELECT lsmb__grant_role('ar_invoice_create', 'ar_transaction_create');
 -- ### old code needs UPDATE
 SELECT lsmb__grant_perms('ar_invoice_create', tname, ptype)
-  FROM unnest('{invoice,new_shipto,business_unit_inv}'::text[]) tname
+  FROM unnest('{invoice,business_unit_inv}'::text[]) tname
  CROSS JOIN unnest('{SELECT,INSERT,UPDATE}'::text[]) ptype;
 
 SELECT lsmb__grant_menu('ar_invoice_create', 3, 'allow');
@@ -793,7 +793,6 @@ SELECT lsmb__grant_perms('sales_order_create', 'orderitems', 'INSERT');
 SELECT lsmb__grant_perms('sales_order_create', 'orderitems', 'UPDATE');
 SELECT lsmb__grant_perms('sales_order_create', 'business_unit_oitem', 'INSERT');
 SELECT lsmb__grant_perms('sales_order_create', 'business_unit_oitem', 'UPDATE');
-SELECT lsmb__grant_perms('sales_order_create', 'new_shipto_id_seq', 'ALL');
 SELECT lsmb__grant_menu('sales_order_create', '51', 'allow');
 
 SELECT lsmb__create_role('sales_order_edit',
@@ -803,8 +802,6 @@ SELECT lsmb__create_role('sales_order_edit',
 );
 SELECT lsmb__grant_perms('sales_order_edit', 'orderitems', 'DELETE');
 SELECT lsmb__grant_perms('sales_order_edit', 'business_unit_oitem', 'DELETE');
-SELECT lsmb__grant_perms('sales_order_edit', 'new_shipto', 'DELETE');
-SELECT lsmb__grant_perms('sales_order_edit', 'new_shipto_id_seq', 'ALL');
 
 SELECT lsmb__create_role('sales_order_delete',
                          $DOC$
@@ -827,8 +824,7 @@ SELECT lsmb__create_role('rfq_delete',
                          $DOC$
 );
 SELECT lsmb__grant_perms(dt || '_delete', obj, 'DELETE')
-  FROM unnest(ARRAY['oe'::TEXT, 'orderitems', 'business_unit_oitem',
-                    'new_shipto']) obj
+  FROM unnest(ARRAY['oe'::TEXT, 'orderitems', 'business_unit_oitem']) obj
  CROSS
   JOIN unnest(array['sales_order'::text, 'sales_quotation', 'purchase_order',
               'rfq']) dt;
@@ -846,7 +842,6 @@ SELECT lsmb__grant_perms('sales_quotation_create', obj, 'ALL')
 SELECT lsmb__grant_perms('sales_quotation_create', obj, ptype)
   FROM unnest(array['orderitems'::text, 'business_unit_oitem']) obj,
        unnest(array['INSERT'::text, 'UPDATE']) ptype;
-SELECT lsmb__grant_perms('sales_quotation_create', 'new_shipto_id_seq', 'ALL');
 
 SELECT lsmb__grant_menu('sales_quotation_create', 68, 'allow');
 
@@ -1004,7 +999,6 @@ SELECT lsmb__grant_perms('purchase_order_create', obj, ptype)
 SELECT lsmb__grant_perms('purchase_order_create', obj, 'ALL')
   FROM unnest(array['oe_id_seq'::text, 'orderitems_id_seq', 'warehouse_inventory',
                     'warehouse_inventory_entry_id_seq']) obj;
-SELECT lsmb__grant_perms('purchase_order_create', 'new_shipto_id_seq', 'ALL');
 SELECT lsmb__grant_menu('purchase_order_create', 52, 'allow');
 
 SELECT lsmb__create_role('purchase_order_edit',
@@ -1013,9 +1007,7 @@ SELECT lsmb__create_role('purchase_order_edit',
                          $DOC$
 );
 SELECT lsmb__grant_perms('purchase_order_edit', obj, 'DELETE')
-  FROM unnest(array['oe'::text, 'orderitems', 'business_unit_oitem',
-                    'new_shipto']) obj;
-SELECT lsmb__grant_perms('purchase_order_edit', 'new_shipto_id_seq', 'ALL');
+  FROM unnest(array['oe'::text, 'orderitems', 'business_unit_oitem']) obj;
 
 SELECT lsmb__create_role('rfq_create',
                          $DOC$
@@ -1030,7 +1022,6 @@ SELECT lsmb__grant_perms('rfq_create', 'orderitems_id_seq', 'ALL');
 SELECT lsmb__grant_perms('rfq_create', obj, ptype)
   FROM unnest(array['oe'::text, 'orderitems', 'business_unit_oitem']) obj,
        unnest(array['INSERT'::text, 'UPDATE']) ptype;
-SELECT lsmb__grant_perms('rfq_create', 'new_shipto_id_seq', 'ALL');
 
 SELECT lsmb__create_role('purchase_order_list',
                          $DOC$
@@ -1971,10 +1962,8 @@ SELECT lsmb__grant_perms('base_user', obj, 'SELECT')
                     'business', 'template',
                     --###TODO: Add table for advisory rates
                     --'exchangerate',
-                    'new_shipto', 'tax',
+                    'tax',
                     'entity_employee', 'jcitems', 'salutation', 'assembly']) obj;
-
-SELECT lsmb__grant_perms('base_user', 'new_shipto', 'UPDATE');
 
 SELECT lsmb__grant_perms('base_user', obj, 'SELECT')
   FROM unnest(array['partstax'::text, 'partscustomer',


### PR DESCRIPTION
The table is an artifact of over-engineering. There should only be one shipping address associated with every order and invoice, but this setup allows multiple. In addition, it doesn't add value of itself and forwards to 'location' for all its functional fields.
