### PR TITLE
Display applicable buttons on readonly forms

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -19,6 +19,7 @@ Cleanup & architecture improvements
 * Deprecated 'ledgersmb.conf' configuration in favor of 'ledgersmb.yaml' (#8570)
 * Loading of main section more predictable through state machine use (#8530)
 * Removed deps in favor of (experimental) built-in functionality (#8571, #8572)
+* Allow workflows to determine buttons on read-only screens (#8583)
 
 Updated dependencies
 * Feature::Compat::Try (removed)

--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -391,7 +391,7 @@ sub recurring_transactions {
 
             $column_data{id} = {
                 text => $ref->{id},
-                href => qq|$module?__action=edit&id=$ref->{id}&vc=$ref->{vc}&type=$type&readonly=1|,
+                href => qq|$module?__action=edit&id=$ref->{id}&vc=$ref->{vc}&type=$type|,
                 };
 
             $column_data{repeat} = $repeat;

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -386,41 +386,38 @@ sub display_form
 
   $transdate = $form->datetonum( \%myconfig, $form->{transdate} );
   my @buttons;
-  if ( !$form->{readonly} ) {
-      %button_types = (
-          print => 'lsmb/PrintButton'
-          );
-      for my $action_name ( $wf->get_current_actions ) {
-          my $action = $wf->get_action( $action_name );
+    %button_types = (
+        print => 'lsmb/PrintButton'
+        );
+    for my $action_name ( $wf->get_current_actions ) {
+        my $action = $wf->get_action( $action_name );
 
-          next if ($action->ui // '') eq 'none';
-          push @buttons, {
-              ndx   => $action->order,
-              name  => $action->name,
-              text => $locale->maketext($action->text),
-              doing => ($action->doing ? $locale->maketext($action->doing) : ''),
-              done  => ($action->done ? $locale->maketext($action->done) : ''),
-              type  => $button_types{$action->ui},
-              tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
-          };
-      }
+        next if ($action->ui // '') eq 'none';
+        push @buttons, {
+            ndx   => $action->order,
+            name  => $action->name,
+            text => $locale->maketext($action->text),
+            doing => ($action->doing ? $locale->maketext($action->doing) : ''),
+            done  => ($action->done ? $locale->maketext($action->done) : ''),
+            type  => $button_types{$action->ui},
+            tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
+        };
+    }
 
-      @buttons = map {
-          {
-              name => '__action',
-              value => $_->{name},
-              text => $_->{text},
-              type => 'submit',
-              class => $_->{class} // 'submit',
-              order => $_->{ndx},
-              'data-lsmb-doing' => $_->{doing},
-              'data-lsmb-done' => $_->{done},
-              'data-dojo-type' => $_->{type} // 'dijit/form/Button',
-              'data-dojo-props' => $_->{type} ? 'minimalGET: false' : '',
-          }
-      }
-      sort { $a->{ndx} <=> $b->{ndx} } @buttons;
-  }
+    @buttons = map {
+        {
+            name => '__action',
+            value => $_->{name},
+            text => $_->{text},
+            type => 'submit',
+            class => $_->{class} // 'submit',
+            order => $_->{ndx},
+            'data-lsmb-doing' => $_->{doing},
+            'data-lsmb-done' => $_->{done},
+            'data-dojo-type' => $_->{type} // 'dijit/form/Button',
+            'data-dojo-props' => $_->{type} ? 'minimalGET: false' : '',
+        }
+    } sort { $a->{ndx} <=> $b->{ndx} } @buttons;
 
   $form->{recurringset}=0;
   if ( $form->{recurring} ) {

--- a/old/bin/ic.pl
+++ b/old/bin/ic.pl
@@ -812,37 +812,34 @@ sub form_footer {
     # type=submit $locale->text('Save as new')
     # type=submit $locale->text('Delete')
 
-    if ( !$form->{readonly} ) {
-
-        %button = (
-            'update' =>
-              { ndx => 1, key => 'U', value => $locale->text('Update') },
-            'save' => { ndx => 3, key => 'S', value => $locale->text('Save') },
+    %button = (
+        'update' =>
+        { ndx => 1, key => 'U', value => $locale->text('Update') },
+        'save' => { ndx => 3, key => 'S', value => $locale->text('Save') },
         );
 
-        if ( $form->{id} ) {
+    if ( $form->{id} ) {
 
-            if ( !$form->{isassemblyitem} ) {
-                $button{'save_as_new'} = {
-                    ndx   => 7,
-                    key   => 'N',
-                    value => $locale->text('Save as new')
-                };
-            }
-
-            if ( $form->{orphaned} ) {
-                $button{'delete'} =
-                  { ndx => 16, key => 'D', value => $locale->text('Delete') };
-            }
-        }
-        %button = () if $form->{isassemblyitem} && $form->{item} eq 'assembly';
-
-        for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button )
-        {
-            $form->print_button( \%button, $_ );
+        if ( !$form->{isassemblyitem} ) {
+            $button{'save_as_new'} = {
+                ndx   => 7,
+                key   => 'N',
+                value => $locale->text('Save as new')
+            };
         }
 
+        if ( $form->{orphaned} ) {
+            $button{'delete'} =
+            { ndx => 16, key => 'D', value => $locale->text('Delete') };
+        }
     }
+    %button = () if $form->{isassemblyitem} && $form->{item} eq 'assembly';
+
+    for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button )
+    {
+        $form->print_button( \%button, $_ );
+    }
+
     if ($form->{callback} and $form->{id}){
         print qq|<div class='returnlink'><a href='$form->{callback}'>|
               . $locale->text('Continue Previous Workflow')

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -250,10 +250,6 @@ sub invoice_links {
     $form->{AP} = $form->{AP_1} unless $form->{id};
     $form->{AP} //= $form->{AP_links}->{AP}->[0]->{accno} unless $form->{id};
 
-    if ( !$form->{readonly} ) {
-        $form->{readonly} = 1 if $myconfig{acs} && $myconfig{acs} =~ /AP--Vendor Invoice/;
-    }
-
      $form->generate_selects(\%myconfig);
 
 }
@@ -487,32 +483,29 @@ sub form_header {
   </tr>
 |;
 
-    if ( !$form->{readonly} ) {
-        print "<tr><td>";
+    print "<tr><td>";
 
-        %button_types = (
-            print => 'lsmb/PrintButton'
-            );
-        %button = ();
-        for my $action_name ( $wf->get_current_actions( 'main') ) {
-            my $action = $wf->get_action( $action_name );
+    %button_types = (
+        print => 'lsmb/PrintButton'
+        );
+    %button = ();
+    for my $action_name ( $wf->get_current_actions( 'main') ) {
+        my $action = $wf->get_action( $action_name );
 
-            next if ($action->ui // '') eq 'none';
-            $button{$action_name} = {
-                ndx   => $action->order,
-                value => $locale->maketext($action->text),
-                doing => ($action->doing ? $locale->maketext($action->doing) : ''),
-                done  => ($action->done ? $locale->maketext($action->done) : ''),
-                type  => $button_types{$action->ui},
-                tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
-            };
-        }
+        next if ($action->ui // '') eq 'none';
+        $button{$action_name} = {
+            ndx   => $action->order,
+            value => $locale->maketext($action->text),
+            doing => ($action->doing ? $locale->maketext($action->doing) : ''),
+            done  => ($action->done ? $locale->maketext($action->done) : ''),
+            type  => $button_types{$action->ui},
+            tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
+        };
+    }
 
-        for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} }
-              keys %button ) {
-            $form->print_button( \%button, $_ );
-        }
-
+    for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} }
+          keys %button ) {
+        $form->print_button( \%button, $_ );
     }
 
     $form->hide_form(qw(defaultcurrency taxaccounts workflow_id));
@@ -929,12 +922,8 @@ qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="memo_$i" id
     # type=submit $locale->text('Purchase Order')
     # type=submit $locale->text('Delete')
 
-    if ( !$form->{readonly} ) {
-        for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button )
-        {
-            $form->print_button( \%button, $_ );
-        }
-
+    for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button ) {
+        $form->print_button( \%button, $_ );
     }
 
     my $wf = $form->{_wire}->get( 'workflows' )->fetch_workflow( 'AR/AP', $form->{workflow_id} );

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -590,36 +590,34 @@ sub form_header {
 |;
 
 
-    if ( !$form->{readonly} ) {
-        print "<tr><td>";
+    print "<tr><td>";
 
-        %button_types = (
-            print => 'lsmb/PrintButton'
-            );
-        %button = ();
-        for my $action_name ( $wf->get_current_actions( 'main') ) {
-            my $action = $wf->get_action( $action_name );
+    %button_types = (
+        print => 'lsmb/PrintButton'
+        );
+    %button = ();
+    for my $action_name ( $wf->get_current_actions( 'main') ) {
+        my $action = $wf->get_action( $action_name );
 
-            next if ($action->ui // '') eq 'none';
-            $button{$action_name} = {
-                ndx   => $action->order,
-                value => $locale->maketext($action->text),
-                doing => ($action->doing ? $locale->maketext($action->doing) : ''),
-                done  => ($action->done ? $locale->maketext($action->done) : ''),
-                type  => $button_types{$action->ui},
-                tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
-            };
-        }
-
-        for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} }
-              keys %button ) {
-            $form->print_button( \%button, $_ );
-        }
-
-        $form->hide_form(qw(defaultcurrency workflow_id));
-
-        print "</td></tr>";
+        next if ($action->ui // '') eq 'none';
+        $button{$action_name} = {
+            ndx   => $action->order,
+            value => $locale->maketext($action->text),
+            doing => ($action->doing ? $locale->maketext($action->doing) : ''),
+            done  => ($action->done ? $locale->maketext($action->done) : ''),
+            type  => $button_types{$action->ui},
+            tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
+        };
     }
+
+    for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} }
+          keys %button ) {
+        $form->print_button( \%button, $_ );
+    }
+
+    $form->hide_form(qw(defaultcurrency workflow_id));
+
+    print "</td></tr>";
 }
 
 sub void {
@@ -1032,11 +1030,8 @@ qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="memo_$i" 
     # type=submit $locale->text('Delete')
     # type=submit $locale->text('Sales Order')
 
-    if ( !$form->{readonly} ) {
-        for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button )
-        {
-            $form->print_button( \%button, $_ );
-        }
+    for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button ) {
+        $form->print_button( \%button, $_ );
     }
 
     my $wf = $form->{_wire}->get( 'workflows' )->fetch_workflow( 'AR/AP', $form->{workflow_id} );

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -678,35 +678,33 @@ sub form_header {
 <input type=hidden name="${_}_description" value="$form->{"${_}_description"}">
 |;
     }
-    if ( !$form->{readonly} ) {
-        print "<tr><td>";
+    print "<tr><td>";
 
-        %button_types = (
-            print => 'lsmb/PrintButton'
-            );
-        %button = ();
-        for my $action_name ( $wf->get_current_actions( 'main') ) {
-            my $action = $wf->get_action( $action_name );
+    %button_types = (
+        print => 'lsmb/PrintButton'
+        );
+    %button = ();
+    for my $action_name ( $wf->get_current_actions( 'main') ) {
+        my $action = $wf->get_action( $action_name );
 
-            next if ($action->ui // '') eq 'none';
-            $button{$action_name} = {
-                ndx   => $action->order,
-                value => $locale->maketext($action->text),
-                doing => ($action->doing ? $locale->maketext($action->doing) : ''),
-                done  => ($action->done ? $locale->maketext($action->done) : ''),
-                type  => $button_types{$action->ui},
-                tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
-            };
-        }
-
-        for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} }
-              keys %button ) {
-            $form->print_button( \%button, $_ );
-        }
-
-        $form->hide_form(qw(defaultcurrency workflow_id));
-        print "</td></tr>";
+        next if ($action->ui // '') eq 'none';
+        $button{$action_name} = {
+            ndx   => $action->order,
+            value => $locale->maketext($action->text),
+            doing => ($action->doing ? $locale->maketext($action->doing) : ''),
+            done  => ($action->done ? $locale->maketext($action->done) : ''),
+            type  => $button_types{$action->ui},
+            tooltip => ($action->short_help ? $locale->maketext($action->short_help) : '')
+        };
     }
+
+    for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} }
+          keys %button ) {
+        $form->print_button( \%button, $_ );
+    }
+
+    $form->hide_form(qw(defaultcurrency workflow_id));
+    print "</td></tr>";
 }
 
 sub form_footer {


### PR DESCRIPTION
Removing all buttons is too coarse grained, especially since we now have workflows to help us decide which buttons apply in which state.
