### PR TITLE
Fix orders and quotes being frozen after Update

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -985,11 +985,11 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
 sub update {
     $form->{nextsub} = 'update';
 
-    $form->create_links( module => "OE", # effectively 'none'
-             myconfig => \%myconfig,
-             vc => $form->{vc},
-             billing => 0,
-             job => 1 );
+    # $form->create_links( module => "OE", # effectively 'none'
+    #          myconfig => \%myconfig,
+    #          vc => $form->{vc},
+    #          billing => 0,
+    #          job => 1 );
 
     $form->get_regular_metadata(
         \%myconfig,


### PR DESCRIPTION
Follow-up to #8348 which fixes most of the frozen orders and quotes, but not quotes and orders becoming frozen after Update in SAVED state.
