### PR TITLE
Remove redundant comment from preferences.html

### DIFF
--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -60,8 +60,6 @@
                 ALERT = text("Warning: Your password will expire today");
                 END;
                 %]
-                <!-- don't translate password_expires as it's essentially a generated string with numbers and untranslatable -->
-                <!-- tracked in issue #1699 -->
                 [% ALERT %]
               </th>
             </tr>


### PR DESCRIPTION
File `UI/users/preferences.html` contained a redundant comment advising not to translate
"password expires" messages, referencing issue #1699.

The issue has been resolved and the messages are now translated. 

The redundant comment is removed by this patch. No code changes.