### PR TITLE
Increase dependency to fixed version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -94,7 +94,7 @@ requires 'PGObject::Type::BigFloat', '2.1.1';
 requires 'PGObject::Type::DateTime', '2.0.2';
 requires 'PGObject::Type::ByteString', '1.2.3';
 requires 'PGObject::Util::DBMethod', '1.1.0';
-requires 'PGObject::Util::DBAdmin', '1.6.1';
+requires 'PGObject::Util::DBAdmin', '1.6.2';
 requires 'Plack', '1.0031';
 requires 'Plack::App::File';
 requires 'Plack::Builder';


### PR DESCRIPTION
PGObject::Util::DBAdmin 1.6.2 fixes the port being included in the connection string; we want to use the known-fixed dependency, even though there is probably a very small minority using this functionality (since it went undetected for 3+ years...)
