### PR TITLE
Fix non-intuitive failure mode on GL entry

### DIFF
--- a/UI/journal/journal_entry.html
+++ b/UI/journal/journal_entry.html
@@ -44,11 +44,12 @@
           <td>
               [% INCLUDE input element_data = {
                         name = "transdate"
-         id = "transdate"
+                        id = "transdate"
                         value = form.transdate
                         size = "11"
                         type = 'text'
                         class = 'date'
+              "data-dojo-props" = "defaultIsToday:true"
               } %]
           </td>
         </tr>


### PR DESCRIPTION
Closes #7806 by setting the transaction date to "today" by default.
