### PR TITLE
Remove redundant code from LedgerSMB::Scripts::invoice

### DIFF
--- a/lib/LedgerSMB/Scripts/invoice.pm
+++ b/lib/LedgerSMB/Scripts/invoice.pm
@@ -105,9 +105,6 @@ sub invoice_search {
             formatter_options => $request->formatter_options,
             from_date => $request->parse_date( $request->{from_date} ),
             to_date => $request->parse_date( $request->{to_date} ),
-            interval => $request->{interval},
-            from_month => $request->{from_month},
-            from_year => $request->{from_year},
         )
     );
 }


### PR DESCRIPTION
Remove redundant code added in commit
153cbb60b484fe8a75780d7bf93000877912ade5 while fixing date period search.

It is not required to explicitly pass on individual $request elements as the whole request is passed along.
