### PR TITLE
Cleanup after removal of <lsmb-date> component from page

### DIFF
--- a/UI/src/elements/lsmb-date.js
+++ b/UI/src/elements/lsmb-date.js
@@ -24,6 +24,14 @@ export class LsmbDate extends LsmbBaseInput {
     _widgetClass() {
         return dojoDateBox;
     }
+
+    disconnectedCallback() {
+        if (this.widgetWrapper) {
+            this.widgetWrapper.remove();
+            this.widgetWrapper = null;
+        }
+        super.disconnectedCallback();
+    }
 }
 
 customElements.define("lsmb-date", LsmbDate);


### PR DESCRIPTION
We were creating a `<span>` wrapper element when adding the `<lsmb-date>` component,
but not reversing this when removing it.

This patch adds a `disconnectedCallback()` method, to clean-up.

Without this, the ordering position of label and date selector elements were messed up if the element
was moved within the DOM, as the `<label>` element was being destroyed and recreated, but the date
widget container was not.