### PR TITLE
Add ADR and code changes for minimal Perl code layout

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -20,7 +20,6 @@ requires 'Email::MessageID';
 requires 'Email::Sender::Simple';
 requires 'Email::Sender', '2.601'; # 2.601 adds 'sasl_authenticator'
 requires 'Email::Stuffer';
-requires 'Feature::Compat::Try';
 requires 'File::Find::Rule';
 requires 'Hash::Merge';
 requires 'HTML::Entities';

--- a/doc/adr/0102-perl-pragmas-top-declarations.md
+++ b/doc/adr/0102-perl-pragmas-top-declarations.md
@@ -1,0 +1,61 @@
+# 0101 Perl pragma declarations on top of file
+
+Date: 2025-01-03
+
+## Status
+
+Draft
+
+## Context
+
+The `use` statement in Perl is used for two distinct purposes. The most
+straight forward being loading of dependency modules (e.g., `use LedgerSMB;`).
+The other purpose is to enable "pragmas" (e.g. `use strict;`); these change
+Perl's behaviour in the scope in which they are declared.
+
+Traditionally, Perl pragmas have been declared after the opening `package`
+line in a module; like this:
+
+```perl
+package LedgerSMB::PGDate;
+
+use Moose;
+
+use strict;
+use warnings;
+
+...
+
+1;
+```
+
+In recent years, syntax was added to Perl which depends on the correct pragmas
+to be enabled (or on older Perls compatibility modules to be loaded); e.g.:
+
+```perl
+use v5.40;
+
+class LedgerSMB::PGDate {
+   ...
+}
+```
+
+## Decision
+
+1. Pragmas such as `utf8`, `warnings`, `strict`, `vX.YY` (minimum Perl version
+   requirement declaration) should be declared
+   *before* the first line of of code (e.g. the `package` declaration)
+2. Modules which modify or enhance syntax, such as `Syntax::*`, `Feature::Compat::*`
+   and `Object::Pad`, should be declared *after* the pragmas and before the
+   `package` or `class` declarations
+3. All regular module dependencies need to be declared *after* the `package`
+   declaration
+4. All code in `lib/`, `t/` and `xt/` must declare the minimum Perl version using
+   the `vX.YY` syntax.
+
+## Consequences
+
+
+
+## Annotations
+

--- a/doc/adr/0102-perl-pragmas-top-declarations.md
+++ b/doc/adr/0102-perl-pragmas-top-declarations.md
@@ -4,7 +4,7 @@ Date: 2025-01-03
 
 ## Status
 
-Draft
+Accepted
 
 ## Context
 

--- a/lib/LedgerSMB/Admin/Command/backup.pm
+++ b/lib/LedgerSMB/Admin/Command/backup.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Admin::Command::backup;
 
 =head1 NAME
@@ -7,17 +11,12 @@ LedgerSMB::Admin::Command::backup - ledgersmb-admin 'backup' command
 
 =cut
 
-use strict;
-use warnings;
-
 use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
-
-use Feature::Compat::Try;
 
 
 sub run {

--- a/lib/LedgerSMB/Admin/Command/backup.pm
+++ b/lib/LedgerSMB/Admin/Command/backup.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Admin::Command::backup;
 

--- a/lib/LedgerSMB/Admin/Command/backup.pm
+++ b/lib/LedgerSMB/Admin/Command/backup.pm
@@ -15,6 +15,7 @@ use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 

--- a/lib/LedgerSMB/Admin/Command/copy.pm
+++ b/lib/LedgerSMB/Admin/Command/copy.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Admin::Command::copy;
 

--- a/lib/LedgerSMB/Admin/Command/copy.pm
+++ b/lib/LedgerSMB/Admin/Command/copy.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Admin::Command::copy;
 
 =head1 NAME
@@ -7,17 +11,12 @@ LedgerSMB::Admin::Command::copy - ledgersmb-admin 'copy' command
 
 =cut
 
-use strict;
-use warnings;
-
 use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
-
-use Feature::Compat::Try;
 
 sub run {
     my ($self, $dbname, $newname) = @_;

--- a/lib/LedgerSMB/Admin/Command/copy.pm
+++ b/lib/LedgerSMB/Admin/Command/copy.pm
@@ -15,6 +15,7 @@ use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 

--- a/lib/LedgerSMB/Admin/Command/create.pm
+++ b/lib/LedgerSMB/Admin/Command/create.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Admin::Command::create;
 

--- a/lib/LedgerSMB/Admin/Command/create.pm
+++ b/lib/LedgerSMB/Admin/Command/create.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Admin::Command::create;
 
 =head1 NAME
@@ -6,9 +10,6 @@ package LedgerSMB::Admin::Command::create;
 LedgerSMB::Admin::Command::create - ledgersmb-admin 'create' command
 
 =cut
-
-use strict;
-use warnings;
 
 use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
@@ -18,7 +19,6 @@ extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 
 use Getopt::Long qw(GetOptionsFromArray);
-use Feature::Compat::Try;
 
 has options => (is => 'ro', default => sub { {} });
 

--- a/lib/LedgerSMB/Admin/Command/create.pm
+++ b/lib/LedgerSMB/Admin/Command/create.pm
@@ -15,6 +15,7 @@ use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 

--- a/lib/LedgerSMB/Admin/Command/destroy.pm
+++ b/lib/LedgerSMB/Admin/Command/destroy.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Admin::Command::destroy;
 

--- a/lib/LedgerSMB/Admin/Command/destroy.pm
+++ b/lib/LedgerSMB/Admin/Command/destroy.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Admin::Command::destroy;
 
 =head1 NAME
@@ -7,17 +11,12 @@ LedgerSMB::Admin::Command::destroy - ledgersmb-admin 'destroy' command
 
 =cut
 
-use strict;
-use warnings;
-
 use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
-
-use Feature::Compat::Try;
 
 my $logger;
 

--- a/lib/LedgerSMB/Admin/Command/destroy.pm
+++ b/lib/LedgerSMB/Admin/Command/destroy.pm
@@ -15,6 +15,7 @@ use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 

--- a/lib/LedgerSMB/Admin/Command/restore.pm
+++ b/lib/LedgerSMB/Admin/Command/restore.pm
@@ -19,6 +19,7 @@ use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 

--- a/lib/LedgerSMB/Admin/Command/restore.pm
+++ b/lib/LedgerSMB/Admin/Command/restore.pm
@@ -1,3 +1,8 @@
+
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Admin::Command::restore;
 
 =head1 NAME
@@ -6,8 +11,6 @@ LedgerSMB::Admin::Command::restore - ledgersmb-admin 'restore' command
 
 =cut
 
-use strict;
-use warnings;
 use version;
 
 use File::Temp;
@@ -18,8 +21,6 @@ use LedgerSMB::Database;
 use Moose;
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
-
-use Feature::Compat::Try;
 
 my $schema = 'public';
 

--- a/lib/LedgerSMB/Admin/Command/restore.pm
+++ b/lib/LedgerSMB/Admin/Command/restore.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Admin::Command::restore;
 

--- a/lib/LedgerSMB/Admin/Command/upgrade.pm
+++ b/lib/LedgerSMB/Admin/Command/upgrade.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Admin::Command::upgrade;
 

--- a/lib/LedgerSMB/Admin/Command/upgrade.pm
+++ b/lib/LedgerSMB/Admin/Command/upgrade.pm
@@ -16,6 +16,7 @@ use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 

--- a/lib/LedgerSMB/Admin/Command/upgrade.pm
+++ b/lib/LedgerSMB/Admin/Command/upgrade.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Admin::Command::upgrade;
 
 =head1 NAME
@@ -7,9 +11,6 @@ LedgerSMB::Admin::Command::upgrade - ledgersmb-admin 'upgrade' command
 
 =cut
 
-use strict;
-use warnings;
-
 use Getopt::Long qw(GetOptionsFromArray);
 use LedgerSMB::Admin::Command;
 use LedgerSMB::Database;
@@ -17,8 +18,6 @@ use LedgerSMB::Database;
 use Moose;
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
-
-use Feature::Compat::Try;
 
 has modules_only => (is => 'ro');
 

--- a/lib/LedgerSMB/Admin/Command/user.pm
+++ b/lib/LedgerSMB/Admin/Command/user.pm
@@ -1,3 +1,8 @@
+
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Admin::Command::user;
 
 =head1 NAME
@@ -5,9 +10,6 @@ package LedgerSMB::Admin::Command::user;
 LedgerSMB::Admin::Command::user - ledgersmb-admin 'user' command
 
 =cut
-
-use strict;
-use warnings;
 
 use Getopt::Long qw(GetOptionsFromArray);
 use LedgerSMB::Admin::Command;
@@ -24,8 +26,6 @@ use Array::PrintCols;
 use Moose;
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
-
-use Feature::Compat::Try;
 
 has options => (is => 'ro', default => sub { {} });
 

--- a/lib/LedgerSMB/Admin/Command/user.pm
+++ b/lib/LedgerSMB/Admin/Command/user.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Admin::Command::user;
 

--- a/lib/LedgerSMB/Admin/Command/user.pm
+++ b/lib/LedgerSMB/Admin/Command/user.pm
@@ -24,6 +24,7 @@ use LedgerSMB::User;
 use Array::PrintCols;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 

--- a/lib/LedgerSMB/FileFormats/ISO20022/CAMT053.pm
+++ b/lib/LedgerSMB/FileFormats/ISO20022/CAMT053.pm
@@ -1,10 +1,12 @@
-package LedgerSMB::FileFormats::ISO20022::CAMT053;
-use strict;
+
+use v5.36;
+use experimental 'try';
 use warnings;
+
+package LedgerSMB::FileFormats::ISO20022::CAMT053;
 
 use XML::LibXML;
 use XML::LibXML::XPathContext;
-use Feature::Compat::Try;
 
 =head1 NAME
 

--- a/lib/LedgerSMB/FileFormats/ISO20022/CAMT053.pm
+++ b/lib/LedgerSMB/FileFormats/ISO20022/CAMT053.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::FileFormats::ISO20022::CAMT053;
 

--- a/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
+++ b/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
@@ -1,8 +1,10 @@
+
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::FileFormats::OFX::BankStatement;
 
-use warnings;
-use strict;
-use Feature::Compat::Try;
 use XML::LibXML;
 
 =head1 NAME

--- a/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
+++ b/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::FileFormats::OFX::BankStatement;
 

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -1,3 +1,7 @@
+
+use v5.36;
+use experimental 'try';
+
 package LedgerSMB::PSGI;
 
 =head1 NAME
@@ -49,7 +53,6 @@ use Log::Any;
 use Log::Log4perl;
 use Scalar::Util qw{ reftype };
 use String::Random;
-use Feature::Compat::Try;
 
 # To build the URL space
 use Plack;

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -1,5 +1,6 @@
 
 use v5.36;
+use warnings;
 use experimental 'try';
 
 package LedgerSMB::PSGI;
@@ -22,9 +23,6 @@ Maps the URL name space to the various entry points.
 This module doesn't specify any (public) methods.
 
 =cut
-
-use strict;
-use warnings;
 
 use LedgerSMB;
 use LedgerSMB::App_State;

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Scripts::account;
 

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Scripts::account;
 
 =head1 NAME
@@ -19,11 +23,7 @@ maintainable.
 
 =cut
 
-use strict;
-use warnings;
-
 use Log::Any;
-use Feature::Compat::Try;
 
 use LedgerSMB;
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Scripts::contact;
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -1,4 +1,7 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
 
 package LedgerSMB::Scripts::contact;
 
@@ -14,11 +17,6 @@ This module is the UI controller for the customer, vendor, etc functions; it
 =head1 METHODS
 
 =cut
-
-use v5.36.1;
-use warnings;
-
-use Feature::Compat::Try;
 
 use LedgerSMB;
 use LedgerSMB::Entity::Company;

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Scripts::import_csv;
 

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Scripts::import_csv;
 
 =head1 NAME
@@ -16,11 +20,7 @@ This module doesn't specify any methods.
 
 =cut
 
-use strict;
-use warnings;
-
 use JSON::PP;
-use Feature::Compat::Try;
 
 use LedgerSMB::AA;
 use LedgerSMB::Batch;

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Scripts::setup;
 

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1,4 +1,8 @@
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::Scripts::setup;
 
 =head1 NAME
@@ -22,8 +26,6 @@ management tasks.
 # these are maintained inside the LedgerSMB::Database package.
 #
 
-use strict;
-use warnings;
 use version;
 
 use Carp;
@@ -35,7 +37,6 @@ use HTTP::Status qw( HTTP_OK HTTP_INTERNAL_SERVER_ERROR HTTP_UNAUTHORIZED );
 use Log::Any;
 use MIME::Base64;
 use Scope::Guard;
-use Feature::Compat::Try;
 
 use LedgerSMB;
 use LedgerSMB::App_State;

--- a/lib/LedgerSMB/Template/Plugin/External.pm
+++ b/lib/LedgerSMB/Template/Plugin/External.pm
@@ -26,6 +26,7 @@ use Log::Any;
 use POSIX;
 
 use Moo;
+use experimental 'try'; # Work around Moo re-enabling experimenal warnings
 
 my $logger = Log::Any->get_logger(category => __PACKAGE__);
 

--- a/lib/LedgerSMB/Template/Plugin/External.pm
+++ b/lib/LedgerSMB/Template/Plugin/External.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::Template::Plugin::External;
 

--- a/lib/LedgerSMB/Template/Plugin/External.pm
+++ b/lib/LedgerSMB/Template/Plugin/External.pm
@@ -1,9 +1,9 @@
 
-package LedgerSMB::Template::Plugin::External;
-
 use v5.36;
+use experimental 'try';
 use warnings;
-use Feature::Compat::Try;
+
+package LedgerSMB::Template::Plugin::External;
 
 =head1 NAME
 

--- a/old/lib/LedgerSMB/oldHandler.pm
+++ b/old/lib/LedgerSMB/oldHandler.pm
@@ -44,6 +44,8 @@
 #
 #######################################################################
 
+use experimental 'try';
+
 package lsmb_legacy;
 
 use LedgerSMB::User;
@@ -56,7 +58,6 @@ use LedgerSMB::PSGI::Util;
 
 use HTML::Escape;
 use Log::Any;
-use Feature::Compat::Try;
 
 our $logger;
 

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -21,18 +21,18 @@ LedgerSMB::old_code - dispatching from new code to old code
 
 =cut
 
+use v5.36;
+use experimental 'try';
+use warnings;
+
 package LedgerSMB::old_code;
 
-
-use strict;
-use warnings;
 use CGI::Parse::PSGI qw(parse_cgi_output);
 use IO::File;
 use LedgerSMB::Form;
 use Log::Any;
 use POSIX 'SEEK_SET';
 use Symbol;
-use Feature::Compat::Try;
 
 use parent qw(Exporter);
 our @EXPORT_OK = qw(dispatch);

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -22,8 +22,8 @@ LedgerSMB::old_code - dispatching from new code to old code
 =cut
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package LedgerSMB::old_code;
 

--- a/xt/lib/PageObject/App/Main.pm
+++ b/xt/lib/PageObject/App/Main.pm
@@ -8,6 +8,7 @@ package PageObject::App::Main;
 use PageObject;
 
 use Moose;
+use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 use namespace::autoclean;
 extends 'PageObject';
 

--- a/xt/lib/PageObject/App/Main.pm
+++ b/xt/lib/PageObject/App/Main.pm
@@ -1,7 +1,7 @@
 
 use v5.36;
-use experimental 'try';
 use warnings;
+use experimental 'try';
 
 package PageObject::App::Main;
 

--- a/xt/lib/PageObject/App/Main.pm
+++ b/xt/lib/PageObject/App/Main.pm
@@ -1,14 +1,15 @@
-package PageObject::App::Main;
 
-use strict;
+use v5.36;
+use experimental 'try';
 use warnings;
+
+package PageObject::App::Main;
 
 use PageObject;
 
 use Moose;
 use namespace::autoclean;
 extends 'PageObject';
-use Feature::Compat::Try;
 
 
 __PACKAGE__->self_register(


### PR DESCRIPTION
Eliminate Feature::Compat::Try which was there for pre-5.36 compatibility.
Set up code layout for modified files per the ADR.