### PR TITLE
Fix link to login page on logout

### DIFF
--- a/UI/logout.html
+++ b/UI/logout.html
@@ -7,6 +7,6 @@
           ELSE;
             text('Logout Successful');
           END; %]</h1>
-<p><a target="_top" href="login.pl">[% text('Return to the login screen.') %]</a>
+<p><a target="_top" href="../login.pl">[% text('Return to the login screen.') %]</a>
 </body>
 [% END %]


### PR DESCRIPTION
Support for login to multiple companies broke the link to return to the login page on the logout page. Restore the functionality by linking 'up' one level.
