### PR TITLE
feat: allow hyphen in host

### DIFF
--- a/lib/LedgerSMB/Admin/Command.pm
+++ b/lib/LedgerSMB/Admin/Command.pm
@@ -70,7 +70,7 @@ sub connect_data_from_arg {
     $arg =~ m!^
         (postgresql://)?
         (((?<user>[^@]+)@)?
-         (?<host>\[[:0-9a-zA-Z]+\]|[\w.]+)
+         (?<host>\[[:0-9a-zA-Z]+\]|[\w.-]+)
          (:(?<port>\d+))?/)?
         ((?<dbname>[a-z0-9A-Z_% -]+)
          (\#(?<schema>[a-z0-9A-Z_% -]+))?


### PR DESCRIPTION
For the case where host has hyphens. Like when trying to use to a digitalocean managed database server for your ledgersmb, the host looks like this: ledgersmb-do-user-66666666-0.k.db.ondigitalocean.com
