### PR TITLE
Run API tests in 'node' environment to unbreak 'undici' (for good?)

### DIFF
--- a/UI/jest.config.js
+++ b/UI/jest.config.js
@@ -109,10 +109,6 @@ module.exports = {
     moduleFileExtensions: ["js", "json", "vue"],
 
     // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-    moduleNameMapper: {
-        "^@/i18n": "<rootDir>/tests/common/i18n", // Jest doesn't support esm or top level await well
-        "^@/(.*)$": "<rootDir>/src/$1"
-    },
 
     // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
     modulePathIgnorePatterns: [],
@@ -142,7 +138,43 @@ module.exports = {
     // Run tests from one or more projects, found in the specified paths; also takes path globs.
     // This option is the CLI equivalent of the projects configuration option.
     // Note that if configuration files are found in the specified paths, all projects specified within those configuration files will be run.
-    projects: [],
+    projects: [
+        {
+            displayName: "browser",
+            moduleFileExtensions: ["js", "json", "vue"],
+            moduleNameMapper: {
+              "^@/i18n": "<rootDir>/tests/common/i18n", // Jest doesn't support esm or top level await well
+              "^@/(.*)$": "<rootDir>/src/$1"
+            },
+            testMatch: [ "<rootDir>/tests/specs/**/*.spec.js" ],
+            setupFiles: ["<rootDir>/tests/common/jest.polyfills.js"],
+            setupFilesAfterEnv: [ "<rootDir>/tests/common/jest-setup.js" ],
+            testEnvironment: "jsdom",
+            testEnvironmentOptions: {
+                customExportConditions: ["node", "node-addons"]
+            },
+            testPathIgnorePatterns: [ "<rootDir>/tests/specs/openapi/.*\.spec\.js" ],
+            transform: {
+                "^.+\\.yaml$": "yaml-jest-transform",
+                "^.+\\.js$": "babel-jest",
+                "^.+\\.vue$": "@vue/vue3-jest",
+                "^@": "babel-jest",
+
+            },
+        },
+        {
+            displayName: "API",
+            moduleFileExtensions: ["js", "json", "vue"],
+            testMatch: [ "<rootDir>/tests/specs/openapi/**/*.spec.js" ],
+            testEnvironment: "node",
+            transform: {
+                "^.+\\.yaml$": "yaml-jest-transform",
+                "^.+\\.js$": "babel-jest",
+                "^.+\\.vue$": "@vue/vue3-jest",
+                "^@": "babel-jest",
+            },
+        }
+    ],
 
     // Use this configuration option to add custom reporters to Jest
     // reporters: [],
@@ -179,10 +211,10 @@ module.exports = {
     sandboxInjectedGlobals: [],
 
     // The paths to modules that run some code to configure or set up the testing environment before each test
-    setupFiles: ["<rootDir>/tests/common/jest.polyfills.js"],
+    //setupFiles: ["<rootDir>/tests/common/jest.polyfills.js"],
 
     // A list of paths to modules that run some code to configure or set up the testing framework before each test
-    setupFilesAfterEnv: ["<rootDir>/tests/common/jest-setup.js"],
+    setupFilesAfterEnv: [],
 
     skipFilter: false,
 
@@ -225,6 +257,7 @@ module.exports = {
     transform: {
         "^.+\\.yaml$": "yaml-jest-transform",
         "^.+\\.js$": "babel-jest",
+        "^@": "babel-jest",
         "^.+\\.vue$": "@vue/vue3-jest"
     },
 

--- a/UI/tests/specs/openapi/API-contacts-business_types.spec.js
+++ b/UI/tests/specs/openapi/API-contacts-business_types.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -12,7 +15,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml", 'utf8'));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-contacts-sic.spec.js
+++ b/UI/tests/specs/openapi/API-contacts-sic.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -12,7 +15,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-country.spec.js
+++ b/UI/tests/specs/openapi/API-country.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -12,7 +15,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-gifi.spec.js
+++ b/UI/tests/specs/openapi/API-gifi.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -12,7 +15,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-invoices.spec.js
+++ b/UI/tests/specs/openapi/API-invoices.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -17,7 +20,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-languages.spec.js
+++ b/UI/tests/specs/openapi/API-languages.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -12,7 +15,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-orders.spec.js
+++ b/UI/tests/specs/openapi/API-orders.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -17,7 +20,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-products-pricegroups.spec.js
+++ b/UI/tests/specs/openapi/API-products-pricegroups.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -12,7 +15,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";

--- a/UI/tests/specs/openapi/API-products-warehouses.spec.js
+++ b/UI/tests/specs/openapi/API-products-warehouses.spec.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment node
+ */
 /* global process, require */
 
 // Import test packages
@@ -12,7 +15,9 @@ const openapi = process.env.PWD.replace("/UI", "");
 jestOpenAPI(openapi + "/openapi/API.yaml");
 
 // Load the API definition
-const API_yaml = require(openapi + "/openapi/API.yaml");
+const fs = require("node:fs");
+const yaml = require('js-yaml');
+const API_yaml = yaml.load(fs.readFileSync(openapi + "/openapi/API.yaml"));
 
 // Set API version to use
 const api = "erp/api/v0";


### PR DESCRIPTION
This solves the incompatibility between 'undici' and the jsdom environment.
