### PR TITLE
Fix the outstanding summary report generation

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -499,7 +499,7 @@ sub _render {
             %{ preprocess($vars, sub { $self->{format_plugin}->escape(@_) } ) },
             %{$self->{additional_vars} // {}},
             %$cvars,
-            escape => $escape,
+            escape => sub { $self->{format_plugin}->escape(@_) },
             text => sub {
                 return $self->{format_plugin}->escape($self->_maketext(@_));
             },

--- a/templates/lib/dynatable.tex
+++ b/templates/lib/dynatable.tex
@@ -63,7 +63,7 @@ FOREACH COL IN columns;
         UNLESS loop.first();
            ' & ';
         END;
-        COL.name;
+        escape(COL.name);
     END;
 END;
 -?>\tabularnewline


### PR DESCRIPTION
The outstanding summary report has a column named '# Invoices' for 'Number of invoices'. However, the hash sign doesn't get escaped correctly, leading to a PDF generation error.
