### PR TITLE
Fix Formatting of Password Change Screen

### DIFF
--- a/UI/js-src/lsmb/users/ChangePassword.js
+++ b/UI/js-src/lsmb/users/ChangePassword.js
@@ -33,7 +33,6 @@ define([
                 "new password": "New Password",
                 verify: "Verify",
                 change: "Change Password",
-                "no-oldpw": "No Old Password",
                 strength: "Strength"
             },
             lstrings: {},

--- a/UI/js-src/lsmb/users/ChangePassword.js
+++ b/UI/js-src/lsmb/users/ChangePassword.js
@@ -30,7 +30,7 @@ define([
             _lstrings: {
                 title: "Change Password",
                 "old password": "Old Password",
-                "new password": "New password",
+                "new password": "New Password",
                 verify: "Verify",
                 change: "Change Password",
                 "no-oldpw": "No Old Password",

--- a/UI/js-src/lsmb/users/templates/PasswordChange.html
+++ b/UI/js-src/lsmb/users/templates/PasswordChange.html
@@ -1,22 +1,19 @@
 <div>
-  <div id="pwtitle" class="listheading"></div>
+  <div id="pwtitle" class="listtop"></div>
   <div id="pwfeedback" data-dojo-type="dijit/layout/ContentPane" data-dojo-attach-point="feedback">&#xA0;</div>
-  <div id="pwcontainer">
-    <div class="input-line">
-      <label id="old-pw-label" for="old-pw"></label><input id="old-pw" data-dojo-type="dijit/form/TextBox" type="password" data-dojo-attach-point="oldpw" />
-    </div>
-    <div class="input-line">
-      <label id="new-pw-label" for="new-pw"></label><input id="new-pw" data-dojo-type="dijit/form/TextBox" type="password" data-dojo-attach-point="newpw" />
-    </div>
-    <div class="input-line" id="pw-strength-container">
-        <label id="pw-strength-label" for="pw-strength"></label><div style="display:inline-block" id="pw-strength">0</div>
-    </div>
-    <div class="input-line">
-      <label id="verify-pw-label" for="verify-pw"></label><input id="verify-pw" data-dojo-type="dijit/form/TextBox" type="password" data-dojo-attach-point="verified"/>
-    </div>
-    <div class="input-line">
-      <button data-dojo-type="dijit/form/Button" id="pw-change" data-dojo-attach-point="submitbutton"></button>
-    </div>
-    <div class="input-line"></div>
+  <div id="pwcontainer" class="two-column-grid" style="width:fit-content">
+    <label id="old-pw-label" for="old-pw"></label>
+    <input id="old-pw" data-dojo-type="dijit/form/TextBox" type="password" data-dojo-attach-point="oldpw" />
+
+    <label id="new-pw-label" for="new-pw"></label>
+    <input id="new-pw" data-dojo-type="dijit/form/TextBox" type="password" data-dojo-attach-point="newpw" />
+
+    <label id="pw-strength-label" for="pw-strength"></label>
+    <div style="display:inline-block" id="pw-strength">0</div>
+
+    <label id="verify-pw-label" for="verify-pw"></label>
+    <input id="verify-pw" data-dojo-type="dijit/form/TextBox" type="password" data-dojo-attach-point="verified"/>
   </div>
+  <hr size="3" noshade="noshade" />
+  <button data-dojo-type="dijit/form/Button" id="pw-change" data-dojo-attach-point="submitbutton"></button>
 </div>

--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -14,7 +14,7 @@
 
     password_strings = "title:'" _ text("Change Password") _
                       "', old password:'" _ text("Old Password") _
-                      "', new password:'" _ text("New password") _
+                      "', new password:'" _ text("New Password") _
                       "', verify:'" _ text("Verify") _
                       "', change:'" _ text("Change Password") _
                       "', no-oldpw:'" _ text("No Old Password") _

--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -13,15 +13,14 @@
     };
 
     password_strings = "title:'" _ text("Change Password") _
-                      "', old password:'" _ text("Old Password") _
-                      "', new password:'" _ text("New Password") _
+                      "', 'old password':'" _ text("Old Password") _
+                      "', 'new password':'" _ text("New Password") _
                       "', verify:'" _ text("Verify") _
                       "', change:'" _ text("Change Password") _
-                      "', no-oldpw:'" _ text("No Old Password") _
-                      "', strength:'" _    text("Strength");
+                      "', strength:'" _    text("Strength") _ "'";
     %]
     <div data-dojo-type="dijit/layout/TabContainer" style="width: 100%; height: 500px;">
-      <div data-dojo-type="dijit/layout/ContentPane" title="Preferences"
+      <div data-dojo-type="dijit/layout/ContentPane" title="[% text("Preferences") %]"
            data-dojo-props="selected:false">
         <form data-dojo-type="lsmb/Form" method="post" id="prefs" name="prefs" action="user.pl">
           <script type="dojo/on" data-dojo-event="submit">
@@ -149,9 +148,9 @@
             text = text('Save') } %]
         </form>
       </div>
-      <div data-dojo-type="dijit/layout/ContentPane" title="Password" data-dojo-props="selected:true">
+      <div data-dojo-type="dijit/layout/ContentPane" title="[% text("Password") %]" data-dojo-props="selected:true">
         <div data-dojo-type="lsmb/users/ChangePassword"
-             data-dojo-properties="lstrings:{[% password_strings | html %]}"></div>
+             data-dojo-props="lstrings:{[% password_strings | html %]}"></div>
       </div>
     </div>
   </div>

--- a/xt/66-cucumber/01-basic/change_password.feature
+++ b/xt/66-cucumber/01-basic/change_password.feature
@@ -8,34 +8,34 @@ Background:
 Scenario: Error when "Old Password" field is empty
   When I navigate the menu and select the item at "Preferences"
    And I enter "" into "Old Password"
-   And I enter "a new password" into "New password"
+   And I enter "a new password" into "New Password"
    And I enter "a new password" into "Verify"
   Then I should see an error message "Password Required"
 
 Scenario: Error when no new password is entered
   When I navigate the menu and select the item at "Preferences"
    And I enter "a6m1n" into "Old Password"
-   And I enter "" into "New password"
+   And I enter "" into "New Password"
    And I enter "" into "Verify"
   Then I should see an error message "Password Required"
 
 Scenario: Error when "New Password" and "Verify" fields don't match
   When I navigate the menu and select the item at "Preferences"
    And I enter "a6m1n" into "Old Password"
-   And I enter "a new password" into "New password"
+   And I enter "a new password" into "New Password"
    And I enter "a different password" into "Verify"
   Then I should see an error message "Confirmation did not match"
 
 Scenario: Error when the "Old Password" field is incorrect
   When I navigate the menu and select the item at "Preferences"
    And I enter "the wrong password" into "Old Password"
-   And I enter "a new password" into "New password"
+   And I enter "a new password" into "New Password"
    And I enter "a new password" into "Verify"
   Then I should see an error message "Error changing password."
 
 Scenario: Successfully change password
   When I navigate the menu and select the item at "Preferences"
    And I enter "password" into "Old Password"
-   And I enter "a new password" into "New password"
+   And I enter "a new password" into "New Password"
    And I enter "a new password" into "Verify"
   Then I should see a message "Password Changed"

--- a/xt/66-cucumber/01-basic/preferences.feature
+++ b/xt/66-cucumber/01-basic/preferences.feature
@@ -16,61 +16,62 @@ Scenario: I change user preferences to the <selection> language
    And I select the "Preferences" tab
    And I select "<selection>" from the drop down "Language"
    And I save the page
-   And I select the "Preferences" tab
+   And I select the "<preferences>" tab
   Then I expect "<translation>" to be selected for "<language>"
 
   Examples:
   Non UTF8 accented characters are confirmed working
-    | selection            | translation           | language |
-    | American English     | American English      | Language |
-    | Brazilian Portuguese | português - Brasil    | Idioma   |
+    | selection            | translation           | language | preferences  |
+    | American English     | American English      | Language | Preferences  |
+    | Brazilian Portuguese | português - Brasil    | Idioma   | Preferências |
 
   @extended
   Examples:
   Non UTF8 accented characters are confirmed working
-    | selection            | translation           | language |
-    | British English      | British English       | Language |
-    | Canadian English     | Canadian English      | Language |
-    | Canadian French      | français canadien     | Langue   |
-    | Catalan              | català                | Idioma   |
-    | Danish               | dansk                 | Sprog    |
-    | Dutch                | Nederlands            | Taal     |
-    | Estonian             | eesti                 | Keel     |
-    | Finnish              | suomi                 | Kieli    |
-    | Flemish              | Nederlands - België   | Taal     |
-    | French               | français              | Langue   |
-    | French - Belgium     | français - Belgique   | Langue   |
-    | German               | Deutsch               | Sprache  |
-    | Hungarian            | magyar                | Nyelv    |
-    | Icelandic            | íslenska              | Túngumál |
-    | Indonesian           | Indonesia             | Bahasa   |
-    | Italian              | italiano              | Lingua   |
-    | Malay - Malaysia     | Melayu - Malaysia     | Bahasa   |
-    | Mexican Spanish      | español de México     | Lenguaje |
-    | Norwegian Bokmål     | norsk bokmål          | Språk    |
-    | Portuguese           | português             | Língua   |
-    | Spanish              | español               | Lenguaje |
-    | Spanish - Argentina  | español - Argentina   | Idioma   |
-    | Spanish - Colombia   | español - Colombia    | Idioma   |
-    | Spanish - Ecuador    | español - Ecuador     | Lenguaje |
-    | Spanish - Panama     | español - Panamá      | Idioma   |
-    | Spanish - Paraguay   | español - Paraguay    | Idioma   |
-    | Spanish - Venezuela  | español - Venezuela   | Idioma   |
-    | Swedish              | svenska               | Språk    |
-    | Swiss High German    | Schweizer Hochdeutsch | Sprache  |
+    | selection            | translation           | language | preferences   |
+    | British English      | British English       | Language | Preferences   |
+    | Canadian English     | Canadian English      | Language | Preferences   |
+    | Canadian French      | français canadien     | Langue   | Préférences   |
+    | Catalan              | català                | Idioma   | Preferències  |
+    | Danish               | dansk                 | Sprog    | Præferencer   |
+    | Dutch                | Nederlands            | Taal     | Instellingen  |
+    | Estonian             | eesti                 | Keel     | Eelistused    |
+    | Finnish              | suomi                 | Kieli    | Asetukset     |
+    | Flemish              | Vlaams                | Taal     | Instellingen  |
+    | French               | français              | Langue   | Préférences   |
+    | French - Belgium     | français - Belgique   | Langue   | Préférences   |
+    | German               | Deutsch               | Sprache  | Benutzereinstellungen |
+    | Hungarian            | magyar                | Nyelv    | Beállítások   |
+    | Icelandic            | íslenska              | Túngumál | Uppsetningar  |
+    | Indonesian           | Indonesia             | Bahasa   | Preferences   |
+    | Italian              | italiano              | Lingua   | Preferenze    |
+    | Malay - Malaysia     | Melayu - Malaysia     | Bahasa   | Keutamaan     |
+    | Mexican Spanish      | español de México     | Lenguaje | Preferencias  |
+    | Norwegian Bokmål     | norsk bokmål          | Språk    | Innstillinger |
+    | Portuguese           | português             | Língua   | Preferências  |
+    | Spanish              | español               | Lenguaje | Preferencias  |
+    | Spanish - Argentina  | español - Argentina   | Idioma   | Preferencias  |
+    | Spanish - Colombia   | español - Colombia    | Idioma   | Preferencias  |
+    | Spanish - Ecuador    | español - Ecuador     | Lenguaje | Preferencias  |
+    | Spanish - Panama     | español - Panamá      | Idioma   | Preferencias  |
+    | Spanish - Paraguay   | español - Paraguay    | Idioma   | Preferencias  |
+    | Spanish - Venezuela  | español - Venezuela   | Idioma   | Preferencias  |
+    | Swedish              | svenska               | Språk    | Inställningar |
+    | Swiss High German    | Schweizer Hochdeutsch | Sprache  | Benutzereinstellungen |
 
   @wip
   Examples:
   prove has problems displaying UTF8, even though tests works
-    | selection        | translation | language      |
-    | Arabic - Egypt   | اللغة       | العربية - مصر |
-    | Bulgarian        | български   | Език          |
-    | Chinese - China  | 中文 - 中国 | 语言          |
-    | Chinese - Taiwan | 中文 - 台灣 | 語言          |
-    | Czech            | čeština     | Jazyk         |
-    | Greek            | Ελληνικά    | Γλώσσα        |
-    | Lithuanian       | lietuvių    | Kalba         |
-    | Polish           | polski      | Język         |
-    | Russian          | русский     | Язык          |
-    | Turkish          | Türkçe      | Dil           |
-    | Ukrainian        | українська  | Мова          |
+    | selection        | translation | language      | preferences |
+    | Arabic - Egypt   |العربية - مصر |        اللغة | Preferences |
+    | Bulgarian        | български   | Език          | Свойства    |
+    | Chinese - China  | 中文 - 中国 | 语言          | 个人设定    |
+    | Chinese - Taiwan | 中文 - 台灣 | 語言          | 個人設定    |
+    | Czech            | čeština     | Jazyk         | Nastavení   |
+    | Greek            | Ελληνικά    | Γλώσσα        | Επιλογές    |
+    | Lithuanian       | lietuvių    | Kalba         | Nuostatos   |
+    | Polish           | polski      | Język         | Preferencje |
+    | Russian          | русский     | Язык          | Настройки   |
+    | Turkish          | Türkçe      | Dil           | Tercihler   |
+    | Ukrainian        | українська  | Мова          | Параметри   |
+


### PR DESCRIPTION
Fields and labels were not aligned on the password change screen for certain
stylesheets. This PR makes the page consistent with other lsmb forms, using
our standard `two-column-grid` layout.

No change to functionality.