### PR TITLE
Fix and test AP/AR Search by date period

### DIFF
--- a/UI/Reports/filters/invoice_search.html
+++ b/UI/Reports/filters/invoice_search.html
@@ -38,7 +38,7 @@
        } %]</td>
 </tr>
 <tr id="name-row">
-  <th>[% NAME %]</th>
+  <th><label for="entity-name">[% NAME %]</label></th>
   <td>[% PROCESS input element_data = {
            name = "entity_name"
           value = entity_name
@@ -86,7 +86,7 @@
        } %]</td>
 </tr>
 <tr id="invnumber-row">
-  <th>[% text('Invoice Number') %]</th>
+  <th><label for="invnumber">[% text('Invoice Number') %]</label></th>
   <td>[% PROCESS input element_data = {
            name = "invnumber"
           value = invnumber

--- a/UI/lib/report_base.html
+++ b/UI/lib/report_base.html
@@ -134,6 +134,7 @@ END # BLOCK -%]
    <th align="right">[% text('Period') %]</th>
 
     <td colspan="5">
+        <label for="from_month[% SUFFIX %]" hidden>From Month</label>
         [%
         PROCESS select element_data = {
                name = "from_month" _ SUFFIX
@@ -141,7 +142,9 @@ END # BLOCK -%]
                options = all_months
                default_blank = 1
         };
-
+        %]
+        <label for="from_year[% SUFFIX %]" hidden>From Year</label>
+        [%
         PROCESS select element_data = {
                name="from_year" _ SUFFIX
                id="from_year" _ SUFFIX
@@ -150,43 +153,50 @@ END # BLOCK -%]
                value_attr = "date_get_all_years"
                default_blank = 1
         };
+        label_pos=1;
         PROCESS input element_data = {
                name="interval" _ SUFFIX
                id="interval" _ SUFFIX _ "current"
+               label=text('Current')
                class="radio"
                type="radio"
                value="none"
-               checked="checked" } %]&nbsp;[% text('Current');
+               checked="checked" } %]&nbsp;[%
         PROCESS input element_data = {
                name="interval"  _ SUFFIX
                id="interval" _ SUFFIX _ "day"
+               label=text('Day')
                class="radio"
                type="radio"
-               value="month" } %]&nbsp;[% text('Day');
+               value="month" } %]&nbsp;[%
         PROCESS input element_data = {
                name="interval"  _ SUFFIX
                id="interval" _ SUFFIX _ "week"
+               label=text('Week')
                class="radio"
                type="radio"
-               value="month" } %]&nbsp;[% text('Week');
+               value="month" } %]&nbsp;[%
         PROCESS input element_data = {
                name="interval"  _ SUFFIX
                id="interval" _ SUFFIX _ "month"
+               label=text('Month')
                class="radio"
                type="radio"
-               value="month" } %]&nbsp;[% text('Month');
+               value="month" } %]&nbsp;[%
         PROCESS input element_data = {
                name="interval" _ SUFFIX
                id="interval" _ SUFFIX _ "quarter"
+               label=text('Quarter')
                class="radio"
                type="radio"
-               value="quarter" } %]&nbsp;[% text('Quarter');
+               value="quarter" } %]&nbsp;[%
         PROCESS input element_data = {
                name="interval" _ SUFFIX
                id="interval" _ SUFFIX _ "year"
+               label=text('Year')
                class="radio"
                type="radio"
-               value="year" } %]&nbsp;[% text('Year') %]
+               value="year" } %]&nbsp;
 
         </td>
 [% END # BLOCK %]

--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -47,7 +47,7 @@ Either 'none', 'month', 'quarter', or 'year'
 
 =cut
 
-has interval => (is => 'ro', isa => 'Str', required => 0, default => 'None');
+has interval => (is => 'ro', isa => 'Str', required => 0, default => 'none');
 
 =item from_month int
 

--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -177,6 +177,20 @@ around BUILDARGS => sub {
         }
     }
 
+    # There are two *mutually exclusive* ways to specify a time range
+    if ($args{from_year} && $args{from_month} && $args{interval}) {
+        # Prioritise a date range specified as a starting year, month and
+        # time interval. The corresponding from_date and to_date values will
+        # be calculated and used to populate object properties.
+        delete $args{from_date};
+        delete $args{to_date};
+    }
+    else {
+        # Use explicit from_date and to_date parameters
+        delete $args{from_year};
+        delete $args{from_month};
+    }
+
     return $class->$orig(%args);
 };
 
@@ -256,7 +270,7 @@ before 'run_report' => sub {
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2012 The LedgerSMB Core Team
+Copyright (C) 2012-2025 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/Scripts/invoice.pm
+++ b/lib/LedgerSMB/Scripts/invoice.pm
@@ -90,7 +90,7 @@ LedgerSMB::Report::Invoices::Transactions for expected properties.
 
 =cut
 
-sub invoice_search{
+sub invoice_search {
 
     my ($request) = @_;
     $request->{is_approved} //= 'Y'; # backwards-compatibility to 1.4

--- a/lib/LedgerSMB/Scripts/invoice.pm
+++ b/lib/LedgerSMB/Scripts/invoice.pm
@@ -85,31 +85,38 @@ sub invoices_outstanding {
 
 =item invoice_search
 
-This produces the transactions earch report.  See
+This produces the transactions search report.  See
 LedgerSMB::Report::Invoices::Transactions for expected properties.
 
 =cut
 
-sub  invoice_search{
+sub invoice_search{
+
     my ($request) = @_;
     $request->{is_approved} //= 'Y'; # backwards-compatibility to 1.4
+
     # the line below is needed because we are using trinary boolean logic
     # which does not work well with Moose
     delete $request->{on_hold} if $request->{on_hold} eq 'on';
+
     return $request->render_report(
         LedgerSMB::Report::Invoices::Transactions->new(
             %$request,
             formatter_options => $request->formatter_options,
             from_date => $request->parse_date( $request->{from_date} ),
             to_date => $request->parse_date( $request->{to_date} ),
-        ));
+            interval => $request->{interval},
+            from_month => $request->{from_month},
+            from_year => $request->{from_year},
+        )
+    );
 }
 
 =back
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2012 The LedgerSMB Core Team
+Copyright (C) 2012-2025 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/t/14-report-dates.t
+++ b/t/14-report-dates.t
@@ -66,6 +66,7 @@ use LedgerSMB::Report::Balance_Sheet;
         basis => 'accrual',
         ignore_yearend => 'all',
         from_date => LedgerSMB::PGDate->from_input( '2016-01-05', format => 'YYYY-MM-DD' ),
+        to_date => LedgerSMB::PGDate->from_input( '2017-01-04', format => 'YYYY-MM-DD' ),
         interval => 'year', # just a random valid value
         comparison_periods => '1',
         comparison_type => 'by_periods',

--- a/xt/66-cucumber/12-ap/search.feature
+++ b/xt/66-cucumber/12-ap/search.feature
@@ -1,0 +1,120 @@
+@weasel
+Feature: Search AP transactions by date
+  As a LedgerSMB user I want to be able to search for AP transactions
+  according to date parameters and display the results.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+    And a vendor "Vendor A"
+    And a vendor "Vendor B"
+    And unpaid AP transactions with these values:
+       | Vendor   | Date       | Invoice Number | Amount |
+       | Vendor A | 2024-12-01 | INV100         | 100.00 |
+       | Vendor A | 2025-01-01 | INV101         | 100.01 |
+       | Vendor A | 2025-03-31 | INV102         | 100.02 |
+       | Vendor B | 2025-04-01 | INV103         | 100.03 |
+
+Scenario: Search by date, specifying start and end date
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I enter "2025-01-01" into "From"
+   And I enter "2025-03-31" into "To"
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I should see a heading "Report Name" displaying "Search AP"
+   And I expect the report to contain 2 rows
+   And I expect the 'Date' report column to contain '2025-01-01' for Invoice 'INV101'
+   And I expect the 'Vendor' report column to contain 'Vendor A' for Invoice 'INV101'
+   And I expect the 'Total' report column to contain '100.01' for Invoice 'INV101'
+   And I expect the 'Paid' report column to contain '0' for Invoice 'INV101'
+   And I expect the 'Due' report column to contain '100.01' for Invoice 'INV101'
+   And I expect the 'Date' report column to contain '2025-03-31' for Invoice 'INV102'
+
+Scenario: Search by date, specifying only start date
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I enter "2025-03-31" into "From"
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 2 rows
+   And I expect the 'Date' report column to contain '2025-03-31' for Invoice 'INV102'
+   And I expect the 'Vendor' report column to contain 'Vendor A' for Invoice 'INV102'
+   And I expect the 'Date' report column to contain '2025-04-01' for Invoice 'INV103'
+   And I expect the 'Vendor' report column to contain 'Vendor B' for Invoice 'INV103'
+
+Scenario: Search by date, specifying only end date
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I enter "2025-01-01" into "To"
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 2 rows
+   And I expect the 'Date' report column to contain '2024-12-01' for Invoice 'INV100'
+   And I expect the 'Date' report column to contain '2025-01-01' for Invoice 'INV101'
+
+Scenario: Search by date, specifying month period
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I select "March" from the drop down "From Month"
+   And I select "2025" from the drop down "From Year"
+   And I select 'Month' as the period
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 1 row
+   And I expect the 'Date' report column to contain '2025-03-31' for Invoice 'INV102'
+
+Scenario: Search by date, specifying quarter period
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I select "January" from the drop down "From Month"
+   And I select "2025" from the drop down "From Year"
+   And I select 'Quarter' as the period
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 2 rows
+   And I expect the 'Date' report column to contain '2025-01-01' for Invoice 'INV101'
+   And I expect the 'Date' report column to contain '2025-03-31' for Invoice 'INV102'
+
+Scenario: Search by date, specifying year period
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I select "February" from the drop down "From Month"
+   And I select "2024" from the drop down "From Year"
+   And I select 'Year' as the period
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 2 rows
+   And I expect the 'Date' report column to contain '2024-12-01' for Invoice 'INV100'
+   And I expect the 'Date' report column to contain '2025-01-01' for Invoice 'INV101'
+
+Scenario: Search by date, specifying current period
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I select "February" from the drop down "From Month"
+   And I select "2025" from the drop down "From Year"
+   And I select 'Current' as the period
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 2 rows
+   And I expect the 'Date' report column to contain '2025-03-31' for Invoice 'INV102'
+   And I expect the 'Date' report column to contain '2025-04-01' for Invoice 'INV103'
+
+Scenario: Search by invoice number
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I enter "INV101" into "Invoice Number"
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 1 row
+   And I expect the 'Date' report column to contain '2025-01-01' for Invoice 'INV101'
+
+Scenario: Search by vendor
+  When I navigate the menu and select the item at "AP > Search"
+  Then I should see the AP search screen
+  When I enter "Vendor B" into "Vendor"
+   And I press "Continue"
+  Then I should see the Search AP Report screen
+   And I expect the report to contain 1 row
+   And I expect the 'Date' report column to contain '2025-04-01' for Invoice 'INV103'
+

--- a/xt/66-cucumber/12-ap/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/12-ap/step_definitions/pageobject_steps.pl
@@ -1,0 +1,17 @@
+#!perl
+
+use lib 'xt/lib';
+use strict;
+use warnings;
+
+use Test::More;
+use Test::BDD::Cucumber::StepFile;
+
+When qr/I select '(\w+)' as the period$/, sub {
+    my $label_text = $1;
+    my $page = S->{ext_wsl}->page->body->maindiv;
+    my $radio_button = $page->find('*labeled', text => $label_text);
+    $radio_button->click;
+};
+
+1;

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -117,6 +117,7 @@ my %screens = (
     'GL entry'  => 'PageObject::App::GL::JournalEntry',
     'GL search' => 'PageObject::App::Search::GL',
     'New Reconciliation Report' => 'PageObject::App::Cash::Reconciliation::NewReport',
+    'Search AP Report' => 'PageObject::App::Search::ReportDynatable',
     'Single Payment Vendor Selection' => 'PageObject::App::Cash::SelectVC',
     'Single Payment Customer Selection' => 'PageObject::App::Cash::SelectVC',
     'Single Payment Entry' => 'PageObject::App::Cash::Entry',


### PR DESCRIPTION
AP/AR search was not applying a date period filter (from_year, from_month,
interval) and was instead returning transactions for all time.

This patch fixes this issue and adds tests for all time period searches of
AP/AR transactions, including the alternative from_date/to_date range
selection.