### PR TITLE
Remove 'status' table

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -636,7 +636,7 @@ $form->open_status_div($status_div_id) . qq|
 
 |;
     $form->hide_form(
-        qw(batch_id approved id printed emailed sort
+        qw(batch_id approved id sort
            oldtransdate audittrail recurring checktax reverse subtype
            entity_control_code tax_id meta_number default_reportable
            address city zipcode state country workflow_id reversing)
@@ -1544,7 +1544,6 @@ sub post {
         my $wf = $form->{_wire}->get('workflows')->fetch_workflow( 'AR/AP', $id );
         $wf->execute_action( $form->{__action} );
 
-        $form->update_status;
        if ( $form->{printandpost} ) {
            &{"print_$form->{formname}"}( $old_form, 1 );
         }

--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -642,7 +642,7 @@ sub process_transactions {
                         $form->{paidaccounts} = -1;
                     }
 
-                    for (qw(id workflow_id recurring intnotes printed emailed)) {
+                    for (qw(id workflow_id recurring intnotes)) {
                         delete $form->{$_};
                     }
                     my $wf = $form->{_wire}->get('workflows')
@@ -775,7 +775,7 @@ sub process_transactions {
                 #         $pt->{req}, "days" )
                 #       if $form->{reqdate};
 
-                #     for (qw(id recurring intnotes printed emailed)) {
+                #     for (qw(id recurring intnotes)) {
                 #         delete $form->{$_};
                 #     }
                 #     for ( 1 .. $form->{rowcount} ) {

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -321,7 +321,7 @@ sub post_as_new {
     my %args = @_;
 
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(id printed emailed workflow_id invnumber)) { delete $form->{$_} }
+    for (qw(id workflow_id invnumber)) { delete $form->{$_} }
     $form->{invnumber} = $args{invnumber} // '';
 
     my $wf = $form->{_wire}->get('workflows')
@@ -335,7 +335,7 @@ sub post_as_new {
 sub print_and_post_as_new {
 
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(id printed emailed workflow_id)) { delete $form->{$_} }
+    for (qw(id workflow_id)) { delete $form->{$_} }
 
     my $wf = $form->{_wire}->get('workflows')
         ->create_workflow( 'AR/AP' );

--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -233,16 +233,6 @@ sub print_transaction {
     } elsif ( $form->{media} !~ /(zip|screen)/ ) {
         $form->{OUT} = $form->{_wire}->get( 'printers' )->get( $form->{media} );
         $form->{printmode} = '|-';
-
-        if ( $form->{printed} !~ /$form->{formname}/ ) {
-
-            $form->{printed} .= " $form->{formname}";
-            $form->{printed} =~ s/^ //;
-
-            $form->update_status;
-        }
-
-        $old_form->{printed} = $form->{printed} if %$old_form;
     }
 
     $form->{fileid} = $form->{invnumber};

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -776,7 +776,7 @@ sub check_balanced {
 }
 
 sub save_as_new {
-    for (qw(id printed emailed)) { delete $form->{$_} }
+    for (qw(id)) { delete $form->{$_} }
     if ($form->{workflow_id}) {
         my $wf = $form->{_wire}->get('workflows')->fetch_workflow(
             'GL', $form->{workflow_id}

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1039,7 +1039,7 @@ sub quotation {
 
 sub create_form {
 
-    for (qw(id printed emailed workflow_id)) { delete $form->{$_} }
+    for (qw(id workflow_id)) { delete $form->{$_} }
 
     $form->{script} = 'oe.pl';
 
@@ -1403,17 +1403,6 @@ sub print_form {
         $form->{OUT} =~ s/<%(fax)%>/<%$form->{vc}$1%>/;
         $form->{OUT} =~ s/<%(.*?)%>/$form->{$1}/g;
         $form->{printmode} = '|-';
-
-        if ( $form->{printed} !~ /$form->{formname}/ ) {
-
-            $form->{printed} .= " $form->{formname}";
-            $form->{printed} =~ s/^ //;
-
-            $form->update_status;
-        }
-
-        $old_form->{printed} = $form->{printed} if %$old_form;
-
     } elsif ( $form->{media} eq 'email' ) {
         $form->{plainpaper} = 1;
         $output_options{filename} = $form->{formname} . '-'. $form->{"${inv}number"};

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -390,7 +390,7 @@ sub form_header {
 |;
 
     $form->hide_form(
-        qw(form_id id type printed emailed title vc terms discount
+        qw(form_id id type title vc terms discount
            creditlimit creditremaining tradediscount business
            shipped oldtransdate recurring reverse batch_id subtype tax_id
            meta_number separate_duties lock_description nextsub

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -598,7 +598,7 @@ sub form_header {
     }
     $form->hide_form(qw(entity_control_code meta_number tax_id address city zipcode state country));
     $form->hide_form(
-        qw(id type printed emailed vc title discount creditlimit creditremaining tradediscount business recurring form_id nextsub
+        qw(id type vc title discount creditlimit creditremaining tradediscount business recurring form_id nextsub
    lock_description)
     );
 
@@ -1459,7 +1459,7 @@ sub invoice {
     }
     my $lib = uc($script);
 
-    for (qw(id subject message printed emailed)) { delete $form->{$_} }
+    for (qw(id subject message)) { delete $form->{$_} }
     $form->{ $form->{vc} } =~ s/--.*//g;
     $form->{type} = "invoice";
 
@@ -1502,7 +1502,7 @@ sub invoice {
     $form->{duedate} = $form->current_date( \%myconfig, $form->{transdate},
                                             $form->{terms} * 1 );
 
-    for (qw(id subject message printed emailed audittrail)) {
+    for (qw(id subject message audittrail)) {
         delete $form->{$_};
     }
 
@@ -1651,7 +1651,7 @@ sub create_backorder {
     }
 
     # clear flags
-    for (qw(id subject message cc bcc printed emailed audittrail)) {
+    for (qw(id subject message cc bcc audittrail)) {
         delete $form->{$_};
     }
 
@@ -1685,7 +1685,7 @@ sub save_as_new {
     # orders don't have a quonumber
     # quotes don't have an ordnumber
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(closed id printed emailed ordnumber quonumber workflow_id)) {
+    for (qw(closed id ordnumber quonumber workflow_id)) {
         delete $form->{$_}
     }
     &_save;
@@ -1696,7 +1696,7 @@ sub print_and_save_as_new {
     # orders don't have a quonumber
     # quotes don't have an ordnumber
     $form->{old_workflow_id} = $form->{workflow_id};
-    for (qw(closed id printed emailed ordnumber quonumber workflow_id)) {
+    for (qw(closed id ordnumber quonumber workflow_id)) {
         delete $form->{$_}
     }
     &_print_and_save;
@@ -1795,7 +1795,7 @@ sub display_ship_receive {
 <input type=hidden name=display_form value=display_ship_receive>
 |;
 
-    $form->hide_form(qw(id type media format printed emailed vc));
+    $form->hide_form(qw(id type media format vc));
 
     print qq|
 <input type=hidden name="old$form->{vc}" value="$form->{"old$form->{vc}"}">

--- a/old/bin/printer.pl
+++ b/old/bin/printer.pl
@@ -156,16 +156,6 @@ sub print_options {
 
     $options{copies} = $form->{copies};
 
-    # $locale->text('Printed')
-    # $locale->text('E-mailed')
-    # $locale->text('Scheduled')
-
-    $options{status} = {
-        printed   => 'Printed',
-        emailed   => 'E-mailed',
-        recurring => 'Scheduled'
-    };
-
     $options{groupby} = {};
     $options{groupby}{groupprojectnumber} = "checked" if $form->{groupprojectnumber};
     $options{groupby}{grouppartsgroup} = "checked" if $form->{grouppartsgroup};

--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -523,8 +523,6 @@ sub post_transaction {
 
     IIAA->process_form_payments($myconfig, $form);
 
-    # save printed
-    $form->save_status($dbh);
     return 1 unless $dbh->errstr;
 }
 

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1207,9 +1207,6 @@ sub post_invoice {
     $form->{name} =~ s/--$form->{customer_id}//;
     $form->add_shipto($form->{id});
 
-    # save printed, emailed
-    $form->save_status($dbh);
-
     if ($form->get_setting('separate_duties')){
         $self->add_cogs($form);
     }

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -500,9 +500,6 @@ VALUES (?, (select id from account where accno = ?), ?, ?, ?)
 
     $form->add_shipto($form->{id}, 1);
 
-    # save printed, emailed
-    $form->save_status($dbh);
-
     if ( $form->{type} =~ /_order$/ ) {
 
         # adjust onhand
@@ -542,12 +539,6 @@ sub delete {
               if ( $inv || $assembly );
         }
     }
-    $sth->finish;
-
-    # delete status entries
-    $query = qq|DELETE FROM status WHERE trans_id = ?|;
-    $sth   = $dbh->prepare($query);
-    $sth->execute( $form->{id} ) || $form->dberror($query);
     $sth->finish;
 
     # delete individual entries
@@ -622,23 +613,6 @@ sub retrieve {
         $form->db_parse_numeric(sth=>$sth, hashref=>$ref);
         for ( keys %$ref ) { $form->{$_} = $ref->{$_} }
         $sth->finish;
-
-        # get printed, emailed
-        $query = qq|
-            SELECT s.printed, s.emailed, s.formname
-            FROM status s
-            WHERE s.trans_id = ?|;
-        $sth = $dbh->prepare($query);
-        $sth->execute( $form->{id} ) || $form->dberror($query);
-
-        while ( $ref = $sth->fetchrow_hashref(NAME_lc) ) {
-            $form->{printed} .= "$ref->{formname} "
-              if $ref->{printed};
-            $form->{emailed} .= "$ref->{formname} "
-              if $ref->{emailed};
-        }
-        $sth->finish;
-        for (qw(printed emailed)) { $form->{$_} =~ s/ +$//g }
 
         # retrieve individual items
         $query = qq|

--- a/sql/changes/1.13/rm-status.sql
+++ b/sql/changes/1.13/rm-status.sql
@@ -1,0 +1,2 @@
+
+drop table if exists status;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -195,3 +195,4 @@ mc/delete-migration-validation-data.sql
 1.12/shipto_attn.sql
 # 1.13 changes
 1.13/change-logout.sql
+1.13/rm-status.sql

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1948,7 +1948,7 @@ SELECT lsmb__grant_perms('base_user', obj, 'SELECT')
 SELECT lsmb__grant_perms('base_user', obj, 'ALL')
   FROM unnest(array['session'::text, 'session_session_id_seq',
                     'user_preference_id_seq',
-                    'user_preference', 'status', 'recurring',
+                    'user_preference', 'recurring',
                     'recurringemail', 'recurringprint', 'transactions',
                     'transactions_reversal',
                     'ac_tax_form', 'invoice_tax_form', 'lsmb_sequence']) obj;

--- a/t/10-form.t
+++ b/t/10-form.t
@@ -44,8 +44,6 @@
 ##sub like {
 ##sub redo_rows {
 ##sub get_partsgroup {
-##sub update_status {
-##sub save_status {
 ##sub get_recurring {
 ##sub save_recurring {
 ##sub save_intnotes {


### PR DESCRIPTION
The "status" functionality has been broken for 18 years or so (see https://github.com/ledgersmb/LedgerSMB/issues/5295). Code to *show* the status hasn't been there since 1.2; nobody using LedgerSMB is expecting this anymore. Actual status is now captured by workflows and shown in their history.

Migrations which want to retain this information from SQL Ledger can use the workflow history to store it.
