### PR TITLE
Fix UI misspelling on AP/AR Batch Import screen

### DIFF
--- a/UI/src/views/ImportCSV-AA-Batch.vue
+++ b/UI/src/views/ImportCSV-AA-Batch.vue
@@ -56,7 +56,7 @@ export default {
                     <dd />
                     <dt>ap</dt>
                     <dd />
-                    <dt>escription</dt>
+                    <dt>description</dt>
                     <dd />
                     <dt>invnumber</dt>
                     <dd />


### PR DESCRIPTION
In list of expected fields, `description` was missing it's initial `d`.