### PR TITLE
Fix Add Entity after removal of `notes` column, add tests

### DIFF
--- a/UI/Contact/contact.html
+++ b/UI/Contact/contact.html
@@ -22,14 +22,6 @@
 [% IF entity_id %][% operation = "Edit" %][% ELSE
 %][% operation = "Add"
 %][% END %]
-<!-- CT: Keys for localization scripts:
-[% text("Add Customer") %]
-[% text("Edit Customer") %]
-[% text("Add Vendor") %]
-[% text("Edit Vendor") %]
-[% text("Add Employee") %]
-[% text("Edit Employee") %]
--->
 </div>
     <div id="contact_tabs"
          data-dojo-type="dijit/layout/TabContainer"

--- a/UI/Contact/contact.html
+++ b/UI/Contact/contact.html
@@ -19,9 +19,6 @@
     <div class="notice">[% notice %]</div>
     [% END %]
     <div class="navigation" id="nav_div">[% target_div %]
-[% IF entity_id %][% operation = "Edit" %][% ELSE
-%][% operation = "Add"
-%][% END %]
 </div>
     <div id="contact_tabs"
          data-dojo-type="dijit/layout/TabContainer"

--- a/UI/Contact/divs/company.html
+++ b/UI/Contact/divs/company.html
@@ -6,9 +6,9 @@
      >
   <div class="listtop"><strong>[%
       IF entity_id.defined ;
-      text("Edit");
+      text("Edit Company");
       ELSE ;
-      text("Add");
+      text("Add Company");
       END;
     %]</strong></div>
 <form data-dojo-type="lsmb/Form" id="company" method="post" action="[% request.script %]">

--- a/UI/Contact/divs/person.html
+++ b/UI/Contact/divs/person.html
@@ -5,9 +5,9 @@
      >
   <div class="listtop"><strong>[%
       IF entity_id.defined ;
-      text("Edit");
+      text("Edit Person");
       ELSE ;
-      text("Add");
+      text("Add Person");
       END ;
       %]</strong></div>
   <form data-dojo-type="lsmb/Form" name="customer" method="post" action="[% request.script %]">

--- a/sql/modules/Company.sql
+++ b/sql/modules/Company.sql
@@ -1101,19 +1101,13 @@ CREATE OR REPLACE FUNCTION eca__list_notes(in_credit_id int)
 RETURNS SETOF eca_note AS
 $$
 DECLARE out_row record;
-        t_entity_id int;
 BEGIN
         -- ALERT: security definer function.  Be extra careful about EXECUTE
         -- in here. --CT
-        SELECT entity_id INTO t_entity_id
-        FROM entity_credit_account
-        WHERE id = in_credit_id;
-
         FOR out_row IN
                 SELECT *
-                FROM note
-                WHERE (note_class = 3 and ref_key = in_credit_id) or
-                        (note_class = 1 and ref_key = t_entity_id)
+                FROM eca_note
+                WHERE ref_key = in_credit_id
                 ORDER BY created
         LOOP
                 RETURN NEXT out_row;

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -118,9 +118,11 @@ Scenario Outline: Navigate to menu "<path>" and open screen "<screen>"
     | Cash > Vouchers > Reverse Overpay          |                          |
     | Cash > Vouchers > Reverse Payment          |                          |
     | Cash > Vouchers > Reverse Receipts         |                          |
+
   Examples:
     | path                                       | screen                   |
     | Contacts > Search                          | Contact Search           |
+    | Contacts > Add Entity                      | Edit Contact             |
 
   Examples:
     | path                                        | screen                   |

--- a/xt/66-cucumber/02-contacts/add_entity.feature
+++ b/xt/66-cucumber/02-contacts/add_entity.feature
@@ -1,0 +1,33 @@
+@weasel
+Feature: Add Entity
+  As a LedgerSMB user I want to add a new entities - companies and people.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Add a new Customer with minimal information
+  When I navigate the menu and select the item at "Contacts > Add Entity"
+  Then I should see the Edit Contact screen
+   And I expect the "Company" tab to be selected
+  When I enter "Company A" into "Name"
+   And I select "Spain" from the drop down "Country"
+   And I press "Save"
+  Then I expect the "Credit Accounts" tab to be selected
+  When I press "Save New"
+  Then I expect the Accounts table to contain 1 row
+
+Scenario: Add a new Person with minimal information
+  When I navigate the menu and select the item at "Contacts > Add Entity"
+  Then I should see the Edit Contact screen
+  When I select the "Person" tab
+  Then I expect the "Person" tab to be selected
+  When I select "Dr" from the drop down "Salutation"
+   And I enter "James" into "Given Name"
+   And I enter "Taylor" into "Surname"
+   And I enter "-" into "Personal ID"
+   And I enter "2025-01-01" into "Birthdate"
+   And I press "Save"
+  Then I expect the "Credit Accounts" tab to be selected
+  When I press "Save New"
+  Then I expect the Accounts table to contain 1 row

--- a/xt/66-cucumber/02-contacts/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/02-contacts/step_definitions/pageobject_steps.pl
@@ -1,0 +1,44 @@
+#!perl
+
+use lib 'xt/lib';
+use strict;
+use warnings;
+
+use Test::More;
+use Test::BDD::Cucumber::StepFile;
+
+Then qr/^I expect the "(.+)" tab to be selected$/, sub {
+    my $tab_label = $1;
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+    ok($page->tab_is_selected($tab_label), "$tab_label tab is selected");
+};
+
+
+Then qr/^I expect the Accounts table to contain (\d+) rows?$/, sub {
+    my $wanted_row_count = $1;
+    my @rows = S->{ext_wsl}->page->body->maindiv->content->find_all(
+        './/table[@id="credit_accounts_list"]/tbody/tr'
+    );
+    my $row_count = scalar @rows;
+
+    is($row_count, $wanted_row_count, "Accounts table contains $wanted_row_count rows");
+};
+
+
+# Overriding this action to cope with multiple buttons having the same label
+# being loaded on the page, but hidden in an invisible tab pane. We want to
+# press the button that is visible and ignore those that are hidden.
+# An example is the 'Add Entity' screen, which has a 'Save' button on both
+# 'Company' and 'Person' tabs, only one of which is visible at a time.
+When qr/^I press "(.+)"$/, sub {
+    my $button_text = $1;
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+    my $active_pane = $page->find(
+        './/div[@role="tabpanel" and contains(@class,"dijitVisible")]'
+    );
+    $active_pane->find(
+        ".//*[\@role='button']/*[text()='$button_text']"
+    )->click;
+};
+
+1;

--- a/xt/lib/PageObject/App/Contacts/EditContact.pm
+++ b/xt/lib/PageObject/App/Contacts/EditContact.pm
@@ -24,5 +24,29 @@ sub _verify {
 }
 
 
+sub find_tab {
+    my $self = shift;
+    my $tab_text = shift;
+
+    my $tab = $self->find(
+        '//div[@id="contact_tabs_tablist"]'.
+        '//span[@class="tabLabel" and normalize-space(.)="'.$tab_text.'"]'
+    );
+
+    return $tab;
+}
+
+
+sub tab_is_selected {
+    my $self = shift;
+    my $tab_label = shift;
+
+    my $tab = $self->find_tab($tab_label) or die "$tab_label tab not found";
+    my $selected = $tab->get_attribute('aria-selected');
+
+    return $selected;
+}
+
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -25,8 +25,8 @@ __PACKAGE__->self_register(
 
 
 my %menu_path_pageobject_map = (
-    "Contacts > Add Contact" => '',
     "Contacts > Search" => 'PageObject::App::Search::Contact',
+    "Contacts > Add Entity" => 'PageObject::App::Contacts::EditContact',
 
     "AR > Add Transaction" => 'PageObject::App::AR::Transaction',
     "AR > Import Batch" => 'PageObject::App::BatchImport',


### PR DESCRIPTION
This PR fixes Add Entity functionality after the `notes` abstract table was
removed and adds BDD tests for adding a person and a company.

Root cause was sql function `eca__list_notes` referencing the dropped
`notes` table.

