### PR TITLE
1.12 Fix AP/AR Invoice search by date period

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,10 @@
 Changelog for 1.12 Series
 Released 2024-12-14
 
+Changelog for 1.12.4
+* Fix AR/AP Invoice search by date period
+
+
 Changelog for 1.12.3
 * Fix GL search and sort not correctly applying search parameters (#8630)
 

--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -177,6 +177,20 @@ around BUILDARGS => sub {
         }
     }
 
+    # There are two *mutually exclusive* ways to specify a time range
+    if ($args{from_year} && $args{from_month} && $args{interval}) {
+        # Prioritise a date range specified as a starting year, month and
+        # time interval. The corresponding from_date and to_date values will
+        # be calculated and used to populate object properties.
+        delete $args{from_date};
+        delete $args{to_date};
+    }
+    else {
+        # Use explicit from_date and to_date parameters
+        delete $args{from_year};
+        delete $args{from_month};
+    }
+
     return $class->$orig(%args);
 };
 
@@ -256,7 +270,7 @@ before 'run_report' => sub {
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2012 The LedgerSMB Core Team
+Copyright (C) 2012-2025 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with


### PR DESCRIPTION
Minimal backport fix for AP/AR Invoice search filtering by date period (using
start month, start year and interval).

Without this fix, the time period is ignored and results for all time are returned.

Note that this fix is not needed for 1.11 or earlier.