### PR TITLE
Fix Ship To on purchase documents, orders and quotes

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -718,7 +718,7 @@ sub display_form {
 
     &{$subroutine}($numrows) if $numrows;
 
-    $form->hide_form(qw|locationid|);
+    $form->hide_form(qw|shiptolocationid|);
 
     &form_footer;
     $form->finalize_request unless $want_return;
@@ -1355,7 +1355,7 @@ sub print_form {
 
     $shipto = 0;
     # if there is no shipto fill it in from billto
-    $form->get_shipto($form->{locationid}) if $form->{locationid};
+    $form->get_shipto($form->{shiptolocationid}) if $form->{shiptolocationid};
     foreach my $item (@vars) {
         if ($form->{"shipto$item"} ) {
             $shipto = 1;
@@ -1685,9 +1685,9 @@ sub ship_to {
                            {
                                my $checked = '';
                                $checked = 'CHECKED="CHECKED"'
-                                   if ($form->{locationid}
-                                       and ($form->{locationid} == $form->{"shiptolocationid_$i"}
-                                            or $form->{locationid} == $form->{"locationid_$i"}));
+                                   if ($form->{shiptolocationid}
+                                       and ($form->{shiptolocationid} == $form->{"shiptolocationid_$i"}
+                                            or $form->{shiptolocationid} == $form->{"locationid_$i"}));
 
                                 print qq|
                            <tr>
@@ -1862,7 +1862,7 @@ $locale->text('Cancel')
 
 Author...Sadashiva
 
-The list of functions would create the new location / uses existing locations , and sets the $form->{locationid}.
+The list of functions would create the new location / uses existing locations , and sets the $form->{shiptolocationid}.
 
 list_locations_contacts() would extracts all locations and sets into form parameter...
 
@@ -1872,7 +1872,7 @@ construct_countrys_types return the drop down list of the country/contact_class 
 
 createlocations called by update action... calling eca__location_save and eca__save_contact
 
-setlocation_id called by continue action... just setting $form->{locationid} this is the final location id which is returned by shipto service
+setlocation_id called by continue action... just setting $form->{shiptolocationid} this is the final location id which is returned by shipto service
 
 
 
@@ -1910,7 +1910,7 @@ sub createlocations
 
     my $loc_id_index=$form->{"shiptoradio"};
 
-    my $index="locationid_".$loc_id_index;
+    my $index="shiptolocationid_".$loc_id_index;
 
     my $loc_id=$form->{$index};
 
@@ -1922,7 +1922,7 @@ sub createlocations
 
          &validatelocation;
 
-         $form->{locationid} = IIAA->createlocation($form);
+         $form->{shiptolocationid} = IIAA->createlocation($form);
 
 
     }

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -2019,7 +2019,7 @@ sub list_locations_contacts
 
     my $sth = $dbh->prepare($query);
 
-    $sth->execute( $form->{customer_id} ) || $form->dberror($query);
+    $sth->execute( $form->{customer_id} // $form->{vendor_id} ) || $form->dberror($query);
 
     my $i=0;
 

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1767,9 +1767,9 @@ sub ship_to {
 
               for(my $k=1;$k<$deletecontacts;$k++)
             {
-                for (qq| type_$k contact_$k description_$k |)
+                for (qw| type_ contact_ description_ |)
                 {
-                delete $form->{"shipto$_"};
+                delete $form->{"shipto$_$k"};
                 }
 
                }
@@ -1786,9 +1786,9 @@ sub ship_to {
 
               for(my $k=1;$k<$deletelocations;$k++)
               {
-                    for (qq| locationid_$k address1_$k address2_$k address3_$k city_$k state_$k zipcode_$k country_$k|)
+                    for (qw| locationid_ address1_ address2_ address3_ city_ state_ zipcode_ country_|)
                     {
-                    delete $form->{"shipto$_"};
+                    delete $form->{"shipto$_$k"};
                     }
 
               }

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1777,9 +1777,9 @@ sub ship_to {
                  delete $form->{shiptoradiocontact};
                delete $form->{shiptoradio};
 
-               for (qq| address1_new address2_new address3_new city_new state_new zipcode_new country_new type_new contact_new description_new|)
+               for (qw| address1_ address2_ address3_ city_ state_ zipcode_ country_ type_ contact_ description_|)
                {
-                delete $form->{"shipto$_"};
+                delete $form->{"shipto${_}new"};
                }
 
 

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -671,7 +671,7 @@ sub form_header {
 |;
 
     $form->hide_form(
-        qw(shiptoname shiptoaddress1 shiptoaddress2 shiptocity shiptostate shiptozipcode shiptocountry shiptocontact shiptophone shiptofax shiptoemail message email subject cc bcc taxaccounts)
+        qw(shiptoname shiptoaddress1 shiptoaddress2 shiptocity shiptostate shiptozipcode shiptocountry shiptocontact shiptophone shiptofax shiptoemail message email subject cc bcc taxaccounts shiptolocationid)
     );
 
     for ( split / /, $form->{taxaccounts} ) {

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1307,7 +1307,7 @@ sub update_balance {
 =item $form->add_shipto($id, $is_oe);
 
 Inserts a new location_id reference into the table new_shipto, using the
-Form->{locationid} property.
+Form->{shiptolocationid} property.
 
 $is_oe determines whether the locaation is linked with a transaction or an oe.
 
@@ -1994,7 +1994,7 @@ sub create_links {
                 c.language_code, a.ponumber, a.reverse,
                 a.approved, ctf.default_reportable,
                 a.description, a.on_hold, a.crdate,
-                a.shipto as locationid, a.is_return, $seq,
+                a.shipto as shiptolocationid, a.is_return, $seq,
                 t.workflow_id, t.reversing, t.reversing_reference,
                 t.reversed_by, t.reversed_by_reference
             FROM $arap a

--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -539,7 +539,8 @@ sub post_invoice {
                ponumber = ?,
                        approved = ?,
                        reverse = ?,
-               crdate = ?
+               crdate = ?,
+               shipto = ?
          WHERE id = ?|;
 
     $sth = $dbh->prepare($query);
@@ -553,6 +554,7 @@ sub post_invoice {
         $form->{currency},
         $form->{language_code}, $form->{ponumber},
         $approved,              $form->{reverse},       $form->{crdate},
+        $form->{shiptolocationid},
         $form->{id}
     ) || $form->dberror($query);
 

--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -633,7 +633,7 @@ sub retrieve_invoice {
                    a.notes, a.intnotes, a.curr AS currency,
                    a.entity_credit_account as vendor_id, a.language_code,
                    a.ponumber, a.crdate, a.on_hold, a.reverse, a.description,
-                   a.shipto as locationid, l.line_one, l.line_two,
+                   a.shipto as shiptolocationid, l.line_one, l.line_two,
                    l.line_three, l.city, l.state, l.country_id, l.mail_code,
                    tran.workflow_id
               FROM ap a

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1241,7 +1241,7 @@ sub retrieve_invoice {
                       a.reverse, a.entity_credit_account as customer_id,
                       a.language_code, a.ponumber, a.crdate,
                       a.on_hold, a.description, a.setting_sequence,
-                      a.shipto as locationid, l.line_one, l.line_two,
+                      a.shipto as shiptolocationid, l.line_one, l.line_two,
                       l.line_three, l.city, l.state, l.country_id, l.mail_code,
                       tran.workflow_id
                  FROM ar a

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1175,10 +1175,11 @@ sub post_invoice {
                language_code = ?,
                ponumber = ?,
                        approved = ?,
-               crdate = ?,
-                       reverse = ?,
+                       crdate = ?,
+                              reverse = ?,
                        is_return = ?,
-                       setting_sequence = ?
+                       setting_sequence = ?,
+                       shipto = ?
          WHERE id = ?
              |;
     $sth = $dbh->prepare($query);
@@ -1198,6 +1199,7 @@ sub post_invoice {
         $form->{language_code}, $form->{ponumber}, $approved,
         $form->{crdate} || 'today', $form->{reverse},
         $form->{is_return},     $form->{setting_sequence},
+         $form->{shiptolocationid},
         $form->{id}
     ) || $form->dberror($query);
 

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -600,7 +600,7 @@ sub retrieve {
                 o.amount_tc AS invtotal, o.closed, o.reqdate,
                 o.quonumber, o.language_code,
                 o.ponumber, cr.entity_class,
-                shipto as locationid
+                shipto as shiptolocationid
             FROM oe o
             JOIN entity_credit_account cr ON (cr.id = o.entity_credit_account)
             JOIN entity vc ON (cr.entity_id = vc.id)

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -466,7 +466,8 @@ VALUES (?, (select id from account where accno = ?), ?, ?, ?)
                 person_id = ?,
                 language_code = ?,
                 ponumber = ?,
-                terms = ?
+                terms = ?,
+                shipto = ?
             WHERE id = ?|;
 
         if ( !$form->{reqdate} ) {
@@ -483,7 +484,8 @@ VALUES (?, (select id from account where accno = ?), ?, ?, ?)
             $form->{closed},        $quotation,
             $form->{employee_id},
             $form->{language_code}, $form->{ponumber},
-            $form->{terms},         $form->{id}
+            $form->{terms},         $form->{shiptolocationid},
+            $form->{id}
         );
     }
     $sth = $dbh->prepare($query) || $form->dberror($query);


### PR DESCRIPTION
Ship To didn't work at all on purchases (invoices, orders, requests for quote). Additionally, Ship To didn't work on orders and quotes. Even more, Ship To didn't work when invoked multiple times in a row, e.g. when clicking "Add To List" or when forgetting to select a shipping address.