### PR TITLE
feat: allow hyphen in host

### DIFF
--- a/lib/LedgerSMB/Admin/Command.pm
+++ b/lib/LedgerSMB/Admin/Command.pm
@@ -70,7 +70,7 @@ sub connect_data_from_arg {
     $arg =~ m!^
         (postgresql://)?
         (((?<user>[^@]+)@)?
-         (?<host>\[[:0-9a-zA-Z]+\]|[\w.]+)
+         (?<host>\[[:0-9a-zA-Z]+\]|[\w.-]+)
          (:(?<port>\d+))?/)?
         ((?<dbname>[a-z0-9A-Z_% -]+)
          (\#(?<schema>[a-z0-9A-Z_% -]+))?
@@ -100,12 +100,13 @@ sub connect_data_from_arg {
 sub dispatch {
     my ($self, $command, @args) = @_;
 
-    $command //= 'help';
-    my $dispatch = $self->can($command);
-    die "Unknown command '$command'"
+    my $func = $command // 'help';
+    $func =~ tr/\-/_/;
+    my $dispatch = $self->can($func);
+    die "Unknown command '$command' ($func)"
         if (not $dispatch
             or ($command eq 'run')
-            or ($command !~ m/^([a-zA-Z]+)$/));
+            or ($func !~ m/^([a-zA-Z_]+)$/));
 
     return $self->help($command, @args)
         if $command eq 'help';
@@ -211,4 +212,3 @@ Copyright (C) 2020 The LedgerSMB Core Team
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with
 your software.
-


### PR DESCRIPTION
For the case where host has hyphens. Like when trying to use to a digitalocean managed database server for your ledgersmb, the host looks like this: ledgersmb-do-user-66666666-0.k.db.ondigitalocean.com

