### PR TITLE
Correct spelling in LedgerSMB::Router POD

### DIFF
--- a/lib/LedgerSMB/Router.pm
+++ b/lib/LedgerSMB/Router.pm
@@ -35,14 +35,14 @@ keywords to help define
    get '/route/to/endpoint' => sub {
      my ($env) = @_;
 
-     # return a PSGI tripple
+     # return a PSGI triple
      return [ 200, [], [ 'body']];
    };
 
    post '/route/to/{parameterized}/{endpoint}' => sub {
      my ($env, %params) = @_;
 
-     # return a PSGI tripple
+     # return a PSGI triple
      return [ 200, [], [ 'body' ]];
    }
 


### PR DESCRIPTION
No code changes. Just correcting a spelling error in the POD for LedgerSMB::Router.

s/triple/tripple/