### PR TITLE
Drop legacy role if new already exists

### DIFF
--- a/sql/changes/1.11/ar-ap-role-naming-consistency.sql@1
+++ b/sql/changes/1.11/ar-ap-role-naming-consistency.sql@1
@@ -10,19 +10,11 @@ CREATE FUNCTION pg_temp.lsmb__role(global_role text) RETURNS text
   DO $$
     DECLARE
     t_rolename text;
-    t_new_rolename text;
 BEGIN
   select pg_temp.lsmb__role('ap_all_vouchers') into t_rolename;
-  select pg_temp.lsmb__role('ap_voucher_all') into t_new_rolename;
-
   perform * from pg_roles where rolname = t_rolename;
   if found then
-    perform * from pg_roles where rolname = t_new_rolename;
-    if found then
-      execute 'drop role if exists' || quote_ident(t_rolename);
-    else
-      execute 'alter role ' || quote_ident(t_rolename) || ' rename to ' || quote_ident(t_new_rolename);
-    end if;
+    execute 'alter role ' || quote_ident(t_rolename) || ' rename to ' || quote_ident(pg_temp.lsmb__role('ap_voucher_all'));
   end if;
 
   -- drop a role which doesn't have an AR equivalent and from its naming


### PR DESCRIPTION
Migration from 1.10 to 1.11 fails if a 'ap_voucher_all' role already exists. This is because during migration we rename the legay role 'ap_all_vouchers' to 'ap_voucher_all' (to make role naming consistent), however if the role already exist the SQL migration fails and LedgerSMB upgrade fails with an error:

```plain
Error applying upgrade script ./sql/changes/1.11/ar-ap-role-naming-consistency.sql: ERROR: role "lsmb_{DATABASE}__ap_voucher_all" already exists CONTEXT: SQL statement "alter role lsmb_{DATABASE}__ap_all_vouchers rename to lsmb_{DATABASE}__ap_voucher_all" PL/pgSQL function inline_code_block line 8 at EXECUTE at lib/LedgerSMB/Database/Change.pm line 309.
```

The 'ap_voucher_all' role may already exist if one have previously upgraded to 1.11 and then migrated back, for example if there was an issue/bug in 1.11 and one could not wait until it was solved. This could also happen if one have something like an acceptance test instance of the database that receives old and new versions for testing.
