### PR TITLE
Remove myconfig{acs} references

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -457,11 +457,6 @@ sub create_links {
     $form->{rowcount}++ if ( $form->{id} || !$form->{rowcount} );
     $form->{rowcount} = 1 unless $form->{"$form->{ARAP}_amount_1"};
 
-    # readonly
-    if ( !$form->{readonly} ) {
-        $form->{readonly} = 1
-          if $myconfig{acs} && $myconfig{acs} =~ /$form->{ARAP}--Add Transaction/;
-    }
     delete $form->{selectcurrency};
     #$form->generate_selects(\%myconfig);
     $form->{$form->{ARAP}} = $form->{"$form->{ARAP}_1"} unless $form->{$form->{ARAP}} and $form->{__action} eq 'update';

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -573,12 +573,6 @@ sub edit {
 
     $form->all_business_units($form->{transdate}, undef, 'GL');
 
-    # readonly
-    if ( !$form->{readonly} ) {
-        $form->{readonly} = 1
-            if ($myconfig{acs}
-                and $myconfig{acs} =~ /General Ledger--Add Transaction/);
-    }
     $form->{title} = "Edit";
     if ($form->{department_id}) {
          $form->{department}=$form->{departmentdesc}."--".$form->{department_id};

--- a/old/bin/ic.pl
+++ b/old/bin/ic.pl
@@ -102,8 +102,6 @@ sub link_part {
 
     # readonly
     if ( $form->{item} eq 'part' or $form->{item} eq 'assembly') {
-        $form->{readonly} = 1
-            if $myconfig{acs} and $myconfig{acs} =~ /Goods \& Services--Add Part/;
         $form->error(
             $locale->text(
                 'Cannot create Part; Inventory account does not exist!')
@@ -117,8 +115,6 @@ sub link_part {
     }
 
     if ( $form->{item} eq 'service' ) {
-        $form->{readonly} = 1
-          if $myconfig{acs} =~ /Goods \& Services--Add Service/;
         $form->error(
             $locale->text(
                 'Cannot create Service; Income account does not exist!')
@@ -130,8 +126,6 @@ sub link_part {
     }
 
     if ( $form->{item} eq 'labor' ) {
-        $form->{readonly} = 1
-          if $myconfig{acs} =~ /Goods \& Services--Add Labor\/Overhead/;
         $form->error(
             $locale->text(
                 'Cannot create Labor; Inventory account does not exist!')

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -624,11 +624,7 @@ sub new_item {
 
 <h4 class=error>| . $locale->text('Item not on file!') . qq|</h4>|;
 
-    if ( $myconfig{acs} !~
-        /(Goods \& Services--Add Part|Goods \& Services--Add Service)/ )
-    {
-
-        print qq|
+    print qq|
 <h4>| . $locale->text('What type of item is this?') . qq|</h4>
 
 <form method="post" data-dojo-type="lsmb/Form" action="ic.pl">
@@ -647,16 +643,15 @@ sub new_item {
 <input type=hidden name=action value=add>
 |;
 
-        $form->hide_form(qw(previousform rowcount path login sessionid));
+    $form->hide_form(qw(previousform rowcount path login sessionid));
 
-        print qq|
+    print qq|
 <p>
 <button data-dojo-type="dijit/form/Button" class="submit" type="submit" name="__action" value="continue">|
           . $locale->text('Continue')
           . qq|</button>
 </form>
 |;
-    }
 
     print qq|
 </body>

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -235,29 +235,16 @@ sub prepare_order {
     $form->{oldtransdate} = $form->{transdate};
 
     if ( $form->{type} eq 'sales_quotation' ) {
-        if ( !$form->{readonly} ) {
-            $form->{readonly} = 1 if $myconfig{acs} =~ /Quotations--Quotation/;
-        }
-
         $form->{selectformname} =
           qq|<option value="sales_quotation">| . $locale->text('Quotation');
     }
 
     if ( $form->{type} eq 'request_quotation' ) {
-        if ( !$form->{readonly} ) {
-            $form->{readonly} = 1 if $myconfig{acs} =~ /Quotations--RFQ/;
-        }
-
         $form->{selectformname} =
           qq|<option value="request_quotation">| . $locale->text('RFQ');
     }
 
     if ( $form->{type} eq 'sales_order' ) {
-        if ( !$form->{readonly} ) {
-            $form->{readonly} = 1
-              if $myconfig{acs} =~ /Order Entry--Sales Order/;
-        }
-
         $form->{selectformname} =
           qq|<option value="sales_order">|
           . $locale->text('Sales Order') . qq|
@@ -267,11 +254,6 @@ sub prepare_order {
     }
 
     if ( $form->{type} eq 'purchase_order' ) {
-        if ( !$form->{readonly} ) {
-            $form->{readonly} = 1
-              if $myconfig{acs} =~ /Order Entry--Purchase Order/;
-        }
-
         $form->{selectformname} =
           qq|<option value="purchase_order">|
           . $locale->text('Purchase Order') . qq|

--- a/old/bin/pe.pl
+++ b/old/bin/pe.pl
@@ -143,19 +143,17 @@ sub partsgroup_footer {
 
     $form->hide_form(qw(callback path login sessionid));
 
-    if ( $myconfig{acs} !~ /Goods \& Services--Add Group/ ) {
-        print qq|
+    print qq|
 <button data-dojo-type="dijit/form/Button" type="submit" class="submit" name="__action" value="save">|
           . $locale->text('Save')
           . qq|</button>
 |;
 
-        if ( $form->{id} && $form->{orphaned} ) {
-            print qq|
+    if ( $form->{id} && $form->{orphaned} ) {
+        print qq|
 <button data-dojo-type="dijit/form/Button" type="submit" class="submit" name="__action" value="delete">|
               . $locale->text('Delete')
               . qq|</button>|;
-        }
     }
 
     print qq|


### PR DESCRIPTION
The ACS thingy is from a distant past. These days we rely on the database to provide the correct access (and to prevent it).  The 'acs' key hasn't been populated in %myconfig for a loooong time, making conditional code blocks dead code, except for negative conditions, which are part of the main line of code.
