### PR TITLE
Fix orders/quotes showing read-only

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -126,11 +126,11 @@ sub order_links {
 
 
     # create links
-    $form->create_links( module => "OE", # effectively 'none'
-             myconfig => \%myconfig,
-             vc => $form->{vc},
-             billing => 0,
-             job => 1 );
+    # $form->create_links( module => "OE", # effectively 'none'
+    #          myconfig => \%myconfig,
+    #          vc => $form->{vc},
+    #          billing => 0,
+    #          job => 1 );
 
     # retrieve order/quotation
     OE->retrieve( \%myconfig, \%$form );


### PR DESCRIPTION
Don't combine AR/AP transaction information with orders/quotes which prevents the 'approved' value taken from the AR/AP transaction with the same ID as the order (they use separate sequences) from freezing the order/quote entry screen.

Fixes #8346
