### PR TITLE
Add a <lsmb-checkbox> web component

### DIFF
--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -705,14 +705,17 @@ h2 {
     margin: 4px 0;
 }
 
+.two-column-grid lsmb-checkbox,
 .two-column-grid lsmb-text,
 .two-column-grid lsmb-password,
 .two-column-grid lsmb-date,
 .two-column-grid lsmb-file,
+.four-column-grid lsmb-checkbox,
 .four-column-grid lsmb-text,
 .four-column-grid lsmb-password,
 .four-column-grid lsmb-date,
 .four-column-grid lsmb-file,
+.six-column-grid lsmb-checkbox,
 .six-column-grid lsmb-text,
 .six-column-grid lsmb-password,
 .six-column-grid lsmb-date,

--- a/UI/src/elements/lsmb-base-input.js
+++ b/UI/src/elements/lsmb-base-input.js
@@ -87,26 +87,28 @@ export class LsmbBaseInput extends LsmbDijit {
             this.dojoLabel = document.createElement("label");
             this.dojoLabel.innerHTML = this.getAttribute("label");
             this.dojoLabel.classList.add("label");
+            this.dojoLabel.setAttribute("for", this.dojoWidget.id);
 
             // without this handler, we bubble 2 events "to the outside"
             this.dojoLabel.addEventListener("click", (e) =>
                 e.stopPropagation()
             );
         }
+
         const labelBefore =
             !this.hasAttribute("label-pos") ||
             this.getAttribute("label-pos") !== "after";
+
         if (labelBefore && this.dojoLabel) {
             this._labelRoot().appendChild(this.dojoLabel);
         }
 
         this.dojoWidget.placeAt(this._widgetRoot());
+
         if (!labelBefore && this.dojoLabel) {
             this._labelRoot().appendChild(this.dojoLabel);
         }
-        if (this.dojoLabel) {
-            this.dojoLabel.setAttribute("for", this.dojoWidget.id);
-        }
+
         this.dojoWidget.on("input", (e) => {
             let evt = new InputEvent("input", {
                 data: e.charOrCode

--- a/UI/src/elements/lsmb-checkbox.js
+++ b/UI/src/elements/lsmb-checkbox.js
@@ -1,0 +1,15 @@
+/** @format */
+
+import { LsmbBaseInput } from "@/elements/lsmb-base-input";
+
+const dojoCheckBox = require("dijit/form/CheckBox");
+
+export class LsmbCheckBox extends LsmbBaseInput {
+
+    _widgetClass() {
+        return dojoCheckBox;
+    }
+
+}
+
+customElements.define("lsmb-checkbox", LsmbCheckBox);

--- a/UI/src/elements/lsmb-checkbox.js
+++ b/UI/src/elements/lsmb-checkbox.js
@@ -5,11 +5,9 @@ import { LsmbBaseInput } from "@/elements/lsmb-base-input";
 const dojoCheckBox = require("dijit/form/CheckBox");
 
 export class LsmbCheckBox extends LsmbBaseInput {
-
     _widgetClass() {
         return dojoCheckBox;
     }
-
 }
 
 customElements.define("lsmb-checkbox", LsmbCheckBox);


### PR DESCRIPTION
Adds a new `<lsmb-checkbox>` web component, for use alongside existing `<lsmb-text>`, `<lsmb-date>` etc.