### PR TITLE
Fix schema checks feedback

### DIFF
--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -72,7 +72,7 @@ sub _wrap_html {
                 resubmit_action => $request->{resubmit_action},
                 # note: the line below works because the upgrade
                 # has completed when this wrapper is being run
-                run_id          => $request->{database}->upgrade_run_id,
+                run_id          => $request->{run_id},
                 title           => $failing_check->{title}
             },
             {


### PR DESCRIPTION
which currently fails to call 'upgrade_run_id' on the literal string naming the database being upgraded.
