### PR TITLE
Notify user of the need to upload new templates

### DIFF
--- a/sql/changes/1.8/notify-import-financial-report-templates.sql
+++ b/sql/changes/1.8/notify-import-financial-report-templates.sql
@@ -1,0 +1,15 @@
+
+-- The template count condition below prevents this notification
+-- being thrown on new databases. This change file *will* run on
+-- a new database, but the 'template' table will be empty.
+
+select pg_notify(
+  'upgrade.' || current_database(),
+  $json${"type":"feedback","content":"As of 1.8, the balance sheet and income statement templates used to generate downloaded documents, have been moved to the database. Please go to "System > Templates" and upload the templates provided in the templates/ directory. Until this action is completed, these reports are available only in the UI, but the download links will not work.$json$)
+ where (select count(*) from template) > 0
+   and (not exists (select 1
+                      from template
+                     where template_name = 'balance_sheet')
+        or not exists (select 1
+                         from template
+                        where template_name = 'PNL'));

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -140,6 +140,7 @@ mc/delete-migration-validation-data.sql
 1.8/reconciliation-links-cascade.sql
 1.8/initialize-payments-from-invoices.sql
 1.8/add-payment-links-indices.sql
+1.8/notify-import-financial-report-templates.sql
 # 1.9 changes
 1.9/templates-last-modified-no-tz.sql
 1.9/drop-view-tx_report.sql


### PR DESCRIPTION
The user needs to upload balance sheet and income statement templates, because these are no longer taken from the templates/ directory, but from the database instead.

Closes #4692