### PR TITLE
Fix entity search by country

### DIFF
--- a/xt/42-company.pg
+++ b/xt/42-company.pg
@@ -5,7 +5,7 @@ BEGIN;
     SET client_min_messages TO warning;
 
     -- Plan the tests.
-    SELECT plan(64);
+    SELECT plan(65);
 
     -- Add data
     \i xt/data/42-pg/Company.sql
@@ -306,6 +306,29 @@ BEGIN;
         NULL::text
     );
     SELECT results_eq('test', 'expected_result', 'contact__search find company by address');
+    DEALLOCATE test;
+    DEALLOCATE expected_result;
+
+    --- Search for company by country
+    PREPARE test AS SELECT * FROM contact__search(
+        NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL,
+        'CA', NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL
+    );
+    PREPARE expected_result AS VALUES(
+        -101,
+        '_TEST2',
+        NULL::integer,
+        NULL::text,
+        NULL::text,
+        NULL::integer,
+        'Test Company',
+        NULL::text,
+        NULL::text,
+        NULL::text
+    );
+    SELECT results_eq('test', 'expected_result', 'contact__search find company by country');
     DEALLOCATE test;
     DEALLOCATE expected_result;
 

--- a/xt/66-cucumber/02-contacts/search.feature
+++ b/xt/66-cucumber/02-contacts/search.feature
@@ -6,7 +6,7 @@ Feature: Search for Entity
 Background: The standard test company comes with one Entity already defined.
   Given a standard test company
     And a logged in admin user
-    And a vendor "Antelope"
+    And a vendor "Antelope" from Spain
 
 Scenario: Search for all Entities without filtering
   When I navigate the menu and select the item at "Contacts > Search"
@@ -30,4 +30,12 @@ Scenario: Search based on Entity Name
    And I press "Search"
   Then I should see the Contact Search Report screen
    And I expect the report to contain 1 row
+
+Scenario: Search based on Entity Country
+  When I navigate the menu and select the item at "Contacts > Search"
+  Then I should see the Contact Search screen
+  When I select "Spain" from the drop down "Country"
+   And I press "Search"
+  Then I should see the Contact Search Report screen
+   And I expect the report to contain 1 rows
 

--- a/xt/data/42-pg/Company.sql
+++ b/xt/data/42-pg/Company.sql
@@ -11,7 +11,7 @@ INSERT INTO entity (id, name, control_code, country_id)
 VALUES (-100, 'Testing.....', '_TESTING.....', 242);
 
 INSERT INTO entity (id, name, control_code, country_id)
-VALUES (-101, 'Testing..... 2', '_TEST2', 242);
+VALUES (-101, 'Testing..... 2', '_TEST2', 38);
 
 INSERT INTO person(id, entity_id, first_name, last_name)
 values (-100, -100, 'Test', 'User');

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -157,7 +157,7 @@ Given qr/a logged in user with these rights:/, sub {
 };
 
 
-Given qr/a (vendor|customer) "(.*)"(?: from (.+))$/, sub {
+Given qr/a (vendor|customer) "(.*)"(?: from (.+))?$/, sub {
     my $vc = $1;
     my $vc_name = $2;
     my $country = $3;

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -157,11 +157,11 @@ Given qr/a logged in user with these rights:/, sub {
 };
 
 
-Given qr/a (vendor|customer) "(.*)"$/, sub {
+Given qr/a (vendor|customer) "(.*)"(?: from (.+))$/, sub {
     my $vc = $1;
     my $vc_name = $2;
-
-    my $vc_data = S->{ext_lsmb}->create_vc($vc, $vc_name);
+    my $country = $3;
+    my $vc_data = S->{ext_lsmb}->create_vc($vc, $vc_name, $country);
     S->{$_} = $vc_data->{$_} for %$vc_data;
 };
 


### PR DESCRIPTION
This PR fixes previously broken Entity Search by country and adds both
database-level pgTAP, and browser-level BDD tests for the functionality.

Re-submission of PR#8740.