### PR TITLE
Restore heading_account in header

### DIFF
--- a/templates/demo/PNL.csv
+++ b/templates/demo/PNL.csv
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2024-10-08
    File:     PNL.csv
    Set:      demo
 
@@ -9,7 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
-account,description,is_heading<?lsmb
+account,description,is_heading,heading_account<?lsmb
  FOREACH col IN report.sorted_col_ids -?>
 ,"<?lsmb report.cheads.ids.$col.props.description ?>"<?lsmb END; ?>
 <?lsmb FOREACH row IN report.sorted_row_ids ; -?>

--- a/templates/demo/balance_sheet.csv
+++ b/templates/demo/balance_sheet.csv
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.0
-   Date:     2021-01-04
+   Version:  1.1
+   Date:     2024-10-08
    File:     balance_sheet.csv
    Set:      demo
 
@@ -9,7 +9,7 @@ Template version numbers are explicitly not aligned across templates or
 releases. No explicit versioning was applied before 2021-01-04.
 
 -?>
-account,description,is_heading<?lsmb
+account,description,is_heading,heading_account<?lsmb
  FOREACH col IN report.sorted_col_ids -?>
 ,"<?lsmb report.cheads.ids.$col.props.description ?>"<?lsmb END; ?>
 <?lsmb FOREACH row IN report.sorted_row_ids ; -?>


### PR DESCRIPTION
Restore the account_heading in CSV reports to match with exported data.
Undo part of #8247 
