### PR TITLE
Fix schema checks feedback

### DIFF
--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -71,7 +71,7 @@ sub _wrap_html {
             action_url => $request->{_uri}->as_string,
             # note: the line below works because the upgrade
             # has completed when this wrapper is being run
-            run_id => $request->{database}->upgrade_run_id,
+            run_id => $request->{run_id},
         });
 
     $template = $request->{_wire}->get('ui');


### PR DESCRIPTION
which currently fails to call 'upgrade_run_id' on the literal string naming the database being upgraded.
