### PR TITLE
Immutable addresses (Ship To)

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1992,19 +1992,26 @@ sub list_locations_contacts
 
     # get rest for the customer
     my $query = qq|
-                    WITH eca AS (select * from entity_credit_account
-                                  where id = ?
-                    )
-            select  id as shiptolocationid,line_one as shiptoaddress1,line_two as shiptoaddress2,line_three as shiptoaddress3,city as shiptocity,
-                state as shiptostate,mail_code as shiptozipcode,country as shiptocountry
-            from (
-                            select (eca__list_locations(id)).*
-                              FROM eca
-                             UNION
-                            SELECT (entity__list_locations(entity_id)).*
-                              FROM eca
-                        ) l
-                         WHERE location_class = 3;
+WITH eca AS (
+  select * from entity_credit_account
+   where id = ?
+)
+select id as shiptolocationid,
+       line_one as shiptoaddress1,
+       line_two as shiptoaddress2,
+       line_three as shiptoaddress3,
+       city as shiptocity,
+       state as shiptostate,
+       mail_code as shiptozipcode,
+       country as shiptocountry
+  from (
+    select (eca__list_locations(id)).*
+      FROM eca
+     UNION
+    SELECT (entity__list_locations(entity_id)).*
+      FROM eca
+  ) l
+ WHERE location_class = 3;
           |;
 
 

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1346,7 +1346,7 @@ sub print_form {
         }
     }
     my @vars =
-      qw(name address1 address2 city state zipcode country contact phone fax email);
+      qw(name attn address1 address2 city state zipcode country contact phone fax email);
 
     $shipto = 0;
     # if there is no shipto fill it in from billto
@@ -1453,7 +1453,7 @@ sub print_form {
 
     paid subtotal total
 
-    shipto shiptoname shiptoaddress1 shiptoaddress2 shiptocity shiptostate
+    shipto shiptoname shiptoattn shiptoaddress1 shiptoaddress2 shiptocity shiptostate
     shiptozipcode shiptocountry shiptocontact shiptophone shiptoemail
                        ))};
         my $body = $template->{output};
@@ -1753,19 +1753,18 @@ sub ship_to {
                                 . $locale->text('Contact')
                                 . qq|</th>
                             </tr>
-                           <tr></tr>
-                              |;
+                              <tr>
+                                  <td><input type="radio" data-dojo-type="dijit/form/RadioButton" name="shiptoradiocontact" id="shiptoradiocontact_current" value="" CHECKED="CHECKED"></td>
+                                  <td colspan=2 nowrap>| . $locale->text('Current Attn') . qq|</td>
+                                  <td nowrap>$form->{shiptoattn}</td>
+                             </tr>    |;
 
                            for($i=1;$i<=$form->{totalcontacts};$i++)
                            {
                                my $checked = '';
-                               # $checked = 'CHECKED="CHECKED"'
-                               #     if ($form->{shiptocontactid}
-                               #         and ($form->{shiptocontactid} == $form->{"shiptolocationid_$i"}
-                               #              or $form->{shiptolocationid} == $form->{"locationid_$i"}));
                         print qq|
                               <tr>
-                                  <td><input type="radio" data-dojo-type="dijit/form/RadioButton" name="shiptoradiocontact" id="shiptoradiocontact_$i" value="$i" $checked></td>
+                                  <td><input type="radio" data-dojo-type="dijit/form/RadioButton" name="shiptoradiocontact" id="shiptoradiocontact_$i" value="$form->{"shiptocontact_$i"}"></td>
                                   <td nowrap>$form->{"shiptotype_$i"}</td>
                                   <td nowrap>$form->{"shiptodescription_$i"}</td>
                                   <td nowrap>$form->{"shiptocontact_$i"}</td>
@@ -1978,6 +1977,10 @@ sub setlocation_id
        my $index="shiptolocationid_".$loc_id_index;
 
        $form->{"shiptolocationid"}=$form->{$index};
+
+
+       $form->{"shiptoattn"} = $form->{shiptoradiocontact} if $form->{shiptoradiocontact};
+
 }
 
 

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -487,6 +487,7 @@ sub form_header {
     $business //= '';
     $department //= '';
     $exchangerate //= '';
+    $form->get_shipto( $form->{shiptolocationid} );
     print qq|
             $business
           </table>

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -511,6 +511,10 @@ sub form_header {
         <td colspan=3><input data-dojo-type="dijit/form/TextBox" id="shippingpoint" name="shippingpoint" size="35" value="$form->{shippingpoint}" $readonly></td>
           </tr>
           <tr>
+            <th align=right nowrap>| . $locale->text('Shipping Attn') . qq|</th>
+            <td><input name=shiptoattn id=shiptoattn data-dojo-type="dijit/form/TextBox" value="$form->{shiptoattn}"></td>
+          </tr>
+          <tr>
             <th align=right valign=top nowrap>| . $locale->text('Shipping Address') . qq|</th>
             <td>$form->{shiptoaddress1} <br/>
                 $form->{shiptoaddress2} <br/>

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -603,6 +603,7 @@ sub form_header {
    lock_description)
     );
 
+    $form->get_shipto( $form->{shiptolocationid} );
     print qq|
 <table width=100%>
   <tr class=listtop>
@@ -628,7 +629,19 @@ sub form_header {
           <tr class="shippingpoint-row">
         <th align=right>| . $locale->text('Shipping Point') . qq|</th>
         <td colspan=3><input data-dojo-type="dijit/form/TextBox" id=shippingpoint name=shippingpoint size=35 value="$form->{shippingpoint}"></td>
-          </tr>
+          </tr>|;
+    print qq|
+          <tr>
+            <th align=right nowrap>| . $locale->text('Shipping Address') . qq|</th>
+            <td>$form->{shiptoaddress1} <br/>
+                $form->{shiptoaddress2} <br/>
+                $form->{shiptocity}, $form->{shiptostate} <br/>
+                $form->{shiptozipcode} <br/>
+                $form->{shiptocountry}
+                </td>
+          </tr>|
+        if $form->{vc} eq 'customer';
+    print qq|
           <tr class="shipvia-row">
         <th align=right>| . $locale->text('Ship via') . qq|</th>
         <td colspan=3><textarea data-dojo-type="dijit/form/Textarea" id="shipvia" name="shipvia" cols="35"

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -627,10 +627,14 @@ sub form_header {
           $department
           $exchangerate
           <tr class="shippingpoint-row">
-        <th align=right>| . $locale->text('Shipping Point') . qq|</th>
+        <th align=right nowrap>| . $locale->text('Shipping Point') . qq|</th>
         <td colspan=3><input data-dojo-type="dijit/form/TextBox" id=shippingpoint name=shippingpoint size=35 value="$form->{shippingpoint}"></td>
           </tr>|;
     print qq|
+          <tr>
+            <th align=right nowrap>| . $locale->text('Shipping Attn') . qq|</th>
+            <td><input name=shiptoattn id=shiptoattn data-dojo-type="dijit/form/TextBox" value="$form->{shiptoattn}"></td>
+          </tr>
           <tr>
             <th align=right nowrap>| . $locale->text('Shipping Address') . qq|</th>
             <td>$form->{shiptoaddress1} <br/>

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1994,7 +1994,8 @@ sub create_links {
                 c.language_code, a.ponumber, a.reverse,
                 a.approved, ctf.default_reportable,
                 a.description, a.on_hold, a.crdate,
-                a.shipto as shiptolocationid, a.is_return, $seq,
+                a.shipto as shiptolocationid, a.shipto_attn as shiptoattn,
+                a.is_return, $seq,
                 t.workflow_id, t.reversing, t.reversing_reference,
                 t.reversed_by, t.reversed_by_reference
             FROM $arap a

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1179,7 +1179,8 @@ sub post_invoice {
                               reverse = ?,
                        is_return = ?,
                        setting_sequence = ?,
-                       shipto = ?
+               shipto = ?,
+               shipto_attn = ?
          WHERE id = ?
              |;
     $sth = $dbh->prepare($query);
@@ -1199,7 +1200,7 @@ sub post_invoice {
         $form->{language_code}, $form->{ponumber}, $approved,
         $form->{crdate} || 'today', $form->{reverse},
         $form->{is_return},     $form->{setting_sequence},
-         $form->{shiptolocationid},
+        $form->{shiptolocationid}, $form->{shiptoattn},
         $form->{id}
     ) || $form->dberror($query);
 

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -216,7 +216,7 @@ sub save {
         $query = qq|
             INSERT INTO oe
                 (id, ordnumber, quonumber, transdate,
-                reqdate, shippingpoint, shipvia,
+                reqdate, shippingpoint, shipvia, shipto_attn,
                 notes, intnotes, curr, closed,
                 person_id, language_code, ponumber, terms,
                 quotation, oe_class_id, entity_credit_account, workflow_id)
@@ -231,6 +231,7 @@ sub save {
             $form->{ordnumber},     $form->{quonumber},
             $form->{transdate},     $form->{reqdate},
             $form->{shippingpoint}, $form->{shipvia},
+            $form->{shiptoattn},
             $form->{notes},         $form->{intnotes},
             $form->{currency},      $form->{closed},
             $form->{person_id},
@@ -602,7 +603,7 @@ sub retrieve {
                 o.amount_tc AS invtotal, o.closed, o.reqdate,
                 o.quonumber, o.language_code,
                 o.ponumber, cr.entity_class,
-                shipto as shiptolocationid
+                shipto as shiptolocationid, shipto_attn as shiptoattn
             FROM oe o
             JOIN entity_credit_account cr ON (cr.id = o.entity_credit_account)
             JOIN entity vc ON (cr.entity_id = vc.id)

--- a/sql/changes/1.12/shipto_attn.sql
+++ b/sql/changes/1.12/shipto_attn.sql
@@ -1,0 +1,31 @@
+
+insert into contact_class (class)
+  values ('Ship to Attn');
+
+alter table ar
+  add column shipto_attn text;
+
+comment on column ar.shipto_attn is $$
+  Stores "At the attention of" information for shipping. Can be used
+  to print information on a person to contact about the shipment between
+  the (company) recipient name and the actual address.
+  $$;
+
+alter table oe
+  add column shipto_attn text;
+
+comment on column oe.shipto_attn is $$
+  Stores "At the attention of" information for shipping. Can be used
+  to print information on a person to contact about the shipment between
+  the (company) recipient name and the actual address.
+  $$;
+
+alter table ap
+  add column shipto_attn text;
+
+comment on column ap.shipto_attn is $$
+  This column exists to make sure the 'ar' and 'ap' tables have the same
+  columns and therefor can be accessed with the same queries (except for
+  the table name...).
+  $$;
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -189,3 +189,4 @@ mc/delete-migration-validation-data.sql
 1.12/reconciliation-workflow.sql
 1.12/rm-new_shipto.sql
 1.12/mv-location-temporality.sql
+1.12/shipto_attn.sql

--- a/templates/demo/invoice.html
+++ b/templates/demo/invoice.html
@@ -1,12 +1,16 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2024-08-14
    File:     invoice.html
    Set:      demo
 
 Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
+
+Version   Changes
+1.1       Extended with 'shiptoattn' (at the attention of)
+
 
 -?>
 <!DOCTYPE html>
@@ -53,6 +57,7 @@ releases. No explicit versioning was applied before 2021-01-04.
             <?lsmb text('Fax: [_1]', customerfax) ?> <?lsmb END ?> <?lsmb IF email ?><br>
             <?lsmb email ?> <?lsmb END ?></td>
             <td><?lsmb shiptoname ?><br>
+            <?lsmb IF shiptoattn ?><?lsmb shiptoattn ?><br><?lsmb END ?>
             <?lsmb shiptoaddress1 ?> <?lsmb IF shiptoaddress2 ?><br>
             <?lsmb shiptoaddress2 ?> <?lsmb END ?><br>
             <?lsmb shiptocity ?> <?lsmb IF shiptostate ?> , <?lsmb shiptostate ?> <?lsmb END ?>

--- a/templates/demo/invoice.tex
+++ b/templates/demo/invoice.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.2
-   Date:     2022-07-22
+   Version:  1.3
+   Date:     2024-08-14
    File:     invoice.tex
    Set:      demo
 
@@ -11,7 +11,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 Version   Changes
 1.1       Fix spelling mistake (acrue -> accrue)
 1.2       Merged xelatex targetting templates with those targetting pdflatex
-
+1.3       Extended with 'shiptoattn' (at the attention of)
 
 
 The "$FORMAT($PROCESSOR)" below evaluates to e.g. "pdf(pdflatex)".
@@ -100,6 +100,10 @@ Fax: <?lsmb customerfax ?>
 
 <?lsmb shiptoname ?>
 
+<?lsmb IF shiptoattn -?>
+<?lsmb shiptoattn ?>
+
+<?lsmb END -?>
 <?lsmb shiptoaddress1 ?>
 
 <?lsmb shiptoaddress2 ?>

--- a/workflows/ar-ap.workflow.xml
+++ b/workflows/ar-ap.workflow.xml
@@ -42,6 +42,7 @@
     <action name="update" resulting_state="NOCHANGE" />
     <action name="ship_to" resulting_state="NOCHANGE">
       <condition name="is_invoice" />
+      <condition name="is_sales" />
     </action>
     <action name="schedule" resulting_state="NOCHANGE">
       <condition name="!is-batch-member" />

--- a/workflows/order-quote.workflow.xml
+++ b/workflows/order-quote.workflow.xml
@@ -13,7 +13,9 @@
     <action name="print_and_save_as_new" resulting_state="NOCHANGE" />
     <action name="save" resulting_state="NOCHANGE" />
     <action name="save_as_new" resulting_state="NOCHANGE" />
-    <action name="ship_to" resulting_state="NOCHANGE" />
+    <action name="ship_to" resulting_state="NOCHANGE">
+      <condition name="is_sales" />
+    </action>
     <action name="sales_invoice" resulting_state="NOCHANGE">
       <condition name="is_order" />
       <condition name="is_sales" />


### PR DESCRIPTION
On the road to immutable addresses, this is step one of two: it creates immutable shipping addresses, leaving the immutability of invoice addresses to be implemented/desired.

At the same time, fix the "Ship To" button being on purchase documents: although they support registering shipping addresses, the UI does not, so offering the button doesn't make sense. Even more: the shipping addresses probably should be "our" locations (whereas the list of locations is currently that of the counterparty -- in case of a vendor: *their* locations; the shipping origins, not the destinations).

This PR also fixes the fact that contact information wasn't being retained nor presented on the invoice. For that purpose, we're now presenting "Ship To Attn", also incorporated in the invoice template examples.

Addresses part of #7377.