### PR TITLE
Fix searching draft transactions

### DIFF
--- a/lib/LedgerSMB/Scripts/drafts.pm
+++ b/lib/LedgerSMB/Scripts/drafts.pm
@@ -157,7 +157,7 @@ sub list_drafts {
     $request->open_form;
     return $request->render_report(
         LedgerSMB::Report::Unapproved::Drafts->new(
-            $request->%{ qw( reference type ) },
+            $request->%{ qw( reference type language _locale ) },
             formatter_options => $request->formatter_options,
             from_date => $request->parse_date( $request->{from_date} ),
             to_date => $request->parse_date( $request->{to_date} ),


### PR DESCRIPTION
The data was missing for the Report to instantiate a translation.