### PR TITLE
Extract multiple translation strings per line

### DIFF
--- a/locale/LedgerSMB.pot
+++ b/locale/LedgerSMB.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB 1.13.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -109,7 +109,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -132,9 +133,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -363,7 +365,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -521,6 +523,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -655,10 +661,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -727,6 +733,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1583,10 +1593,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1849,6 +1863,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1881,8 +1896,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr ""
@@ -1895,7 +1911,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2030,13 +2046,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2276,6 +2295,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2408,13 +2428,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2448,7 +2471,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2552,6 +2575,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2881,7 +2905,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3019,6 +3044,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3701,8 +3727,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3728,7 +3755,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4280,6 +4308,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4404,6 +4433,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4422,6 +4455,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4666,14 +4703,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4722,6 +4762,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4789,10 +4833,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4801,7 +4847,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5383,9 +5430,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5596,8 +5644,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5617,10 +5666,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5715,6 +5764,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5730,8 +5780,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6096,10 +6146,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6612,7 +6662,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6652,11 +6703,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6773,8 +6824,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6907,6 +6960,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7723,6 +7780,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8030,6 +8088,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/ar_EG.po
+++ b/locale/po/ar_EG.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Arabic (Egypt) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/ar_EG/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr "فواتير الموردين"
 msgid "AR Outstanding"
 msgstr "ارصدة عملاء "
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "حركة حساب عميل"
 
@@ -371,7 +373,7 @@ msgstr "إضافة ميزانية"
 msgid "Add Business"
 msgstr "اضافة نوع عمل"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "اضافة مخزن"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1591,10 +1601,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "شخص الاتصال"
 
@@ -1857,6 +1871,7 @@ msgstr "عملة"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "عملة"
 
@@ -1889,8 +1904,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "العميل"
@@ -1903,7 +1919,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "بيانات تاريخية للعميل"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2038,13 +2054,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "التاريخ"
 
@@ -2284,6 +2303,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2416,13 +2436,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "وصف"
 
@@ -2456,7 +2479,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2560,6 +2583,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2889,7 +2913,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3027,6 +3052,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "اجمالى"
 
@@ -3709,8 +3735,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "فاتورة"
 
@@ -3736,7 +3763,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "تاريخ الفاتورة"
 
@@ -4288,6 +4316,7 @@ msgstr "مايو"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "ملاحظات"
 
@@ -4412,6 +4441,10 @@ msgstr "الاسم"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4430,6 +4463,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4674,14 +4711,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "الرقم"
 
@@ -4730,6 +4770,10 @@ msgstr "اكتوبر"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4797,10 +4841,12 @@ msgstr "امر"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4809,7 +4855,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "تاريخ الامر"
 
@@ -5391,9 +5438,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "سعر"
 
@@ -5604,8 +5652,9 @@ msgstr "تم الشراء"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "الكمية"
 
@@ -5625,10 +5674,10 @@ msgstr "ربع"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "عروض اسعار للعملاء"
 
@@ -5723,6 +5772,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5738,8 +5788,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "الواردات"
 
@@ -6104,10 +6154,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "امر بيع"
 
@@ -6620,7 +6670,8 @@ msgid "Seventy"
 msgstr "سبعون"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "شحن صادر"
@@ -6660,11 +6711,11 @@ msgid "Ship to"
 msgstr "شحن الى"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6781,8 +6832,10 @@ msgstr "بعض"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "مصدر"
 
@@ -6916,6 +6969,10 @@ msgstr "مخزون"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "تجميع مخزون"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7731,6 +7788,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "وحدة"
 
@@ -8038,6 +8096,10 @@ msgstr "مورد غير موجود في الملف"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/bg.po
+++ b/locale/po/bg.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Bulgarian (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/bg/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Вземания от клиенти"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Превод продажба"
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Добави направление"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Добави склад"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1592,10 +1602,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Лице за контакт"
 
@@ -1858,6 +1872,7 @@ msgstr "Валута"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Валута"
 
@@ -1890,8 +1905,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Клиент"
@@ -1904,7 +1920,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "История на клиента"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2039,13 +2055,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Дата"
 
@@ -2285,6 +2304,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2417,13 +2437,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Обяснение"
 
@@ -2457,7 +2480,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2561,6 +2584,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2890,7 +2914,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3028,6 +3053,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Обобщен"
 
@@ -3711,8 +3737,9 @@ msgstr "Инвентара е преместен!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Фактура"
 
@@ -3738,7 +3765,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Фактура дата"
 
@@ -4290,6 +4318,7 @@ msgstr "Май"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Бележка"
 
@@ -4414,6 +4443,10 @@ msgstr "Име"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4432,6 +4465,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4676,14 +4713,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Номер"
 
@@ -4732,6 +4772,10 @@ msgstr "Октомври"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4799,10 +4843,12 @@ msgstr "Поръчка"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4811,7 +4857,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Дата на поръчка"
 
@@ -5393,9 +5440,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Цена"
 
@@ -5606,8 +5654,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "К-во"
 
@@ -5627,10 +5676,10 @@ msgstr "Четиримесечие"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Запазена форма"
 
@@ -5725,6 +5774,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Запис"
 
@@ -5740,8 +5790,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Постъпления"
 
@@ -6106,10 +6156,10 @@ msgstr "Фактура продажби/Номер на превод от кли
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Поръчка продажба"
 
@@ -6622,7 +6672,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Доставка"
@@ -6662,11 +6713,11 @@ msgid "Ship to"
 msgstr "Доставка до"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6783,8 +6834,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Оригинал"
 
@@ -6918,6 +6971,10 @@ msgstr "Стока"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Изграждане на комплект"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7733,6 +7790,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Единица"
 
@@ -8040,6 +8098,10 @@ msgstr "Липсва доствчика в базата"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/ca.po
+++ b/locale/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Catalan (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "ca/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacte"
 
@@ -1856,6 +1870,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Client"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Data"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripció"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3709,8 +3735,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3736,7 +3763,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Data Fra."
 
@@ -4288,6 +4316,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4412,6 +4441,10 @@ msgstr "Nom"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4430,6 +4463,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4674,14 +4711,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4730,6 +4770,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4797,10 +4841,12 @@ msgstr "Ordre"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4809,7 +4855,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data Ordre"
 
@@ -5391,9 +5438,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Preu"
 
@@ -5604,8 +5652,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Quantitat"
 
@@ -5625,10 +5674,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5723,6 +5772,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5738,8 +5788,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6104,10 +6154,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Pressupost"
 
@@ -6620,7 +6670,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6660,11 +6711,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6781,8 +6832,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Font"
 
@@ -6916,6 +6969,10 @@ msgstr ""
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Inventari Compost"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7731,6 +7788,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unitat"
 
@@ -8038,6 +8096,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/cmn.po
+++ b/locale/po/cmn.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese (Mandarin) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/cmn/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "应收未收"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "應收交易"
 
@@ -370,7 +372,7 @@ msgstr "新增預算"
 msgid "Add Business"
 msgstr "新增业务"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "連絡人"
 
@@ -1856,6 +1870,7 @@ msgstr "目前"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "幣別"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "客戶"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "客户历史"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "日期"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "說明"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "巳扩大"
 
@@ -3708,8 +3734,9 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "发票"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "发票日期"
 
@@ -4287,6 +4315,7 @@ msgstr "五月"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "備忘錄"
 
@@ -4411,6 +4440,10 @@ msgstr "名稱"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "編號"
 
@@ -4729,6 +4769,10 @@ msgstr "十月"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "订单"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "价格"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "数量"
 
@@ -5624,10 +5673,10 @@ msgstr "季度"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "報價單"
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "已收到"
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "收據"
 
@@ -6103,10 +6153,10 @@ msgstr "銷售發票/應收帳交易編號"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "銷貨單"
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "付運"
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr "海运至"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "來源"
 
@@ -6915,6 +6968,10 @@ msgstr "库存"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "把製成品入貨"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "單位"
 
@@ -8037,6 +8095,10 @@ msgstr "沒有此供應商的記錄！"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/cs.po
+++ b/locale/po/cs.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Czech (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "cs/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1591,10 +1601,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1857,6 +1871,7 @@ msgstr "Měna"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Měna"
 
@@ -1889,8 +1904,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Odběratel"
@@ -1903,7 +1919,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2038,13 +2054,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Datum"
 
@@ -2284,6 +2303,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2416,13 +2436,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Popis"
 
@@ -2456,7 +2479,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2560,6 +2583,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2889,7 +2913,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3027,6 +3052,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3709,8 +3735,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Faktura"
 
@@ -3736,7 +3763,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Datum vystavení"
 
@@ -4288,6 +4316,7 @@ msgstr "Květen"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4412,6 +4441,10 @@ msgstr "Jméno"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4430,6 +4463,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4674,14 +4711,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Číslo"
 
@@ -4730,6 +4770,10 @@ msgstr "Říjen"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4797,10 +4841,12 @@ msgstr "Objednávka"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4809,7 +4855,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Datum objednávky"
 
@@ -5391,9 +5438,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Cena"
 
@@ -5604,8 +5652,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Množství"
 
@@ -5625,10 +5674,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5723,6 +5772,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5738,8 +5788,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6104,10 +6154,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Přijatá objednávka"
 
@@ -6620,7 +6670,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6660,11 +6711,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6781,8 +6832,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Zdroj"
 
@@ -6916,6 +6969,10 @@ msgstr ""
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Výrobky"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7731,6 +7788,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Jednotka"
 
@@ -8038,6 +8096,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/da.po
+++ b/locale/po/da.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Mikkel Høgh <mikkel@hoegh.org>, 2016\n"
 "Language-Team: Danish (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -122,7 +122,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -145,9 +146,10 @@ msgstr "Debitorfakturaer"
 msgid "AR Outstanding"
 msgstr "Udestående (Debitor)"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Debitorpostering"
 
@@ -376,7 +378,7 @@ msgstr "Tilføj Budget"
 msgid "Add Business"
 msgstr "Ny forretning"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -534,6 +536,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Nyt lager"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -668,10 +674,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -740,6 +746,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1596,10 +1606,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1862,6 +1876,7 @@ msgstr "Val"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1894,8 +1909,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Kunde"
@@ -1908,7 +1924,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Kundehistorik"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2043,13 +2059,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Dato"
 
@@ -2289,6 +2308,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2421,13 +2441,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -2461,7 +2484,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2565,6 +2588,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2894,7 +2918,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3032,6 +3057,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Udvidet"
 
@@ -3714,8 +3740,9 @@ msgstr "Lagerbeholdning overført!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Faktura"
 
@@ -3741,7 +3768,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fakturadato"
 
@@ -4293,6 +4321,7 @@ msgstr "maj"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Note"
 
@@ -4417,6 +4446,10 @@ msgstr "Navn"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4435,6 +4468,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4679,14 +4716,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nummer"
 
@@ -4735,6 +4775,10 @@ msgstr "oktober"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4802,10 +4846,12 @@ msgstr "Ordre"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4814,7 +4860,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ordredato"
 
@@ -5396,9 +5443,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Pris"
 
@@ -5609,8 +5657,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Mængde"
 
@@ -5630,10 +5679,10 @@ msgstr "Kvartal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Tilbud"
 
@@ -5728,6 +5777,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Modt"
 
@@ -5743,8 +5793,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Kvitteringer"
 
@@ -6109,10 +6159,10 @@ msgstr "Salgsfaktura/debitorposteringnummer"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Salgsordre"
 
@@ -6625,7 +6675,8 @@ msgid "Seventy"
 msgstr "Halvfjerds"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Afsend"
@@ -6665,11 +6716,11 @@ msgid "Ship to"
 msgstr "Send til"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6786,8 +6837,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Bilag"
 
@@ -6921,6 +6974,10 @@ msgstr "Lager"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Sæt produkt på lager"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7736,6 +7793,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Enhed"
 
@@ -8043,6 +8101,10 @@ msgstr "Leverandør ikke i databasen!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/de.po
+++ b/locale/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: d34703e27442b8aae408ee1a019d49fd_1d2c70b, 2022\n"
 "Language-Team: German (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -123,7 +123,8 @@ msgstr "Verbindlichkeitskonto verfügbar, wenn Lieferant definiert"
 msgid "AP transaction"
 msgstr "Ausgangsbuchungen"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -146,9 +147,10 @@ msgstr "Ausstehende Rechnungen"
 msgid "AR Outstanding"
 msgstr "Offene Forderungen"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Ausgangsbuchung"
 
@@ -377,7 +379,7 @@ msgstr "Budget hinzufügen"
 msgid "Add Business"
 msgstr "Gewerbe hinzufÃ¼gen"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Klasse hinzufügen"
 
@@ -535,6 +537,10 @@ msgstr "Lieferantenrückgabe hinzufügen"
 msgid "Add Warehouse"
 msgstr "Warenlager hinzufÃ¼gen"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Abzug hinzufügen/verändern"
@@ -669,10 +675,10 @@ msgstr "Erlaubte Eingabe"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -742,6 +748,10 @@ msgstr "Lineare Abschreibung monatlich"
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Jede"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1606,10 +1616,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1876,6 +1890,7 @@ msgstr "WÃ¤hrung"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "WÃ¤hrung"
 
@@ -1908,8 +1923,9 @@ msgstr "Benutzerdefinierte Markierungen"
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Kunde"
@@ -1922,7 +1938,7 @@ msgstr "Kundenkonto"
 msgid "Customer History"
 msgstr "Alle Belege für Kunde"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "Kundenrechnung"
 
@@ -2057,13 +2073,16 @@ msgstr "Datenbank existiert."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Datum"
 
@@ -2303,6 +2322,7 @@ msgid "Deleting..."
 msgstr "Löschen..."
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Lieferung"
 
@@ -2435,13 +2455,16 @@ msgstr "Abschreibungsbeginn"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -2475,7 +2498,7 @@ msgstr "Disc"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Rabatt %"
 
@@ -2579,6 +2602,7 @@ msgstr "AufklappmenÃ¼s"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "FÃ¤llig"
 
@@ -2910,7 +2934,8 @@ msgid "Entered at: [_1]"
 msgstr "Eingegeben am: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "EntitÃ¤t"
 
@@ -3049,6 +3074,7 @@ msgid "Experimental features"
 msgstr "Experimentelle Eigenschaften"
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Erweitert"
 
@@ -3739,8 +3765,9 @@ msgstr "Inventar Ã¼bertragen!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Rechnung"
 
@@ -3766,7 +3793,8 @@ msgstr "Rechnungserstellt"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Rechnungsdatum"
 
@@ -4326,6 +4354,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Vermerk"
 
@@ -4452,6 +4481,10 @@ msgstr "Name"
 msgid "Name:"
 msgstr "Name:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Bilanzwert"
@@ -4471,6 +4504,10 @@ msgstr "Neuer Vermögensbericht"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Neue Bestandsberichtssuche"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4716,14 +4753,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nummer"
 
@@ -4773,6 +4813,10 @@ msgstr "Oktober"
 #: old/bin/is.pl:810
 msgid "Off Hold"
 msgstr "Warten"
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
+msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:227
@@ -4839,10 +4883,12 @@ msgstr "Bestellung"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Bestellnummer #"
 
@@ -4851,7 +4897,8 @@ msgid "Order By"
 msgstr "Sortieren nach"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Bestelldatum"
 
@@ -5435,9 +5482,10 @@ msgid "Prefix"
 msgstr "Präfix"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Preis"
 
@@ -5648,8 +5696,9 @@ msgstr "Gekauft"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Menge"
 
@@ -5669,10 +5718,10 @@ msgstr "Quartal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Angebot"
 
@@ -5767,6 +5816,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Dokumentieren"
 
@@ -5782,8 +5832,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr "Eingangsergebnisse"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Belege"
 
@@ -6148,10 +6198,10 @@ msgstr "Ausgangsrechnung/Transaktionsnummer ausstehende Rechnung"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Verkaufsauftrag"
 
@@ -6664,7 +6714,8 @@ msgid "Seventy"
 msgstr "siebzig"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Versenden"
@@ -6704,11 +6755,11 @@ msgid "Ship to"
 msgstr "Liefern an"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6825,8 +6876,10 @@ msgstr "Einige"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Quelle"
 
@@ -6960,6 +7013,10 @@ msgstr "Bestand"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Erzeugnis einlagern"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7777,6 +7834,7 @@ msgstr "Einzigartige nicht veraltete Teilnummer"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Einheit"
 
@@ -8085,6 +8143,10 @@ msgstr "Lieferant nicht in der Datei!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "Verkäufer/Kunde"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/de_CH.po
+++ b/locale/po/de_CH.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: German (Switzerland) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/de_CH/)\n"
@@ -119,7 +119,8 @@ msgstr "Verbindlichkeitskonto verfügbar, falls Lieferant definiert"
 msgid "AP transaction"
 msgstr "Ausgangsbuchungen"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -142,9 +143,10 @@ msgstr "Debitorenrechnungen"
 msgid "AR Outstanding"
 msgstr "Offene Forderungen"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Ausgangsbuchung"
 
@@ -373,7 +375,7 @@ msgstr "Budget hinzufügen"
 msgid "Add Business"
 msgstr "Branche erfassen"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Klasse hinzufügen"
 
@@ -531,6 +533,10 @@ msgstr "Lieferantenrückgabe hinzufügen"
 msgid "Add Warehouse"
 msgstr "Warenlager erfassen"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Abzug hinzufügen/verändern"
@@ -665,10 +671,10 @@ msgstr "Erlaubte Eingabe"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -738,6 +744,10 @@ msgstr "Lineare Abschreibung monatlich"
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Jede"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1606,10 +1616,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1876,6 +1890,7 @@ msgstr "Währung"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Währung"
 
@@ -1908,8 +1923,9 @@ msgstr "Benutzerdefinierte Markierungen"
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Kunde"
@@ -1922,7 +1938,7 @@ msgstr "Kundenkonto"
 msgid "Customer History"
 msgstr "Alle Belege für Kunde"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "Kundenrechnung"
 
@@ -2057,13 +2073,16 @@ msgstr "Datenbank existiert."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Datum"
 
@@ -2303,6 +2322,7 @@ msgid "Deleting..."
 msgstr "Löschen..."
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Lieferung"
 
@@ -2435,13 +2455,16 @@ msgstr "Abschreibungsbeginn"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -2475,7 +2498,7 @@ msgstr "Rbt."
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Rbt. %"
 
@@ -2579,6 +2602,7 @@ msgstr "AufklappmenÃ¼s"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Fällig"
 
@@ -2910,7 +2934,8 @@ msgid "Entered at: [_1]"
 msgstr "Eingegeben am: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Entität"
 
@@ -3049,6 +3074,7 @@ msgid "Experimental features"
 msgstr "Experimentelle Eigenschaften"
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Summe"
 
@@ -3739,8 +3765,9 @@ msgstr "Inventar übertragen"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Rechnung"
 
@@ -3766,7 +3793,8 @@ msgstr "Rechnungserstellt"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Rechnungsdatum"
 
@@ -4326,6 +4354,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Notiz"
 
@@ -4452,6 +4481,10 @@ msgstr "Name"
 msgid "Name:"
 msgstr "Name:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Bilanzwert"
@@ -4471,6 +4504,10 @@ msgstr "Neuer Vermögensbericht"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Neue Bestandsberichtssuche"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4716,14 +4753,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Artikelnummer"
 
@@ -4773,6 +4813,10 @@ msgstr "Oktober"
 #: old/bin/is.pl:810
 msgid "Off Hold"
 msgstr "Warten"
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
+msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:227
@@ -4839,10 +4883,12 @@ msgstr "Bestellung"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Bestellung #"
 
@@ -4851,7 +4897,8 @@ msgid "Order By"
 msgstr "Sortieren nach"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Bestelldatum"
 
@@ -5435,9 +5482,10 @@ msgid "Prefix"
 msgstr "Präfix"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Preis"
 
@@ -5648,8 +5696,9 @@ msgstr "Gekauft"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Menge"
 
@@ -5669,10 +5718,10 @@ msgstr "Quartal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Offerte"
 
@@ -5767,6 +5816,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Erh"
 
@@ -5782,8 +5832,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr "Eingangsergebnisse"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Quittungen"
 
@@ -6148,10 +6198,10 @@ msgstr "Verkaufsrechnung-/Buchungsnummer"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Auftragsbestätigung"
 
@@ -6664,7 +6714,8 @@ msgid "Seventy"
 msgstr "siebzig"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Versenden"
@@ -6704,11 +6755,11 @@ msgid "Ship to"
 msgstr "Lieferung an"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6825,8 +6876,10 @@ msgstr "Einige"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Beleg"
 
@@ -6960,6 +7013,10 @@ msgstr "Einlagern"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Erzeugnis einlagern"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7777,6 +7834,7 @@ msgstr "Einzigartige nicht veraltete Teilnummer"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Einheit"
 
@@ -8085,6 +8143,10 @@ msgstr "Lieferant ist nicht in der Datenbank!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "Verkäufer/Kunde"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/el.po
+++ b/locale/po/el.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Greek (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "el/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Κινήσεις Πωλήσεων"
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Προσθήκη Αποθήκης"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Επαφή"
 
@@ -1856,6 +1870,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Συνάλλαγμα"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Πελάτης"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Ιστορικό Πελάτη"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Ημερομηνία"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Περιγραφή"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3708,8 +3734,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Τιμολόγιο"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Ημ. τιμολογίου"
 
@@ -4287,6 +4315,7 @@ msgstr "Μάϊος"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4411,6 +4440,10 @@ msgstr "Όνομα"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Αριθμός"
 
@@ -4729,6 +4769,10 @@ msgstr "Οκτώβριος"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "Παραγγελία"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ημ. Παραγγελίας"
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Τιμή"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Ποσ."
 
@@ -5624,10 +5673,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6103,10 +6153,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Πηγή"
 
@@ -6914,6 +6967,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8037,6 +8095,10 @@ msgstr "Creditor not on file!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/en.po
+++ b/locale/po/en.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2022-01-09T21:20:15.970Z\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
@@ -115,7 +115,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -138,9 +139,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -369,7 +371,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -527,6 +529,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -661,10 +667,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -733,6 +739,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1589,10 +1599,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1855,6 +1869,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1887,8 +1902,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr ""
@@ -1901,7 +1917,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2036,13 +2052,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2282,6 +2301,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2414,13 +2434,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2454,7 +2477,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2558,6 +2581,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2887,7 +2911,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3025,6 +3050,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3707,8 +3733,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3734,7 +3761,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4286,6 +4314,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4410,6 +4439,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4428,6 +4461,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4672,14 +4709,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4728,6 +4768,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4795,10 +4839,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4807,7 +4853,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5389,9 +5436,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5602,8 +5650,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5623,10 +5672,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5721,6 +5770,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5736,8 +5786,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6102,10 +6152,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6618,7 +6668,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6658,11 +6709,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6779,8 +6830,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6913,6 +6966,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7729,6 +7786,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8036,6 +8094,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/en_CA.po
+++ b/locale/po/en_CA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: English (Canada) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/en_CA/)\n"
@@ -119,7 +119,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -142,9 +143,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Sales Transaction"
 
@@ -373,7 +375,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -531,6 +533,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -665,10 +671,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -737,6 +743,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1593,10 +1603,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1859,6 +1873,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1891,8 +1906,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Debtor"
@@ -1905,7 +1921,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2040,13 +2056,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2286,6 +2305,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2418,13 +2438,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2458,7 +2481,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2562,6 +2585,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2891,7 +2915,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3029,6 +3054,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3711,8 +3737,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3738,7 +3765,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4290,6 +4318,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4414,6 +4443,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4432,6 +4465,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4676,14 +4713,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4732,6 +4772,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4799,10 +4843,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4811,7 +4857,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5393,9 +5440,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5606,8 +5654,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5627,10 +5676,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5725,6 +5774,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5740,8 +5790,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6106,10 +6156,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6622,7 +6672,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6662,11 +6713,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6783,8 +6834,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6917,6 +6970,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7733,6 +7790,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8040,6 +8098,10 @@ msgstr "Creditor not on file!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/en_GB.po
+++ b/locale/po/en_GB.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Nick Prater <nick.github@npbroadcast.com>, 2018\n"
 "Language-Team: English (United Kingdom) (http://app.transifex.com/ledgersmb/"
@@ -121,7 +121,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -144,9 +145,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Sales Transaction"
 
@@ -375,7 +377,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -533,6 +535,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -667,10 +673,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -739,6 +745,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1861,6 +1875,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Debtor"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3713,8 +3739,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3740,7 +3767,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4292,6 +4320,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4416,6 +4445,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4434,6 +4467,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4678,14 +4715,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4734,6 +4774,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4801,10 +4845,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4813,7 +4859,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5395,9 +5442,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5608,8 +5656,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5629,10 +5678,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5727,6 +5776,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5742,8 +5792,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6108,10 +6158,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6624,7 +6674,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6664,11 +6715,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6785,8 +6836,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6919,6 +6972,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7735,6 +7792,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8042,6 +8100,10 @@ msgstr "Creditor not on file!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/en_NZ.po
+++ b/locale/po/en_NZ.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: paul bolger <pbolger@gmail.com>, 2015-2016\n"
 "Language-Team: English (New Zealand) (http://app.transifex.com/ledgersmb/"
@@ -121,7 +121,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -144,9 +145,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Sales Transaction"
 
@@ -375,7 +377,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -533,6 +535,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -667,10 +673,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -739,6 +745,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1861,6 +1875,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Debtor"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3713,8 +3739,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3740,7 +3767,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4292,6 +4320,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4416,6 +4445,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4434,6 +4467,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4678,14 +4715,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4734,6 +4774,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4801,10 +4845,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4813,7 +4859,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5395,9 +5442,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5608,8 +5656,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5629,10 +5678,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5727,6 +5776,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5742,8 +5792,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6108,10 +6158,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6624,7 +6674,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6664,11 +6715,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6785,8 +6836,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6919,6 +6972,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7735,6 +7792,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8042,6 +8100,10 @@ msgstr "Creditor not on file!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es.po
+++ b/locale/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Gabriel Díaz Campuzano <correototalmenteserio@gmail.com>, "
 "2020\n"
@@ -121,7 +121,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -144,9 +145,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Cuentas a Cobrar pendientes"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Gestión de cobro"
 
@@ -375,7 +377,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Adicionar Negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -533,6 +535,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Deposito"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -667,10 +673,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -739,6 +745,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1599,10 +1609,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1865,6 +1879,7 @@ msgstr "Mon."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1897,8 +1912,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1911,7 +1927,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Histórico de Clientes"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2046,13 +2062,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2292,6 +2311,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2424,13 +2444,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2464,7 +2487,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2568,6 +2591,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2897,7 +2921,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3035,6 +3060,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendido"
 
@@ -3719,8 +3745,9 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3746,7 +3773,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
@@ -4298,6 +4326,7 @@ msgstr "May"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4422,6 +4451,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4440,6 +4473,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4684,14 +4721,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4740,6 +4780,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4807,10 +4851,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4819,7 +4865,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de elaboración"
 
@@ -5401,9 +5448,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5614,8 +5662,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cantidad"
 
@@ -5635,10 +5684,10 @@ msgstr "Cuarto"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5733,6 +5782,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Cobrado"
 
@@ -5748,8 +5798,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6114,10 +6164,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Presupuesto"
 
@@ -6630,7 +6680,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Envio"
@@ -6670,11 +6721,11 @@ msgid "Ship to"
 msgstr "Destino"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6791,8 +6842,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Fuente"
 
@@ -6926,6 +6979,10 @@ msgstr "Existencia"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Inventariar compuesto"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7744,6 +7801,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8051,6 +8109,10 @@ msgstr "¡No se encuentra el proveedor en la base de datos!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_AR.po
+++ b/locale/po/es_AR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Argentina) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/es_AR/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Cuentas a Cobrar pendientes"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transaccion de Ingreso"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Agregar Negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Deposito"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Moneda"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Histórico de Clientes"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripcion"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendido"
 
@@ -3714,8 +3740,9 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3741,7 +3768,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de Factura"
 
@@ -4293,6 +4321,7 @@ msgstr "May"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4417,6 +4446,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4435,6 +4468,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4679,14 +4716,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numero"
 
@@ -4735,6 +4775,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4802,10 +4846,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4814,7 +4860,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de Orden"
 
@@ -5396,9 +5443,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5609,8 +5657,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Ctd."
 
@@ -5630,10 +5679,10 @@ msgstr "Cuarto"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Presupuesto"
 
@@ -5728,6 +5777,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Rcbdo."
 
@@ -5743,8 +5793,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6109,10 +6159,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
@@ -6625,7 +6675,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Despachar"
@@ -6665,11 +6716,11 @@ msgid "Ship to"
 msgstr "Despachar a"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6786,8 +6837,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Fuente"
 
@@ -6921,6 +6974,10 @@ msgstr "Inventario"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Provicion de Manufacturas"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7739,6 +7796,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8046,6 +8104,10 @@ msgstr "Archivo sin proveedor!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_CO.po
+++ b/locale/po/es_CO.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Colombia) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/es_CO/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Impagados Cartera"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Cuentas por Cobrar"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Agregar Empresa"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Bodega"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Mon."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Historial del Cliente"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendido"
 
@@ -3715,8 +3741,9 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura de Venta"
 
@@ -3742,7 +3769,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
@@ -4294,6 +4322,7 @@ msgstr "Mayo"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4418,6 +4447,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4436,6 +4469,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4680,14 +4717,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4736,6 +4776,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4803,10 +4847,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4815,7 +4861,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de elaboración"
 
@@ -5397,9 +5444,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5610,8 +5658,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cantidad"
 
@@ -5631,10 +5680,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5729,6 +5778,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Cobrado"
 
@@ -5744,8 +5794,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6110,10 +6160,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
@@ -6626,7 +6676,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Envio"
@@ -6666,11 +6717,11 @@ msgid "Ship to"
 msgstr "Destino"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6787,8 +6838,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Fuente"
 
@@ -6922,6 +6975,10 @@ msgstr "Inventario"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Inventariar Compuesto"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7740,6 +7797,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8047,6 +8105,10 @@ msgstr "¡No se encuentra el proveedor en la base de datos!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_EC.po
+++ b/locale/po/es_EC.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Ecuador) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/es_EC/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Impagados Cartera"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Gestión de cobro"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Adicionar Negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Adicionar Bodega"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Mon."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Historial del Cliente"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendido"
 
@@ -3715,8 +3741,9 @@ msgstr "¡Inventario transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura de Venta"
 
@@ -3742,7 +3769,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
@@ -4294,6 +4322,7 @@ msgstr "May"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4418,6 +4447,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4436,6 +4469,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4680,14 +4717,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4736,6 +4776,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4803,10 +4847,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4815,7 +4861,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de elaboración"
 
@@ -5397,9 +5444,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5610,8 +5658,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cantidad"
 
@@ -5631,10 +5680,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5729,6 +5778,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Cobrado"
 
@@ -5744,8 +5794,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6110,10 +6160,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
@@ -6626,7 +6676,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Envio"
@@ -6666,11 +6717,11 @@ msgid "Ship to"
 msgstr "Destino"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6787,8 +6838,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Fuente"
 
@@ -6922,6 +6975,10 @@ msgstr "Inventario"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Inventariar compuesto"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7740,6 +7797,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8047,6 +8105,10 @@ msgstr "¡No se encuentra el proveedor en la base de datos!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_MX.po
+++ b/locale/po/es_MX.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Mexico) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/es_MX/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "CxC pendientes"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Movimiento CxC"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Nuevo negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Nuevo almacén"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Mon."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Historia del cliente"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendido"
 
@@ -3715,8 +3741,9 @@ msgstr "¡Existencias transferidas!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3742,7 +3769,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
@@ -4294,6 +4322,7 @@ msgstr "May"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Nota"
 
@@ -4418,6 +4447,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4436,6 +4469,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4680,14 +4717,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4736,6 +4776,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4803,10 +4847,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4815,7 +4861,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la orden"
 
@@ -5397,9 +5444,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5610,8 +5658,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cant."
 
@@ -5631,10 +5680,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5729,6 +5778,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Recb."
 
@@ -5744,8 +5794,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Cobros"
 
@@ -6110,10 +6160,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Orden de venta"
 
@@ -6626,7 +6676,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Enviar"
@@ -6666,11 +6717,11 @@ msgid "Ship to"
 msgstr "Enviar a"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6787,8 +6838,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Referencia"
 
@@ -6922,6 +6975,10 @@ msgstr "Inventario"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Inventariar ensamblaje"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7740,6 +7797,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8047,6 +8105,10 @@ msgstr "¡Proveedor no registrado!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_PA.po
+++ b/locale/po/es_PA.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Panama) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/es_PA/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Cuentas por Cobrar pendientes"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Movimiento de Cuentas por Cobrar"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Agregar Negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Almacén"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Div"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Divisa"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Historial del Cliente"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Importe"
 
@@ -3714,8 +3740,9 @@ msgstr "¡Inventario transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3741,7 +3768,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
@@ -4293,6 +4321,7 @@ msgstr "Mayo"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Nota"
 
@@ -4417,6 +4446,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4435,6 +4468,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4679,14 +4716,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4735,6 +4775,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4802,10 +4846,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4814,7 +4860,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la orden"
 
@@ -5396,9 +5443,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5609,8 +5657,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cant."
 
@@ -5630,10 +5679,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5728,6 +5777,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Recb."
 
@@ -5743,8 +5793,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6109,10 +6159,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
@@ -6625,7 +6675,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Enviar"
@@ -6665,11 +6716,11 @@ msgid "Ship to"
 msgstr "Enviar a"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6786,8 +6837,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Origen"
 
@@ -6921,6 +6974,10 @@ msgstr "Inventario"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Reponer ensamblaje"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7739,6 +7796,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8046,6 +8104,10 @@ msgstr "¡Proveedor no registrado!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_PY.po
+++ b/locale/po/es_PY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Paraguay) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/es_PY/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Cuentas a Cobrar pendientes"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Movimiento de Cuentas a Cobrar"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Agregar Negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Almacén"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Div"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Divisa"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Historial del Cliente"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Importe"
 
@@ -3714,8 +3740,9 @@ msgstr "¡Existencias transferidas!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3741,7 +3768,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
@@ -4293,6 +4321,7 @@ msgstr "Mayo"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Nota"
 
@@ -4417,6 +4446,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4435,6 +4468,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4679,14 +4716,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4735,6 +4775,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4802,10 +4846,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4814,7 +4860,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la orden"
 
@@ -5396,9 +5443,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5609,8 +5657,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cant."
 
@@ -5630,10 +5679,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5728,6 +5777,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Recb."
 
@@ -5743,8 +5793,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6109,10 +6159,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Orden de Venta"
 
@@ -6625,7 +6675,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Enviar"
@@ -6665,11 +6716,11 @@ msgid "Ship to"
 msgstr "Enviar a"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6786,8 +6837,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Origen"
 
@@ -6921,6 +6974,10 @@ msgstr "Existencia"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Reponer ensamblaje"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7739,6 +7796,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8046,6 +8104,10 @@ msgstr "¡Proveedor no registrado!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_SV.po
+++ b/locale/po/es_SV.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (El Salvador) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/es_SV/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "CxC Extraordinarias"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transaccion - CxC"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Adicionar Negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Deposito"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Mon."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Histórico de Clientes"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendido"
 
@@ -3715,8 +3741,9 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3742,7 +3769,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de Factura"
 
@@ -4294,6 +4322,7 @@ msgstr "May"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4418,6 +4447,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4436,6 +4469,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4680,14 +4717,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4736,6 +4776,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4803,10 +4847,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4815,7 +4861,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de Orden"
 
@@ -5397,9 +5444,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5610,8 +5658,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cant."
 
@@ -5631,10 +5680,10 @@ msgstr "Cuarto"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5729,6 +5778,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Rec"
 
@@ -5744,8 +5794,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Ingresos"
 
@@ -6110,10 +6160,10 @@ msgstr "Factura/Numero de Transaccion para Ingreso"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Orden de venta"
 
@@ -6626,7 +6676,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Envíe"
@@ -6666,11 +6717,11 @@ msgid "Ship to"
 msgstr "Envíe a"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6787,8 +6838,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Fuente"
 
@@ -6922,6 +6975,10 @@ msgstr "Existencia"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Inventariar Ensamblaje?"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7740,6 +7797,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8047,6 +8105,10 @@ msgstr "Proveedor no está en archivo!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/es_VE.po
+++ b/locale/po/es_VE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Spanish (Venezuela) (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/es_VE/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Pendientes de CxC"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Asiento de CxC"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Agregar Negocio"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Agregar Clase"
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Agregar Almacén"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1861,6 +1875,7 @@ msgstr "Mon."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Histórico de Clientes"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Fecha"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descripción"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendido"
 
@@ -3715,8 +3741,9 @@ msgstr "Inventario transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3742,7 +3769,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fecha de Factura"
 
@@ -4294,6 +4322,7 @@ msgstr "May"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4418,6 +4447,10 @@ msgstr "Nombre"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valor Neto de Libro"
@@ -4436,6 +4469,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4680,14 +4717,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Código"
 
@@ -4736,6 +4776,10 @@ msgstr "Octubre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4803,10 +4847,12 @@ msgstr "Orden"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4815,7 +4861,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Fecha de la Orden"
 
@@ -5397,9 +5444,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Precio"
 
@@ -5610,8 +5658,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Cantidad"
 
@@ -5631,10 +5680,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotización"
 
@@ -5729,6 +5778,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Rcbdo"
 
@@ -5744,8 +5794,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6110,10 +6160,10 @@ msgstr "N° Factura/Transacción de CxC"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Pedido"
 
@@ -6626,7 +6676,8 @@ msgid "Seventy"
 msgstr "setenta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Envío"
@@ -6666,11 +6717,11 @@ msgid "Ship to"
 msgstr "Destino"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6787,8 +6838,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Cheque N°"
 
@@ -6922,6 +6975,10 @@ msgstr "Inventario"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Inventariar Juego"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7740,6 +7797,7 @@ msgstr "Numero Unico de Parte no obsoleta"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidad"
 
@@ -8047,6 +8105,10 @@ msgstr "¡Proveedor no se encuentra en la Base de Datos!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/et.po
+++ b/locale/po/et.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>, 2015\n"
 "Language-Team: Estonian (http://app.transifex.com/ledgersmb/ledgersmb/"
@@ -118,7 +118,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -141,9 +142,10 @@ msgstr "Müügiarved"
 msgid "AR Outstanding"
 msgstr "MR Laekumata"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "MR Tehing"
 
@@ -372,7 +374,7 @@ msgstr "Lisa eelarve"
 msgid "Add Business"
 msgstr "Lisa Ettevõte"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Lisa klass"
 
@@ -530,6 +532,10 @@ msgstr "Lisa tarnijale tagastus"
 msgid "Add Warehouse"
 msgstr "Lisa Kaubaladu"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Lisa/Muuda mahaarvamine"
@@ -664,10 +670,10 @@ msgstr "Luba sisestus"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -736,6 +742,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1592,10 +1602,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1858,6 +1872,7 @@ msgstr "Val."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuuta"
 
@@ -1890,8 +1905,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Klient"
@@ -1904,7 +1920,7 @@ msgstr "Kliendi konto"
 msgid "Customer History"
 msgstr "Kliendi Ajalugu"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2039,13 +2055,16 @@ msgstr "Andmebaas eksisteerib."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Kuupäev"
 
@@ -2285,6 +2304,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Üleandmine"
 
@@ -2417,13 +2437,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Selgitus"
 
@@ -2457,7 +2480,7 @@ msgstr "Allahindlus"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Allahindluse %"
 
@@ -2561,6 +2584,7 @@ msgstr "Rippmenüüd"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Tähtaeg"
 
@@ -2890,7 +2914,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3028,6 +3053,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Summa"
 
@@ -3710,8 +3736,9 @@ msgstr "Laoseis üle kantud!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Kaubaarve"
 
@@ -3737,7 +3764,8 @@ msgstr "Arve koostamise kuupäev puudub!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Kaubaarve Kuupäev"
 
@@ -4289,6 +4317,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4413,6 +4442,10 @@ msgstr "Nimi"
 msgid "Name:"
 msgstr "Nimi:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4431,6 +4464,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4675,14 +4712,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Number"
 
@@ -4731,6 +4771,10 @@ msgstr "Oktoober"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4798,10 +4842,12 @@ msgstr "Tellimus"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4810,7 +4856,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tellimuse Kuupäev"
 
@@ -5392,9 +5439,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Hind"
 
@@ -5605,8 +5653,9 @@ msgstr "Ostetud"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Kogus"
 
@@ -5626,10 +5675,10 @@ msgstr "Kvartal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Koteering"
 
@@ -5724,6 +5773,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Kätte saadud"
 
@@ -5739,8 +5789,8 @@ msgstr "Laekumise kuupäev"
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Laekumid"
 
@@ -6105,10 +6155,10 @@ msgstr "Müügiarve/MR Tehingu Number"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Müügitellimus"
 
@@ -6621,7 +6671,8 @@ msgid "Seventy"
 msgstr "seitsekümmend"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Saatmine"
@@ -6661,11 +6712,11 @@ msgid "Ship to"
 msgstr "Kaubasaaja"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6782,8 +6833,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Allikas"
 
@@ -6917,6 +6970,10 @@ msgstr "Kaubavaru"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Komplekti Ladustamine"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7734,6 +7791,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Ühik"
 
@@ -8041,6 +8099,10 @@ msgstr "Tarnija pole failis!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/fa_IR.po
+++ b/locale/po/fa_IR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/fa_IR/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1856,6 +1870,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr ""
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3708,8 +3734,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4287,6 +4315,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4411,6 +4440,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4729,6 +4769,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5624,10 +5673,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6103,10 +6153,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6914,6 +6967,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8037,6 +8095,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/fi.po
+++ b/locale/po/fi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Juha Eerola <juhaeerola@outlook.com>, 2017\n"
 "Language-Team: Finnish (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -119,7 +119,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -142,9 +143,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Ei maksetut myyntilaskut"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Myyntitapahtuma"
 
@@ -373,7 +375,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Lisää yritys"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -531,6 +533,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Lisää varasto"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -665,10 +671,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -737,6 +743,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1593,10 +1603,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Yhteyshenkilö"
 
@@ -1859,6 +1873,7 @@ msgstr "Valuutta"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuutta"
 
@@ -1891,8 +1906,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Asiakas"
@@ -1905,7 +1921,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Asiakashistoria"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2040,13 +2056,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Päiväys"
 
@@ -2286,6 +2305,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2418,13 +2438,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -2458,7 +2481,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2562,6 +2585,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2891,7 +2915,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3029,6 +3054,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Pidennetty"
 
@@ -3711,8 +3737,9 @@ msgstr "Varasto siirretty!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Lasku"
 
@@ -3738,7 +3765,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Laskun päiväys"
 
@@ -4290,6 +4318,7 @@ msgstr "Tou"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Muistio"
 
@@ -4414,6 +4443,10 @@ msgstr "Nimi"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4432,6 +4465,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4676,14 +4713,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numero"
 
@@ -4732,6 +4772,10 @@ msgstr "Lokakuu"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4799,10 +4843,12 @@ msgstr "Tilaus"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4811,7 +4857,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tilauspäivämäärä"
 
@@ -5393,9 +5440,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Hinta"
 
@@ -5606,8 +5654,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Määrä"
 
@@ -5627,10 +5676,10 @@ msgstr "Neljännes"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Tarjous"
 
@@ -5725,6 +5774,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Vastaanotettu"
 
@@ -5740,8 +5790,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Kuitit"
 
@@ -6106,10 +6156,10 @@ msgstr "Myyntilaskun/viennin numero"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Tilausvahvistus"
 
@@ -6622,7 +6672,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Toimita"
@@ -6662,11 +6713,11 @@ msgid "Ship to"
 msgstr "Toimitusosoite"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6783,8 +6834,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Lähde"
 
@@ -6918,6 +6971,10 @@ msgstr "Varasto"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Varastoi tuote"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7733,6 +7790,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Yksikkö"
 
@@ -8040,6 +8098,10 @@ msgstr "Toimittajaa ei järjestelmässä!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/fr.po
+++ b/locale/po/fr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: French (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "fr/)\n"
@@ -120,7 +120,8 @@ msgstr "Compte AP disponible lorsque les fournisseurs sont définis"
 msgid "AP transaction"
 msgstr "Écriture dépenses"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -143,9 +144,10 @@ msgstr "Factures"
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
@@ -374,7 +376,7 @@ msgstr "Ajouter un budget"
 msgid "Add Business"
 msgstr "Ajouter type d'affaire"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Ajouter une classe"
 
@@ -532,6 +534,10 @@ msgstr "Ajouter un retour fournisseur"
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Ajouter/Modifier des déductions"
@@ -666,10 +672,10 @@ msgstr "Autoriser la saisie"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -738,6 +744,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1598,10 +1608,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contact"
 
@@ -1868,6 +1882,7 @@ msgstr "Dev."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Devise"
 
@@ -1900,8 +1915,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Client"
@@ -1914,7 +1930,7 @@ msgstr "Compte client"
 msgid "Customer History"
 msgstr "Historique client"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "Facture client"
 
@@ -2049,13 +2065,16 @@ msgstr "La base de données existe."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Date"
 
@@ -2295,6 +2314,7 @@ msgid "Deleting..."
 msgstr "Suprimer..."
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Livraison"
 
@@ -2427,13 +2447,16 @@ msgstr "Début d'amortissement"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Description"
 
@@ -2467,7 +2490,7 @@ msgstr "Rabais"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Rabais %"
 
@@ -2571,6 +2594,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Exigible"
 
@@ -2902,7 +2926,8 @@ msgid "Entered at: [_1]"
 msgstr "Entré à : [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Entité"
 
@@ -3042,6 +3067,7 @@ msgid "Experimental features"
 msgstr "Fonctionnalités expérimentales"
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Prix total"
 
@@ -3735,8 +3761,9 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Facture"
 
@@ -3762,7 +3789,8 @@ msgstr "Date de création de facture manquante!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
@@ -4335,6 +4363,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Mémo"
 
@@ -4461,6 +4490,10 @@ msgstr "Nom"
 msgid "Name:"
 msgstr "Nom:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valeur comptable nette"
@@ -4480,6 +4513,10 @@ msgstr "Nouveau rapport d'actif"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Rapport de recherche des nouveaux actifs"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4728,14 +4765,17 @@ msgstr "Numéros de modèle nuls"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numéro"
 
@@ -4784,6 +4824,10 @@ msgstr "Octobre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4851,10 +4895,12 @@ msgstr "Commande"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Commande #"
 
@@ -4863,7 +4909,8 @@ msgid "Order By"
 msgstr "Commandé par"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
@@ -5455,9 +5502,10 @@ msgid "Prefix"
 msgstr "Préfixe"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Prix"
 
@@ -5668,8 +5716,9 @@ msgstr "Acheté"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Qté"
 
@@ -5689,10 +5738,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Devis"
 
@@ -5787,6 +5836,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Reconstruire/Mettre à jour?"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5802,8 +5852,8 @@ msgstr "Date de réception"
 msgid "Receipt Results"
 msgstr "Résultats de réception"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Reçus"
 
@@ -6168,10 +6218,10 @@ msgstr "Numéro facture de vente/écriture recette"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Commande de vente"
 
@@ -6685,7 +6735,8 @@ msgid "Seventy"
 msgstr "Soixante-dix"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Expédier"
@@ -6725,11 +6776,11 @@ msgid "Ship to"
 msgstr "Expédier à"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6846,8 +6897,10 @@ msgstr "Certains"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Source"
 
@@ -6987,6 +7040,10 @@ msgstr "Stock"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Stock de produits"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7815,6 +7872,7 @@ msgstr "Numéros uniques de pièces non obsolètes"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unité"
 
@@ -8125,6 +8183,10 @@ msgstr "Fournisseur absent du fichier!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "Fournisseur/Client"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/fr_BE.po
+++ b/locale/po/fr_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: French (Belgium) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/fr_BE/)\n"
@@ -120,7 +120,8 @@ msgstr "Compte AP disponible lorsque les fournisseurs sont définis"
 msgid "AP transaction"
 msgstr "Écriture dépenses"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -143,9 +144,10 @@ msgstr "Factures"
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
@@ -374,7 +376,7 @@ msgstr "Ajouter un budget"
 msgid "Add Business"
 msgstr "Ajouter type d'affaire"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Ajouter une classe"
 
@@ -532,6 +534,10 @@ msgstr "Ajouter un retour fournisseur"
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Ajouter/Modifier des déductions"
@@ -666,10 +672,10 @@ msgstr "Autoriser la saisie"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -738,6 +744,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1598,10 +1608,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contact"
 
@@ -1868,6 +1882,7 @@ msgstr "Dev."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Devise"
 
@@ -1900,8 +1915,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Client"
@@ -1914,7 +1930,7 @@ msgstr "Compte client"
 msgid "Customer History"
 msgstr "Historique client"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "Facture client"
 
@@ -2049,13 +2065,16 @@ msgstr "La base de données existe."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Date"
 
@@ -2295,6 +2314,7 @@ msgid "Deleting..."
 msgstr "Suprimer..."
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Livraison"
 
@@ -2427,13 +2447,16 @@ msgstr "Début d'amortissement"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Description"
 
@@ -2467,7 +2490,7 @@ msgstr "Rabais"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Rabais %"
 
@@ -2571,6 +2594,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Exigible"
 
@@ -2902,7 +2926,8 @@ msgid "Entered at: [_1]"
 msgstr "Entré à : [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Entité"
 
@@ -3042,6 +3067,7 @@ msgid "Experimental features"
 msgstr "Fonctionnalités expérimentales"
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Prix total"
 
@@ -3735,8 +3761,9 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Facture"
 
@@ -3762,7 +3789,8 @@ msgstr "Date de création de facture manquante!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
@@ -4335,6 +4363,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Mémo"
 
@@ -4461,6 +4490,10 @@ msgstr "Nom"
 msgid "Name:"
 msgstr "Nom:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valeur comptable nette"
@@ -4480,6 +4513,10 @@ msgstr "Nouveau rapport d'actif"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Rapport de recherche des nouveaux actifs"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4728,14 +4765,17 @@ msgstr "Numéros de modèle nuls"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numéro"
 
@@ -4784,6 +4824,10 @@ msgstr "Octobre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4851,10 +4895,12 @@ msgstr "Commande"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Commande #"
 
@@ -4863,7 +4909,8 @@ msgid "Order By"
 msgstr "Commandé par"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
@@ -5455,9 +5502,10 @@ msgid "Prefix"
 msgstr "Préfixe"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Prix"
 
@@ -5668,8 +5716,9 @@ msgstr "Acheté"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Qté"
 
@@ -5689,10 +5738,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Devis"
 
@@ -5787,6 +5836,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Reconstruire/Mettre à jour?"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5802,8 +5852,8 @@ msgstr "Date de réception"
 msgid "Receipt Results"
 msgstr "Résultats de réception"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Reçus"
 
@@ -6168,10 +6218,10 @@ msgstr "Numéro facture de vente/écriture recette"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Commande de vente"
 
@@ -6685,7 +6735,8 @@ msgid "Seventy"
 msgstr "Septante"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Expédier"
@@ -6725,11 +6776,11 @@ msgid "Ship to"
 msgstr "Expédier à"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6846,8 +6897,10 @@ msgstr "Certains"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Source"
 
@@ -6987,6 +7040,10 @@ msgstr "Stock"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Stock de produits"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7815,6 +7872,7 @@ msgstr "Numéros uniques de pièces non obsolètes"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unité"
 
@@ -8125,6 +8183,10 @@ msgstr "Fournisseur absent du fichier!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "Fournisseur/Client"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/fr_CA.po
+++ b/locale/po/fr_CA.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: ylavoie <ylavoie@yveslavoie.com>, 2016,2020\n"
 "Language-Team: French (Canada) (http://app.transifex.com/ledgersmb/ledgersmb/"
@@ -123,7 +123,8 @@ msgstr "Compte AP disponible lorsque les fournisseurs sont définis"
 msgid "AP transaction"
 msgstr "Écriture dépenses"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -146,9 +147,10 @@ msgstr "Factures"
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
@@ -377,7 +379,7 @@ msgstr "Ajouter un budget"
 msgid "Add Business"
 msgstr "Ajouter type d'affaire"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Ajouter une classe"
 
@@ -535,6 +537,10 @@ msgstr "Ajouter un retour fournisseur"
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Ajouter/Modifier des déductions"
@@ -669,10 +675,10 @@ msgstr "Autoriser la saisie"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -741,6 +747,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1600,10 +1610,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contact"
 
@@ -1870,6 +1884,7 @@ msgstr "Dev."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Devise"
 
@@ -1902,8 +1917,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Client"
@@ -1916,7 +1932,7 @@ msgstr "Compte client"
 msgid "Customer History"
 msgstr "Historique client"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "Facture client"
 
@@ -2051,13 +2067,16 @@ msgstr "La base de données existe."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Date"
 
@@ -2297,6 +2316,7 @@ msgid "Deleting..."
 msgstr "Suprimer..."
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Livraison"
 
@@ -2429,13 +2449,16 @@ msgstr "Début d'amortissement"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Description"
 
@@ -2469,7 +2492,7 @@ msgstr "Rabais"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Rabais %"
 
@@ -2573,6 +2596,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Exigible"
 
@@ -2904,7 +2928,8 @@ msgid "Entered at: [_1]"
 msgstr "Entré à : [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Entité"
 
@@ -3044,6 +3069,7 @@ msgid "Experimental features"
 msgstr "Fonctionnalités expérimentales"
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Prix total"
 
@@ -3737,8 +3763,9 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Facture"
 
@@ -3764,7 +3791,8 @@ msgstr "Date de création de facture manquante!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
@@ -4337,6 +4365,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Mémo"
 
@@ -4463,6 +4492,10 @@ msgstr "Nom"
 msgid "Name:"
 msgstr "Nom:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valeur comptable nette"
@@ -4482,6 +4515,10 @@ msgstr "Nouveau rapport d'actif"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Rapport de recherche des nouveaux actifs"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4730,14 +4767,17 @@ msgstr "Numéros de modèle nuls"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numéro"
 
@@ -4786,6 +4826,10 @@ msgstr "Octobre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4853,10 +4897,12 @@ msgstr "Commande"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Commande #"
 
@@ -4865,7 +4911,8 @@ msgid "Order By"
 msgstr "Commandé par"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
@@ -5458,9 +5505,10 @@ msgid "Prefix"
 msgstr "Préfixe"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Prix"
 
@@ -5671,8 +5719,9 @@ msgstr "Acheté"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Qté"
 
@@ -5692,10 +5741,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Devis"
 
@@ -5790,6 +5839,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Reconstruire/Mettre à jour?"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5805,8 +5855,8 @@ msgstr "Date de réception"
 msgid "Receipt Results"
 msgstr "Résultats de réception"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Reçus"
 
@@ -6171,10 +6221,10 @@ msgstr "Numéro facture de vente/écriture recette"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Commande de vente"
 
@@ -6688,7 +6738,8 @@ msgid "Seventy"
 msgstr "Soixante-dix"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Expédier"
@@ -6728,11 +6779,11 @@ msgid "Ship to"
 msgstr "Expédier à"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6849,8 +6900,10 @@ msgstr "Certains"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Source"
 
@@ -6990,6 +7043,10 @@ msgstr "Stock"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Stock de produits"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7818,6 +7875,7 @@ msgstr "Numéros uniques de pièces non obsolètes"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unité"
 
@@ -8128,6 +8186,10 @@ msgstr "Fournisseur absent du fichier!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "Fournisseur/Client"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/fr_FR.po
+++ b/locale/po/fr_FR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: French (France) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/fr_FR/)\n"
@@ -120,7 +120,8 @@ msgstr "Compte AP disponible lorsque les fournisseurs sont définis"
 msgid "AP transaction"
 msgstr "Écriture dépenses"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -143,9 +144,10 @@ msgstr "Factures"
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
@@ -374,7 +376,7 @@ msgstr "Ajouter un budget"
 msgid "Add Business"
 msgstr "Ajouter type d'affaire"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Ajouter une classe"
 
@@ -532,6 +534,10 @@ msgstr "Ajouter un retour fournisseur"
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Ajouter/Modifier des déductions"
@@ -666,10 +672,10 @@ msgstr "Autoriser la saisie"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -738,6 +744,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1598,10 +1608,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contact"
 
@@ -1868,6 +1882,7 @@ msgstr "Dev."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Devise"
 
@@ -1900,8 +1915,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Client"
@@ -1914,7 +1930,7 @@ msgstr "Compte client"
 msgid "Customer History"
 msgstr "Historique client"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "Facture client"
 
@@ -2049,13 +2065,16 @@ msgstr "La base de données existe."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Date"
 
@@ -2295,6 +2314,7 @@ msgid "Deleting..."
 msgstr "Suprimer..."
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Livraison"
 
@@ -2427,13 +2447,16 @@ msgstr "Début d'amortissement"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Description"
 
@@ -2467,7 +2490,7 @@ msgstr "Rabais"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Rabais %"
 
@@ -2571,6 +2594,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Exigible"
 
@@ -2902,7 +2926,8 @@ msgid "Entered at: [_1]"
 msgstr "Entré à : [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Entité"
 
@@ -3042,6 +3067,7 @@ msgid "Experimental features"
 msgstr "Fonctionnalités expérimentales"
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Prix total"
 
@@ -3735,8 +3761,9 @@ msgstr "Inventaire transféré!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Facture"
 
@@ -3762,7 +3789,8 @@ msgstr "Date de création de facture manquante!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
@@ -4335,6 +4363,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Mémo"
 
@@ -4461,6 +4490,10 @@ msgstr "Nom"
 msgid "Name:"
 msgstr "Nom:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Valeur comptable nette"
@@ -4480,6 +4513,10 @@ msgstr "Nouveau rapport d'actif"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Rapport de recherche des nouveaux actifs"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4728,14 +4765,17 @@ msgstr "Numéros de modèle nuls"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numéro"
 
@@ -4784,6 +4824,10 @@ msgstr "Octobre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4851,10 +4895,12 @@ msgstr "Commande"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Commande #"
 
@@ -4863,7 +4909,8 @@ msgid "Order By"
 msgstr "Commandé par"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Date de commande"
 
@@ -5455,9 +5502,10 @@ msgid "Prefix"
 msgstr "Préfixe"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Prix"
 
@@ -5668,8 +5716,9 @@ msgstr "Acheté"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Qté"
 
@@ -5689,10 +5738,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Devis"
 
@@ -5787,6 +5836,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Reconstruire/Mettre à jour?"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Reçu"
 
@@ -5802,8 +5852,8 @@ msgstr "Date de réception"
 msgid "Receipt Results"
 msgstr "Résultats de réception"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Reçus"
 
@@ -6168,10 +6218,10 @@ msgstr "Numéro facture de vente/écriture recette"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Commande de vente"
 
@@ -6685,7 +6735,8 @@ msgid "Seventy"
 msgstr "Soixante-dix"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Expédier"
@@ -6725,11 +6776,11 @@ msgid "Ship to"
 msgstr "Expédier à"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6846,8 +6897,10 @@ msgstr "Certains"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Source"
 
@@ -6987,6 +7040,10 @@ msgstr "Stock"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Stock de produits"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7815,6 +7872,7 @@ msgstr "Numéros uniques de pièces non obsolètes"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unité"
 
@@ -8125,6 +8183,10 @@ msgstr "Fournisseur absent du fichier!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "Fournisseur/Client"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/he.po
+++ b/locale/po/he.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Amir Inbar <amir@srvit.co.il>, 2022\n"
 "Language-Team: Hebrew (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -119,7 +119,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -142,9 +143,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -373,7 +375,7 @@ msgstr "הוספת תקציב"
 msgid "Add Business"
 msgstr "הוספת עסק"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "הוספת מחלקה"
 
@@ -531,6 +533,10 @@ msgstr "הוספת החזרה לספק"
 msgid "Add Warehouse"
 msgstr "הוספת מחסן"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -665,10 +671,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -738,6 +744,10 @@ msgstr ""
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "כל"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1593,10 +1603,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "איש קשר"
 
@@ -1859,6 +1873,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "שער חליפין"
 
@@ -1891,8 +1906,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "לקוח"
@@ -1905,7 +1921,7 @@ msgstr "חשבון לקוח"
 msgid "Customer History"
 msgstr "היסטוריית לקוח"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "חשבונית לקוח"
 
@@ -2040,13 +2056,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "תאריך"
 
@@ -2286,6 +2305,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "משלוח"
 
@@ -2418,13 +2438,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "תיאור"
 
@@ -2458,7 +2481,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2562,6 +2585,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2891,7 +2915,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "ישות"
 
@@ -3029,6 +3054,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "מורחב"
 
@@ -3711,8 +3737,9 @@ msgstr "מלאי הועבר!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "חשבונית"
 
@@ -3738,7 +3765,8 @@ msgstr "חסר תאריך יצירת החשבונית!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "תאריך חשבונית"
 
@@ -4290,6 +4318,7 @@ msgstr "מאי"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "פתקית"
 
@@ -4414,6 +4443,10 @@ msgstr "שם"
 msgid "Name:"
 msgstr "שם:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4432,6 +4465,10 @@ msgstr "דוח נכס חדש"
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4676,14 +4713,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "מספר"
 
@@ -4732,6 +4772,10 @@ msgstr "אוקטובר"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4799,10 +4843,12 @@ msgstr "סדר"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "סדר #"
 
@@ -4811,7 +4857,8 @@ msgid "Order By"
 msgstr "הזמנה על ידי"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "תאריך הזמנה"
 
@@ -5393,9 +5440,10 @@ msgid "Prefix"
 msgstr "קידומת"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "מחיר"
 
@@ -5606,8 +5654,9 @@ msgstr "נרכש"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "כמו"
 
@@ -5627,10 +5676,10 @@ msgstr "רבעון"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "הצעת מחיר"
 
@@ -5725,6 +5774,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5740,8 +5790,8 @@ msgstr "תאריך קבלה"
 msgid "Receipt Results"
 msgstr "תוצאות קבלה"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "קבלות"
 
@@ -6106,10 +6156,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "הזמנת מכירה"
 
@@ -6622,7 +6672,8 @@ msgid "Seventy"
 msgstr "שבעים"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "משלוח"
@@ -6662,11 +6713,11 @@ msgid "Ship to"
 msgstr "משלוח אל"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6783,8 +6834,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "מקור"
 
@@ -6917,6 +6970,10 @@ msgstr "מלאי"
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7733,6 +7790,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "יחידה"
 
@@ -8041,6 +8099,10 @@ msgstr "ספק לא בקובץ!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "ספק/לקוח"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/hu.po
+++ b/locale/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Hungarian (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/hu/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr "Vevőszámlák"
 msgid "AR Outstanding"
 msgstr "Kifizetetlen vevőszámlák"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Vevő tranzakció"
 
@@ -370,7 +372,7 @@ msgstr "Új költségvetés"
 msgid "Add Business"
 msgstr "Új partnercsoport"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Új osztály"
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Új raktár"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr "Felülírható"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Bármelyik"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kapcsolat"
 
@@ -1856,6 +1870,7 @@ msgstr "Pénznem"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Pénznem"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Vevő"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Vevő történet"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Dátum"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Szállítás"
 
@@ -2415,13 +2435,16 @@ msgstr "Értékcsökkenés kezdete"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Leírás"
 
@@ -2455,7 +2478,7 @@ msgstr "Árk"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Kedv.%"
 
@@ -2559,6 +2582,7 @@ msgstr "Legördülők"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Esedékes"
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Egyed"
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Összeg"
 
@@ -3712,8 +3738,9 @@ msgstr "Készlet áthelyezve!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Számla"
 
@@ -3739,7 +3766,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Teljesítés dátuma"
 
@@ -4291,6 +4319,7 @@ msgstr "Máj."
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Megjegyzés"
 
@@ -4415,6 +4444,10 @@ msgstr "Név"
 msgid "Name:"
 msgstr "Név:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Nettó könyv szerinti érték"
@@ -4434,6 +4467,10 @@ msgstr "Új tárgyieszköz jelentés"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Új tárgyieszköz riport keresés"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4679,14 +4716,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Azonosító"
 
@@ -4736,6 +4776,10 @@ msgstr "Október"
 #: old/bin/is.pl:810
 msgid "Off Hold"
 msgstr "Elenged"
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
+msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:227
@@ -4802,10 +4846,12 @@ msgstr "Sorrend"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Rendelés #"
 
@@ -4814,7 +4860,8 @@ msgid "Order By"
 msgstr "Rendezés"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Rendelés dátuma"
 
@@ -5398,9 +5445,10 @@ msgid "Prefix"
 msgstr "Előtag"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Ár"
 
@@ -5611,8 +5659,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Menny."
 
@@ -5632,10 +5681,10 @@ msgstr "Negyedév"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Ajánlatadás"
 
@@ -5730,6 +5779,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Érkezett"
 
@@ -5745,8 +5795,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Befizetések"
 
@@ -6111,10 +6161,10 @@ msgstr "Vevőszámla/tranzakció azonosító"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Vevőrendelés"
 
@@ -6627,7 +6677,8 @@ msgid "Seventy"
 msgstr "hetven"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Kiszállítás"
@@ -6667,11 +6718,11 @@ msgid "Ship to"
 msgstr "Szállítási cím"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6788,8 +6839,10 @@ msgstr "Néhány"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Bizonylatszám"
 
@@ -6923,6 +6976,10 @@ msgstr "Készletre vesz"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Saját termék bevét"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7739,6 +7796,7 @@ msgstr "Egyedi élő cikkszám"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Egység"
 
@@ -8046,6 +8104,10 @@ msgstr "A szállító nincs az adatbázisban!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/id.po
+++ b/locale/po/id.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Indonesian (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/id/)\n"
@@ -119,7 +119,8 @@ msgstr "Akun AP tersedia saat vendor ditentukan"
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -142,9 +143,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Piutang Belum Lunas"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transaksi Piutang"
 
@@ -373,7 +375,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Tambah Jenis Bisnis"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -531,6 +533,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Tambah Gudang"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -665,10 +671,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -737,6 +743,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1593,10 +1603,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1859,6 +1873,7 @@ msgstr "Mata Uang"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Mata Uang"
 
@@ -1891,8 +1906,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Pelanggan"
@@ -1905,7 +1921,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Historis Pelanggan"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2040,13 +2056,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Tanggal"
 
@@ -2286,6 +2305,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Pengiriman"
 
@@ -2418,13 +2438,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Keterangan"
 
@@ -2458,7 +2481,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2562,6 +2585,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2891,7 +2915,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3029,6 +3054,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Jumlah"
 
@@ -3711,8 +3737,9 @@ msgstr "Inventory sudah di-transfer"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Invoice"
 
@@ -3738,7 +3765,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Tanggal Invoice"
 
@@ -4290,6 +4318,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4414,6 +4443,10 @@ msgstr "Nama"
 msgid "Name:"
 msgstr "Nama:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4432,6 +4465,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4676,14 +4713,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nomor"
 
@@ -4732,6 +4772,10 @@ msgstr "Oktober"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4799,10 +4843,12 @@ msgstr "No. Pesanan"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4811,7 +4857,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tanggal Pesanan"
 
@@ -5393,9 +5440,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Harga"
 
@@ -5606,8 +5654,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Banyak"
 
@@ -5627,10 +5676,10 @@ msgstr "Kwartal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Quotation"
 
@@ -5725,6 +5774,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Terima"
 
@@ -5740,8 +5790,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Penerimaan"
 
@@ -6106,10 +6156,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Pesanan Penjualan (SO)"
 
@@ -6622,7 +6672,8 @@ msgid "Seventy"
 msgstr "Tujuh puluh"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Kirim"
@@ -6662,11 +6713,11 @@ msgid "Ship to"
 msgstr "Kirim kepada"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6783,8 +6834,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Bukti"
 
@@ -6917,6 +6970,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7733,6 +7790,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Satuan"
 
@@ -8040,6 +8098,10 @@ msgstr "Data Supplier tidak ditemukan!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/is.po
+++ b/locale/po/is.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Icelandic (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/is/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Sölufærsla"
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Talsmaður"
 
@@ -1856,6 +1870,7 @@ msgstr "Gjaldm"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Gjaldmiðill"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Viðskiptavinur"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Dagsetning"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Skýringar"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Framlengt"
 
@@ -3708,8 +3734,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Sölureikningur"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Sölureikningur dags."
 
@@ -4287,6 +4315,7 @@ msgstr "maí"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4411,6 +4440,10 @@ msgstr "Nafn"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Númer"
 
@@ -4729,6 +4769,10 @@ msgstr "óktóber"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "Pöntun"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Pöntunar dags."
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Verð"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Magn"
 
@@ -5624,10 +5673,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Mótt:"
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Kvittanir"
 
@@ -6103,10 +6153,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Sölupöntun"
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Senda"
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr "Senda til"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Frálag"
 
@@ -6915,6 +6968,10 @@ msgstr ""
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Lager samsetning"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Einingar"
 
@@ -8037,6 +8095,10 @@ msgstr "Byrgir ekki til í gagnagrunni!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/it.po
+++ b/locale/po/it.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Ferruccio Zamuner <nonsolosoft@diff.org>, 2016,2023\n"
 "Language-Team: Italian (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -122,7 +122,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -145,9 +146,10 @@ msgstr "Fatture a credito"
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transazione Cliente"
 
@@ -376,7 +378,7 @@ msgstr "Nuovo preventivo"
 msgid "Add Business"
 msgstr "Nuova azienda"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Nuova classe"
 
@@ -534,6 +536,10 @@ msgstr "Nuovo reso a fornitore"
 msgid "Add Warehouse"
 msgstr "Nuovo magazzino"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Aggiungi/Modifica deduzione"
@@ -668,10 +674,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -741,6 +747,10 @@ msgstr ""
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Nessuno"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1596,10 +1606,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contatto"
 
@@ -1862,6 +1876,7 @@ msgstr "Valuta"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1894,8 +1909,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1908,7 +1924,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2043,13 +2059,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Data"
 
@@ -2289,6 +2308,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Consegna"
 
@@ -2421,13 +2441,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descrizione"
 
@@ -2461,7 +2484,7 @@ msgstr "Sconto"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "% sconto"
 
@@ -2565,6 +2588,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Scadenza"
 
@@ -2894,7 +2918,8 @@ msgid "Entered at: [_1]"
 msgstr "Inserito il: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Entità"
 
@@ -3032,6 +3057,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Esteso"
 
@@ -3716,8 +3742,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Fattura"
 
@@ -3743,7 +3770,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Data Registrazione Fattura"
 
@@ -4295,6 +4323,7 @@ msgstr "Mag"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4419,6 +4448,10 @@ msgstr "Nome"
 msgid "Name:"
 msgstr "Nome:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4437,6 +4470,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4681,14 +4718,17 @@ msgstr "Nessun numero modelli"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Partita IVA"
 
@@ -4737,6 +4777,10 @@ msgstr "Ottobre"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4804,10 +4848,12 @@ msgstr "Ordine"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Ordine #"
 
@@ -4816,7 +4862,8 @@ msgid "Order By"
 msgstr "Ordina per"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data dell'ordine"
 
@@ -5398,9 +5445,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Prezzo"
 
@@ -5611,8 +5659,9 @@ msgstr "Comprato"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Q.t&agrave;"
 
@@ -5632,10 +5681,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Offerte"
 
@@ -5730,6 +5779,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Ricevuto"
 
@@ -5745,8 +5795,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Incassi"
 
@@ -6111,10 +6161,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Ordine di vendita"
 
@@ -6627,7 +6677,8 @@ msgid "Seventy"
 msgstr "settanta"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Invio"
@@ -6667,11 +6718,11 @@ msgid "Ship to"
 msgstr "Spedire a"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6788,8 +6839,10 @@ msgstr "Alcuni"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Sorgente"
 
@@ -6923,6 +6976,10 @@ msgstr ""
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Magazzino Assemblati"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7738,6 +7795,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unit&agrave;"
 
@@ -8045,6 +8103,10 @@ msgstr "Fornitore non in archivio!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/ja.po
+++ b/locale/po/ja.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Japanese (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/ja/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1856,6 +1870,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr ""
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3708,8 +3734,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4287,6 +4315,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4411,6 +4440,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4729,6 +4769,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5624,10 +5673,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6103,10 +6153,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6914,6 +6967,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8037,6 +8095,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/lt.po
+++ b/locale/po/lt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Lithuanian (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/lt/)\n"
@@ -118,7 +118,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -141,9 +142,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Pardavimo Operaciją"
 
@@ -372,7 +374,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -530,6 +532,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -664,10 +670,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -736,6 +742,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1592,10 +1602,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontaktas"
 
@@ -1858,6 +1872,7 @@ msgstr "Val."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valiūta"
 
@@ -1890,8 +1905,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Klientas"
@@ -1904,7 +1920,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2039,13 +2055,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Data"
 
@@ -2285,6 +2304,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2417,13 +2437,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Aprašymas"
 
@@ -2457,7 +2480,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2561,6 +2584,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2890,7 +2914,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3028,6 +3053,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Išplėsta"
 
@@ -3710,8 +3736,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Sąskaita-faktūra"
 
@@ -3737,7 +3764,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Sąskaitos-faktūros data"
 
@@ -4289,6 +4317,7 @@ msgstr "Geg"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4413,6 +4442,10 @@ msgstr "Vardas"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4431,6 +4464,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4675,14 +4712,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numeris"
 
@@ -4731,6 +4771,10 @@ msgstr "Spalis"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4798,10 +4842,12 @@ msgstr "Užsakymas"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4810,7 +4856,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Užsakymo data"
 
@@ -5392,9 +5439,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Kaina"
 
@@ -5605,8 +5653,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Kks"
 
@@ -5626,10 +5675,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5724,6 +5773,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Gaut"
 
@@ -5739,8 +5789,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Kasos orderiai"
 
@@ -6105,10 +6155,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Pardavimų užsakymas"
 
@@ -6621,7 +6671,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Pristatymas"
@@ -6661,11 +6712,11 @@ msgid "Ship to"
 msgstr "Pristatyti į"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6782,8 +6833,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Dokumentas"
 
@@ -6917,6 +6970,10 @@ msgstr ""
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Rinkiniai sandėlyje"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7732,6 +7789,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Vienetas"
 
@@ -8039,6 +8097,10 @@ msgstr "Tokio tiekėjo nėra!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/lv.po
+++ b/locale/po/lv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Latvian (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "lv/)\n"
@@ -117,7 +117,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -140,9 +141,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "DP Neapmaksātie"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "DP transakcija"
 
@@ -371,7 +373,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Pievienot komercdarbību"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -529,6 +531,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Pievienot noliktavu"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -663,10 +669,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1591,10 +1601,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontaktpersona"
 
@@ -1857,6 +1871,7 @@ msgstr "Val."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valūta"
 
@@ -1889,8 +1904,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Klients"
@@ -1903,7 +1919,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Klienta vēsture"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2038,13 +2054,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Datums"
 
@@ -2284,6 +2303,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2416,13 +2436,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Apraksts"
 
@@ -2456,7 +2479,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2560,6 +2583,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2889,7 +2913,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3027,6 +3052,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Kopā"
 
@@ -3709,8 +3735,9 @@ msgstr "Krājums pārsūtīts"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Rēķins"
 
@@ -3736,7 +3763,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Rēķina datums"
 
@@ -4288,6 +4316,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memorands"
 
@@ -4412,6 +4441,10 @@ msgstr "Nosaukums"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4430,6 +4463,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4674,14 +4711,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numurs"
 
@@ -4730,6 +4770,10 @@ msgstr "Oktobrī"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4797,10 +4841,12 @@ msgstr "Orderis"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4809,7 +4855,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ordera datums"
 
@@ -5391,9 +5438,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Cena"
 
@@ -5604,8 +5652,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Skaits"
 
@@ -5625,10 +5674,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Tāme"
 
@@ -5723,6 +5772,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Saņemts"
 
@@ -5738,8 +5788,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Kvītis"
 
@@ -6104,10 +6154,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Pārdošanas orderis"
 
@@ -6620,7 +6670,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Piegādāt"
@@ -6660,11 +6711,11 @@ msgid "Ship to"
 msgstr "Piegādes adrese"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6781,8 +6832,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Dokuments"
 
@@ -6916,6 +6969,10 @@ msgstr "Krājums"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Komplektācijas krājumā"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7731,6 +7788,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Vienība"
 
@@ -8038,6 +8096,10 @@ msgstr "Nav tāda pārdevēja!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/ms_MY.po
+++ b/locale/po/ms_MY.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Malay (Malaysia) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/ms_MY/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "AR Memberangsangkan"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transaksi AR"
 
@@ -370,7 +372,7 @@ msgstr "Tambah bajet"
 msgid "Add Business"
 msgstr "Tambah Bisnes"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Tambah kelas"
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Tambah Gudang"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -735,6 +741,10 @@ msgstr ""
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Selain"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1592,10 +1602,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Hubungan"
 
@@ -1858,6 +1872,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Mata Wang"
 
@@ -1890,8 +1905,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Pelanggan"
@@ -1904,7 +1920,7 @@ msgstr "Akaun Pelanggan"
 msgid "Customer History"
 msgstr "Rekod Pelanggan"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2039,13 +2055,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Tarikh"
 
@@ -2285,6 +2304,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2417,13 +2437,16 @@ msgstr "Permulaan Susut Nilai"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Penerangan"
 
@@ -2457,7 +2480,7 @@ msgstr "Disk"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2561,6 +2584,7 @@ msgstr "Gugurkan"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Tarikh Akhir"
 
@@ -2890,7 +2914,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Entiti"
 
@@ -3028,6 +3053,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Dilanjutkan"
 
@@ -3710,8 +3736,9 @@ msgstr "Inventori di hantar"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Invois"
 
@@ -3737,7 +3764,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Tarikh Invois"
 
@@ -4289,6 +4317,7 @@ msgstr "Mei"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4413,6 +4442,10 @@ msgstr "Nama"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Nilai buku bersih"
@@ -4431,6 +4464,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4677,14 +4714,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nombor"
 
@@ -4734,6 +4774,10 @@ msgstr "Oktober"
 #: old/bin/is.pl:810
 msgid "Off Hold"
 msgstr "Teruskan"
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
+msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:227
@@ -4800,10 +4844,12 @@ msgstr "Pesanan"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4812,7 +4858,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Tarikh Pesanan"
 
@@ -5395,9 +5442,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Harga"
 
@@ -5608,8 +5656,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Kuantiti"
 
@@ -5629,10 +5678,10 @@ msgstr "Suku"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Sebut Harga"
 
@@ -5727,6 +5776,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Menbina semula/menaik taraf"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Terima"
 
@@ -5742,8 +5792,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr "Hasil Resit"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Resit"
 
@@ -6108,10 +6158,10 @@ msgstr "jualan invois/nombor urus niaga AR"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Pesanan Jualan"
 
@@ -6624,7 +6674,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Hantar"
@@ -6664,11 +6715,11 @@ msgid "Ship to"
 msgstr "Hantar kepada"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6785,8 +6836,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Sumber"
 
@@ -6920,6 +6973,10 @@ msgstr "Stok"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Himpunan Stok "
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7735,6 +7792,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unit"
 
@@ -8042,6 +8100,10 @@ msgstr "Pembekal tiada dalam fail!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/nb.po
+++ b/locale/po/nb.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Stig Berg <stig@tmb.no>, 2016\n"
 "Language-Team: Norwegian Bokmål (http://app.transifex.com/ledgersmb/ledgersmb/"
@@ -125,7 +125,8 @@ msgstr "Leverandørkonto er tilgjengelig når leverandører er valgt"
 msgid "AP transaction"
 msgstr "Leverandører postering"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -148,9 +149,10 @@ msgstr "Utgående Fakturaer"
 msgid "AR Outstanding"
 msgstr "Utestående fordringer Kunder"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Kunde Postering"
 
@@ -379,7 +381,7 @@ msgstr "Nytt budsjett"
 msgid "Add Business"
 msgstr "Nytt Firma"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Ny klasse"
 
@@ -537,6 +539,10 @@ msgstr "Ny leverandør retur"
 msgid "Add Warehouse"
 msgstr "Nytt lager"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Ny/Forandre Fradrag"
@@ -671,10 +677,10 @@ msgstr "Tillat Innlegg"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -744,6 +750,10 @@ msgstr "Årlig rett linje Månedlig"
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Noen"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1599,10 +1609,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1868,6 +1882,7 @@ msgstr "Val"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1900,8 +1915,9 @@ msgstr "Tilpassede flagg"
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Kunde"
@@ -1914,7 +1930,7 @@ msgstr "Kundekonto"
 msgid "Customer History"
 msgstr "Kundehistorikk"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr "Kunde faktura"
 
@@ -2049,13 +2065,16 @@ msgstr "Databasen eksisterer."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Dato"
 
@@ -2295,6 +2314,7 @@ msgid "Deleting..."
 msgstr "Sletter..."
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Levering"
 
@@ -2427,13 +2447,16 @@ msgstr "Avskrivnings Start"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -2467,7 +2490,7 @@ msgstr "Rab"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Rab %"
 
@@ -2571,6 +2594,7 @@ msgstr "Dropdowns"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Forfall"
 
@@ -2902,7 +2926,8 @@ msgid "Entered at: [_1]"
 msgstr "Lagt inn ved: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Eksisterende"
 
@@ -3040,6 +3065,7 @@ msgid "Experimental features"
 msgstr "Eksperimentelle funksjoner"
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Sum"
 
@@ -3726,8 +3752,9 @@ msgstr "Varebeholdning overført"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Faktura"
 
@@ -3753,7 +3780,8 @@ msgstr "Faktura Opprettet Dato mangler!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fakturadato"
 
@@ -4310,6 +4338,7 @@ msgstr "mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Notat"
 
@@ -4434,6 +4463,10 @@ msgstr "Navn"
 msgid "Name:"
 msgstr "Navn:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Netto bokført verdi"
@@ -4453,6 +4486,10 @@ msgstr "Ny Eiendel rapport"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Søk etter Ny Eiendel rapport"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4696,14 +4733,17 @@ msgstr "Null modell nummer"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nummer"
 
@@ -4753,6 +4793,10 @@ msgstr "oktober"
 #: old/bin/is.pl:810
 msgid "Off Hold"
 msgstr "Av vent"
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
+msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:227
@@ -4819,10 +4863,12 @@ msgstr "Ordre"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Ordre #"
 
@@ -4831,7 +4877,8 @@ msgid "Order By"
 msgstr "Ordre av"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Ordredato"
 
@@ -5419,9 +5466,10 @@ msgid "Prefix"
 msgstr "Prefix"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Pris"
 
@@ -5632,8 +5680,9 @@ msgstr "Kjøpt"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Antall"
 
@@ -5653,10 +5702,10 @@ msgstr "Kvartal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Tilbud"
 
@@ -5751,6 +5800,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Rebygg/Oppgrader?"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Mottatt"
 
@@ -5766,8 +5816,8 @@ msgstr "Kvitterinsdato"
 msgid "Receipt Results"
 msgstr "Kviteringsresultat"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Kvitteringer"
 
@@ -6132,10 +6182,10 @@ msgstr "Utgående Faktura Posterings nummer"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Salgsordre"
 
@@ -6648,7 +6698,8 @@ msgid "Seventy"
 msgstr "Sytti"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Send"
@@ -6688,11 +6739,11 @@ msgid "Ship to"
 msgstr "Send til"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6809,8 +6860,10 @@ msgstr "Noen"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Bilag"
 
@@ -6944,6 +6997,10 @@ msgstr "Lager"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Lagermontering"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7770,6 +7827,7 @@ msgstr "Unike ikke foreldete varenummer"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Enhet"
 
@@ -8080,6 +8138,10 @@ msgstr "Leverandør mangler i database!"
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
 msgstr "Leverandør/Kunde"
+
+#: UI/users/preferences.html:15
+msgid "Verify"
+msgstr ""
 
 #: UI/setup/confirm_operation.html:122
 msgid "View schema patch log"

--- a/locale/po/nl.po
+++ b/locale/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Jos <j.verdoold@gmail.com>, 2016\n"
 "Language-Team: Dutch (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -124,7 +124,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -147,9 +148,10 @@ msgstr "Verkoopfacturen"
 msgid "AR Outstanding"
 msgstr "Openstaande Debiteuren"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Debiteurenboeking"
 
@@ -378,7 +380,7 @@ msgstr "Budget Toevoegen"
 msgid "Add Business"
 msgstr "Bedrijfsactiviteit Toevoegen"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Soort Toevoegen"
 
@@ -536,6 +538,10 @@ msgstr "Inkoopretour Toevoegen"
 msgid "Add Warehouse"
 msgstr "Magazijn Toevoegen"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Aftrekposten aanpassen/toevoegen"
@@ -670,10 +676,10 @@ msgstr "Invoer toestaan"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -743,6 +749,10 @@ msgstr "Lineaire afschrijving, per maand"
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Elk(e)"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1600,10 +1610,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contact"
 
@@ -1866,6 +1880,7 @@ msgstr "Val."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1898,8 +1913,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Klant"
@@ -1912,7 +1928,7 @@ msgstr "Klant Rekening"
 msgid "Customer History"
 msgstr "Klanthistorie"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2047,13 +2063,16 @@ msgstr "Database bestaat al."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Datum"
 
@@ -2293,6 +2312,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Bezorging"
 
@@ -2425,13 +2445,16 @@ msgstr "Afschrijving begint"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Omschrijving"
 
@@ -2465,7 +2488,7 @@ msgstr "Korting"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Kort. %"
 
@@ -2569,6 +2592,7 @@ msgstr "Selectielijsten"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Verschuldigd op"
 
@@ -2900,7 +2924,8 @@ msgid "Entered at: [_1]"
 msgstr "Ingevoerd op: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Bedrijfseenheid"
 
@@ -3038,6 +3063,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Totaal"
 
@@ -3724,8 +3750,9 @@ msgstr "Voorraad overgeheveld!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factuur"
 
@@ -3751,7 +3778,8 @@ msgstr "Factuur aanmaakdatum mist!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Factuurdatum"
 
@@ -4310,6 +4338,7 @@ msgstr "mei"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4436,6 +4465,10 @@ msgstr "Naam"
 msgid "Name:"
 msgstr "Naam:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Netto Boekingswaarde"
@@ -4455,6 +4488,10 @@ msgstr "Nieuw Activa Rapport"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Nieuw Activa Rapport Zoeken"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4702,14 +4739,17 @@ msgstr "NULL modelnummers"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nummer"
 
@@ -4759,6 +4799,10 @@ msgstr "oktober"
 #: old/bin/is.pl:810
 msgid "Off Hold"
 msgstr "Uit de wacht"
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
+msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:227
@@ -4825,10 +4869,12 @@ msgstr "Bestelling"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Order #"
 
@@ -4837,7 +4883,8 @@ msgid "Order By"
 msgstr "Order door"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Orderdatum"
 
@@ -5428,9 +5475,10 @@ msgid "Prefix"
 msgstr "Voorvoegsel"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Prijs"
 
@@ -5641,8 +5689,9 @@ msgstr "Gekocht"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Aantal"
 
@@ -5662,10 +5711,10 @@ msgstr "Kwartaal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Offerte"
 
@@ -5760,6 +5809,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Herbouwen/upgraden?"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Ontvangen"
 
@@ -5775,8 +5825,8 @@ msgstr "Ontvangstdatum"
 msgid "Receipt Results"
 msgstr "Ontvangstresultaat"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Ontvangstbewijzen"
 
@@ -6141,10 +6191,10 @@ msgstr "Verkoopfactuur/Transactienummer Debiteuren"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Verkooporder"
 
@@ -6657,7 +6707,8 @@ msgid "Seventy"
 msgstr "Zeventig"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Verzenden"
@@ -6697,11 +6748,11 @@ msgid "Ship to"
 msgstr "Verzenden aan"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6818,8 +6869,10 @@ msgstr "Sommige"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Herkomst"
 
@@ -6954,6 +7007,10 @@ msgstr "Voorraad"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Assemblagevoorraad"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7771,6 +7828,7 @@ msgstr "Unieke geldige artikelnummers"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Eenheid"
 
@@ -8080,6 +8138,10 @@ msgstr "Leverancier bestaat niet!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/nl_BE.po
+++ b/locale/po/nl_BE.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Dutch (Belgium) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/nl_BE/)\n"
@@ -120,7 +120,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -143,9 +144,10 @@ msgstr "Verkoopfacturen"
 msgid "AR Outstanding"
 msgstr "Openstaande Debiteuren"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Debiteurenboeking"
 
@@ -374,7 +376,7 @@ msgstr "Budget Toevoegen"
 msgid "Add Business"
 msgstr "Zaaktype toevoegen"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Soort Toevoegen"
 
@@ -532,6 +534,10 @@ msgstr "Inkoopretour Toevoegen"
 msgid "Add Warehouse"
 msgstr "Magazijn toevoegen"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Aftrekposten aanpassen/toevoegen"
@@ -666,10 +672,10 @@ msgstr "Invoer toestaan"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -739,6 +745,10 @@ msgstr "Lineaire afschrijving, per maand"
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Elk(e)"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1596,10 +1606,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contact"
 
@@ -1862,6 +1876,7 @@ msgstr "Val."
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1894,8 +1909,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Klant"
@@ -1908,7 +1924,7 @@ msgstr "Klant Rekening"
 msgid "Customer History"
 msgstr "Klant Historie"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2043,13 +2059,16 @@ msgstr "Database bestaat al."
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Datum"
 
@@ -2289,6 +2308,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr "Bezorging"
 
@@ -2421,13 +2441,16 @@ msgstr "Afschrijving begint"
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Omschrijving"
 
@@ -2461,7 +2484,7 @@ msgstr "Korting"
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr "Kort. %"
 
@@ -2565,6 +2588,7 @@ msgstr "Selectielijsten"
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr "Verschuldigd op"
 
@@ -2896,7 +2920,8 @@ msgid "Entered at: [_1]"
 msgstr "Ingevoerd op: [_1]"
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr "Bedrijfseenheid"
 
@@ -3034,6 +3059,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Uitgebreid"
 
@@ -3720,8 +3746,9 @@ msgstr "Voorraad overgeheveld"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factuur"
 
@@ -3747,7 +3774,8 @@ msgstr "Factuur aanmaakdatum mist!"
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Factuurdatum"
 
@@ -4306,6 +4334,7 @@ msgstr "Mei"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memo"
 
@@ -4432,6 +4461,10 @@ msgstr "Naam"
 msgid "Name:"
 msgstr "Naam:"
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr "Netto boekingswaarde"
@@ -4451,6 +4484,10 @@ msgstr "Nieuw activarapport"
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
 msgstr "Nieuw activarapport zoeken"
+
+#: UI/users/preferences.html:15
+msgid "New Password"
+msgstr ""
 
 #: UI/reconciliation/new_report.html:8
 msgid "New Reconciliation Report"
@@ -4698,14 +4735,17 @@ msgstr "NULL modelnummers"
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nummer"
 
@@ -4755,6 +4795,10 @@ msgstr "Oktober"
 #: old/bin/is.pl:810
 msgid "Off Hold"
 msgstr "Uit de wacht"
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
+msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
 #: lib/LedgerSMB/Report/Inventory/Search.pm:227
@@ -4821,10 +4865,12 @@ msgstr "Bestelling"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr "Order #"
 
@@ -4833,7 +4879,8 @@ msgid "Order By"
 msgstr "Order door"
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Orderdatum"
 
@@ -5424,9 +5471,10 @@ msgid "Prefix"
 msgstr "Voorvoegsel"
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Prijs"
 
@@ -5637,8 +5685,9 @@ msgstr "Gekocht"
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Aantal"
 
@@ -5658,10 +5707,10 @@ msgstr "Kwartaal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Offerte"
 
@@ -5756,6 +5805,7 @@ msgid "Rebuild/Upgrade?"
 msgstr "Herbouwen/upgraden?"
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Ontvangen"
 
@@ -5771,8 +5821,8 @@ msgstr "Ontvangstdatum"
 msgid "Receipt Results"
 msgstr "Ontvangstresultaat"
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Ontvangstbewijzen"
 
@@ -6137,10 +6187,10 @@ msgstr "Verkoopfactuur/Transactienummer Debiteuren"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Verkooporder"
 
@@ -6653,7 +6703,8 @@ msgid "Seventy"
 msgstr "zeventig"
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Verzenden"
@@ -6693,11 +6744,11 @@ msgid "Ship to"
 msgstr "Verzenden aan"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6814,8 +6865,10 @@ msgstr "Sommige"
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Herkomst"
 
@@ -6950,6 +7003,10 @@ msgstr "Voorraad"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Assemblage voorraad"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7767,6 +7824,7 @@ msgstr "Unieke geldige artikelnummers"
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Eenheid"
 
@@ -8076,6 +8134,10 @@ msgstr "Leverancier bestaat niet!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/pl.po
+++ b/locale/po/pl.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Polish (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "pl/)\n"
@@ -118,7 +118,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -141,9 +142,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Należności Nieuregulowane"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transakcja Należności"
 
@@ -372,7 +374,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Dodaj Działalność"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -530,6 +532,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Dodaj Magazyn"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -664,10 +670,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -736,6 +742,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1592,10 +1602,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1858,6 +1872,7 @@ msgstr "Waluta"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Waluta"
 
@@ -1890,8 +1905,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Odbiorca"
@@ -1904,7 +1920,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Statystyka Sprzedaży"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2039,13 +2055,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Data"
 
@@ -2285,6 +2304,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2417,13 +2437,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Opis"
 
@@ -2457,7 +2480,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2561,6 +2584,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2890,7 +2914,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3028,6 +3053,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Wartość Netto"
 
@@ -3712,8 +3738,9 @@ msgstr "Inwentarz przeniesiony!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Faktura"
 
@@ -3739,7 +3766,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Data Wystawienia"
 
@@ -4291,6 +4319,7 @@ msgstr "Maj"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Notatka"
 
@@ -4415,6 +4444,10 @@ msgstr "Nazwa"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4433,6 +4466,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4677,14 +4714,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numer Katalogu"
 
@@ -4733,6 +4773,10 @@ msgstr "Pażdziernik"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4800,10 +4844,12 @@ msgstr "Zlecenie"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4812,7 +4858,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data Zlecenia"
 
@@ -5394,9 +5441,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Cena Netto"
 
@@ -5607,8 +5655,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Ilość"
 
@@ -5628,10 +5677,10 @@ msgstr "Kwartał"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Oferta"
 
@@ -5726,6 +5775,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Otrzymano"
 
@@ -5741,8 +5791,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Wpłaty"
 
@@ -6107,10 +6157,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Zlecenie Sprzedaży"
 
@@ -6623,7 +6673,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Wysyłka"
@@ -6663,11 +6714,11 @@ msgid "Ship to"
 msgstr "Wyślij do"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6784,8 +6835,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Żródło"
 
@@ -6919,6 +6972,10 @@ msgstr "Zapas"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Wstaw Zestaw"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7734,6 +7791,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Jednostka"
 
@@ -8041,6 +8099,10 @@ msgstr "Brak Dostawcy w bazie danych"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/pt.po
+++ b/locale/po/pt.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Portuguese (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/pt/)\n"
@@ -120,7 +120,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -143,9 +144,10 @@ msgstr "Faturas a receber"
 msgid "AR Outstanding"
 msgstr "Contas a Receber Pendentes"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transacção Clientes"
 
@@ -374,7 +376,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Adicionar Atividade Comercial"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Adicionar Classe"
 
@@ -532,6 +534,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Adicionar Almoxarifado"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -666,10 +672,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -738,6 +744,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1596,10 +1606,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contacto"
 
@@ -1862,6 +1876,7 @@ msgstr "Moeda"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moeda"
 
@@ -1894,8 +1909,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1908,7 +1924,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Histórico do Cliente"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2043,13 +2059,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Data"
 
@@ -2289,6 +2308,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2421,13 +2441,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descrição"
 
@@ -2461,7 +2484,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2565,6 +2588,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2894,7 +2918,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3032,6 +3057,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendida"
 
@@ -3716,8 +3742,9 @@ msgstr "Inventário transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Factura"
 
@@ -3743,7 +3770,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Data de Factura"
 
@@ -4295,6 +4323,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memorando"
 
@@ -4419,6 +4448,10 @@ msgstr "Nome"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4437,6 +4470,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4681,14 +4718,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4737,6 +4777,10 @@ msgstr "Outubro"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4804,10 +4848,12 @@ msgstr "Encomenda"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4816,7 +4862,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data da Encomenda"
 
@@ -5398,9 +5445,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Preço"
 
@@ -5611,8 +5659,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Qtd"
 
@@ -5632,10 +5681,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotação"
 
@@ -5730,6 +5779,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Recebido"
 
@@ -5745,8 +5795,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibos"
 
@@ -6111,10 +6161,10 @@ msgstr "Fatura de Venda/Númenro da Transação de CR"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Encomenda de Venda"
 
@@ -6627,7 +6677,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Expedir"
@@ -6667,11 +6718,11 @@ msgid "Ship to"
 msgstr "Expedir para"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6788,8 +6839,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Origem"
 
@@ -6923,6 +6976,10 @@ msgstr "Estoque"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Conjunto em stock"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7738,6 +7795,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidade"
 
@@ -8045,6 +8103,10 @@ msgstr "Fornecedor não existe"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/pt_BR.po
+++ b/locale/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Rodrigo Sottomaior Macedo "
 "<sottomaiormacedotec@sottomaiormacedo.tech>, 2016\n"
@@ -123,7 +123,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -146,9 +147,10 @@ msgstr "Faturas a receber"
 msgid "AR Outstanding"
 msgstr "Contas a Receber Pendentes"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Transação - Contas a Receber"
 
@@ -377,7 +379,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Adicionar Atividade Comercial"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Adicionar Classe"
 
@@ -535,6 +537,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Adicionar Almoxarifado"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -669,10 +675,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -741,6 +747,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1599,10 +1609,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Contato"
 
@@ -1865,6 +1879,7 @@ msgstr "Moeda"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Moeda"
 
@@ -1897,8 +1912,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Cliente"
@@ -1911,7 +1927,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Histórico do Cliente"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2046,13 +2062,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Data"
 
@@ -2292,6 +2311,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2424,13 +2444,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Descrição"
 
@@ -2464,7 +2487,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2568,6 +2591,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2897,7 +2921,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3035,6 +3060,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Extendida"
 
@@ -3719,8 +3745,9 @@ msgstr "Inventário transferido!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Fatura"
 
@@ -3746,7 +3773,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Data da Fatura"
 
@@ -4298,6 +4326,7 @@ msgstr "Mai"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Memorando"
 
@@ -4422,6 +4451,10 @@ msgstr "Nome"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4440,6 +4473,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4684,14 +4721,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Número"
 
@@ -4740,6 +4780,10 @@ msgstr "Outubro"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4807,10 +4851,12 @@ msgstr "Pedido"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4819,7 +4865,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Data do Pedido"
 
@@ -5401,9 +5448,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Preço"
 
@@ -5614,8 +5662,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Qtd"
 
@@ -5635,10 +5684,10 @@ msgstr "Trimestre"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Cotação"
 
@@ -5733,6 +5782,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Recebidos"
 
@@ -5748,8 +5798,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Recibimentos"
 
@@ -6114,10 +6164,10 @@ msgstr "Fatura de Venda/Númenro da Transação de CR"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Pedido de Venda"
 
@@ -6630,7 +6680,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Despachar"
@@ -6670,11 +6721,11 @@ msgid "Ship to"
 msgstr "Enviar para"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6791,8 +6842,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Fonte"
 
@@ -6926,6 +6979,10 @@ msgstr "Estoque"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Estoque de Conjuntos"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7741,6 +7798,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Unidade"
 
@@ -8048,6 +8106,10 @@ msgstr "Fornecedor não está no arquivo!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/ru.po
+++ b/locale/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: Ann Madz <annamadzigon@gmail.com>, 2020\n"
 "Language-Team: Russian (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -126,7 +126,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -149,9 +150,10 @@ msgstr "Счета-фактуры ДЗ"
 msgid "AR Outstanding"
 msgstr "Задолженость клиентов"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Проводка продаж"
 
@@ -380,7 +382,7 @@ msgstr "Добавить Бюджет"
 msgid "Add Business"
 msgstr "Новый бизнес"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "Добавить класс"
 
@@ -538,6 +540,10 @@ msgstr "Добавить возврат поставщику"
 msgid "Add Warehouse"
 msgstr "Новый склад"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "Добавить/Изменить отчисления"
@@ -672,10 +678,10 @@ msgstr "Разрешить ввод"
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -745,6 +751,10 @@ msgstr "Годовая прямолинейная амортизация еже�
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
 msgstr "Любой"
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
+msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
 msgid "Applied discount"
@@ -1601,10 +1611,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Контактное лицо"
 
@@ -1867,6 +1881,7 @@ msgstr "Валюта"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Валюта"
 
@@ -1899,8 +1914,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Клиент"
@@ -1913,7 +1929,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "История"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2048,13 +2064,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Дата"
 
@@ -2294,6 +2313,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2426,13 +2446,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Описание"
 
@@ -2466,7 +2489,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2570,6 +2593,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2899,7 +2923,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3037,6 +3062,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Сумма"
 
@@ -3721,8 +3747,9 @@ msgstr "Инвентарь перемещен!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Счет-фактура"
 
@@ -3748,7 +3775,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Дата выставления"
 
@@ -4300,6 +4328,7 @@ msgstr "май"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Комментарий"
 
@@ -4424,6 +4453,10 @@ msgstr "Наименование"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4442,6 +4475,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4686,14 +4723,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "код"
 
@@ -4742,6 +4782,10 @@ msgstr "октябрь"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4809,10 +4853,12 @@ msgstr "Заказ клиента"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4821,7 +4867,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Дата заказа клиента"
 
@@ -5403,9 +5450,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Цена"
 
@@ -5616,8 +5664,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Количество"
 
@@ -5637,10 +5686,10 @@ msgstr "Квартал"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Резервирование"
 
@@ -5735,6 +5784,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Recd"
 
@@ -5750,8 +5800,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Получения"
 
@@ -6116,10 +6166,10 @@ msgstr "Номер проводки Фактуры клиента"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Заказ клиента"
 
@@ -6632,7 +6682,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Доставить"
@@ -6672,11 +6723,11 @@ msgid "Ship to"
 msgstr "доставить для"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6793,8 +6844,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Источник"
 
@@ -6928,6 +6981,10 @@ msgstr "Сформировать"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Сформировать комплект"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7743,6 +7800,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Единица"
 
@@ -8050,6 +8108,10 @@ msgstr "Поставщика нет в справочнике!"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/sv.po
+++ b/locale/po/sv.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Swedish (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "sv/)\n"
@@ -119,7 +119,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -142,9 +143,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Kundfordringar"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Betald fodran"
 
@@ -373,7 +375,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Lägg till verksamhet"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -531,6 +533,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Lägg till lager"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -665,10 +671,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -737,6 +743,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1595,10 +1605,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -1861,6 +1875,7 @@ msgstr "Valuta"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1893,8 +1908,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Kund"
@@ -1907,7 +1923,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Kund historik"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2042,13 +2058,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Datum"
 
@@ -2288,6 +2307,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2420,13 +2440,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Beskrivning"
 
@@ -2460,7 +2483,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2564,6 +2587,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2893,7 +2917,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3031,6 +3056,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Summa"
 
@@ -3714,8 +3740,9 @@ msgstr "Lager överfört"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Faktura"
 
@@ -3741,7 +3768,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fakturadatum"
 
@@ -4293,6 +4321,7 @@ msgstr "Maj"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Anteckning"
 
@@ -4417,6 +4446,10 @@ msgstr "Namn"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4435,6 +4468,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4679,14 +4716,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Nummer"
 
@@ -4735,6 +4775,10 @@ msgstr "Oktober"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4802,10 +4846,12 @@ msgstr "Order"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4814,7 +4860,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Orderdatum"
 
@@ -5396,9 +5443,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Pris"
 
@@ -5609,8 +5657,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Antal"
 
@@ -5630,10 +5679,10 @@ msgstr "Kvartal"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "Offert"
 
@@ -5728,6 +5777,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Mottagen"
 
@@ -5743,8 +5793,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Inbetalningar"
 
@@ -6109,10 +6159,10 @@ msgstr "Kundfaktura / Intäktsverifikat nr"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Säljorder"
 
@@ -6625,7 +6675,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Skicka"
@@ -6665,11 +6716,11 @@ msgid "Ship to"
 msgstr "Skicka till"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6786,8 +6837,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Källa"
 
@@ -6921,6 +6974,10 @@ msgstr "Lager"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Lager produkter"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7736,6 +7793,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Enhet"
 
@@ -8043,6 +8101,10 @@ msgstr "Leverantör finns ej"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/th.po
+++ b/locale/po/th.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Last-Translator: O Kan <teravitk@gmail.com>, 2024\n"
 "Language-Team: Thai (http://app.transifex.com/ledgersmb/ledgersmb/language/"
@@ -118,7 +118,8 @@ msgstr "บัญชีเจ้าหนี้จะมีได้เมื่
 msgid "AP transaction"
 msgstr "รายการทางบัญชีเจ้าหนี้"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -141,9 +142,10 @@ msgstr "ใบกำกับสินค้าลูกหนี้"
 msgid "AR Outstanding"
 msgstr "ยอดลูกหนี้ค้างชำระ"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "รายการทางบัญชีลูกหนี้"
 
@@ -372,7 +374,7 @@ msgstr "เพิ่มงบประมาณ"
 msgid "Add Business"
 msgstr "เพิ่มบริษัท"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "เพิ่ม Class"
 
@@ -530,6 +532,10 @@ msgstr "เพิ่มการคืนสินค้าจากคู่ค
 msgid "Add Warehouse"
 msgstr "เพิ่มคลังสินค้า"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "เพิ่ม/แก้ไข การหักเงิน"
@@ -664,10 +670,10 @@ msgstr "การป้อนเข้าระบบที่อนุญาต
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -736,6 +742,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1592,10 +1602,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1858,6 +1872,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1890,8 +1905,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr ""
@@ -1904,7 +1920,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2039,13 +2055,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2285,6 +2304,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2417,13 +2437,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2457,7 +2480,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2561,6 +2584,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2890,7 +2914,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3028,6 +3053,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3710,8 +3736,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3737,7 +3764,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4289,6 +4317,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4413,6 +4442,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4431,6 +4464,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4675,14 +4712,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4731,6 +4771,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4798,10 +4842,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4810,7 +4856,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5392,9 +5439,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5605,8 +5653,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5626,10 +5675,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5724,6 +5773,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5739,8 +5789,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6105,10 +6155,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6621,7 +6671,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6661,11 +6712,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6782,8 +6833,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6916,6 +6969,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7732,6 +7789,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8039,6 +8097,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/th_TH.po
+++ b/locale/po/th_TH.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Thai (Thailand) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/th_TH/)\n"
@@ -116,7 +116,8 @@ msgstr "บัญชีเจ้าหนี้จะมีได้เมื่
 msgid "AP transaction"
 msgstr "รายการทางบัญชีเจ้าหนี้"
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr "ใบกำกับสินค้าลูกหนี้"
 msgid "AR Outstanding"
 msgstr "ยอดลูกหนี้ค้างชำระ"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "รายการทางบัญชีลูกหนี้"
 
@@ -370,7 +372,7 @@ msgstr "เพิ่มงบประมาณ"
 msgid "Add Business"
 msgstr "เพิ่มบริษัท"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr "เพิ่ม Class"
 
@@ -528,6 +530,10 @@ msgstr "เพิ่มการคืนสินค้าจากคู่ค
 msgid "Add Warehouse"
 msgstr "เพิ่มคลังสินค้า"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr "เพิ่ม/แก้ไข การหักเงิน"
@@ -662,10 +668,10 @@ msgstr "การป้อนเข้าระบบที่อนุญาต
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1856,6 +1870,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr ""
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3708,8 +3734,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4287,6 +4315,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4411,6 +4440,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4729,6 +4769,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5624,10 +5673,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6103,10 +6153,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6914,6 +6967,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8037,6 +8095,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/tr.po
+++ b/locale/po/tr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Turkish (http://app.transifex.com/ledgersmb/ledgersmb/language/"
 "tr/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Kontak"
 
@@ -1856,6 +1870,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Para Birimi"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Alıcı"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Tarih"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Açıklama"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3708,8 +3734,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Fatura"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Fatura Tarihi"
 
@@ -4287,6 +4315,7 @@ msgstr "May"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4411,6 +4440,10 @@ msgstr "İsim"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Numara"
 
@@ -4729,6 +4769,10 @@ msgstr "Ekim"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "Sipariş"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Sipariş Tarihi"
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Fiyat"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Adet"
 
@@ -5624,10 +5673,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6103,10 +6153,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Satış Siparişi"
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Kaynak"
 
@@ -6915,6 +6968,10 @@ msgstr ""
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Grubu Stokla"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Birim"
 
@@ -8037,6 +8095,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/tr_TR.po
+++ b/locale/po/tr_TR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/ledgersmb/ledgersmb/"
 "language/tr_TR/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr ""
 
@@ -370,7 +372,7 @@ msgstr ""
 msgid "Add Business"
 msgstr ""
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr ""
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr ""
 
@@ -1856,6 +1870,7 @@ msgstr ""
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr ""
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr ""
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr ""
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr ""
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr ""
 
@@ -3708,8 +3734,9 @@ msgstr ""
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr ""
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr ""
 
@@ -4287,6 +4315,7 @@ msgstr ""
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr ""
 
@@ -4411,6 +4440,10 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr ""
 
@@ -4729,6 +4769,10 @@ msgstr ""
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr ""
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr ""
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr ""
 
@@ -5624,10 +5673,10 @@ msgstr ""
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr ""
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr ""
 
@@ -6103,10 +6153,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr ""
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr ""
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr ""
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr ""
 
@@ -6914,6 +6967,10 @@ msgstr ""
 
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Strength"
 msgstr ""
 
 #: UI/users/preferences.html:109
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr ""
 
@@ -8037,6 +8095,10 @@ msgstr ""
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/uk.po
+++ b/locale/po/uk.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Ukrainian (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/uk/)\n"
@@ -119,7 +119,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -142,9 +143,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "Несплачені рахунки доходів"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "Проводка доходів"
 
@@ -373,7 +375,7 @@ msgstr ""
 msgid "Add Business"
 msgstr "Додати бізнес"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -531,6 +533,10 @@ msgstr ""
 msgid "Add Warehouse"
 msgstr "Додати склад"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -665,10 +671,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -737,6 +743,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1593,10 +1603,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "Контактна особа"
 
@@ -1859,6 +1873,7 @@ msgstr "Валюта"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "Валюта"
 
@@ -1891,8 +1906,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "Клієнт"
@@ -1905,7 +1921,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "Історія клієнта"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2040,13 +2056,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "Дата"
 
@@ -2286,6 +2305,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2418,13 +2438,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "Опис"
 
@@ -2458,7 +2481,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2562,6 +2585,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2891,7 +2915,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3029,6 +3054,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "Продовжено"
 
@@ -3713,8 +3739,9 @@ msgstr "Інвентар перенесено!"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "Рахунок-фактура"
 
@@ -3740,7 +3767,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "Дата виставлення"
 
@@ -4292,6 +4320,7 @@ msgstr "травня"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "Нотатка"
 
@@ -4416,6 +4445,10 @@ msgstr "Назва"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4434,6 +4467,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4678,14 +4715,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "Номер"
 
@@ -4734,6 +4774,10 @@ msgstr "Жовтень"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4801,10 +4845,12 @@ msgstr ""
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4813,7 +4859,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "Дата замовлення"
 
@@ -5395,9 +5442,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "Ціна"
 
@@ -5608,8 +5656,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "Кількість"
 
@@ -5629,10 +5678,10 @@ msgstr "Квартал"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr ""
 
@@ -5727,6 +5776,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "Отримано"
 
@@ -5742,8 +5792,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "Квитанції"
 
@@ -6108,10 +6158,10 @@ msgstr ""
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "Накладна продажу"
 
@@ -6624,7 +6674,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "Відіслати"
@@ -6664,11 +6715,11 @@ msgid "Ship to"
 msgstr "Відіслати до"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6785,8 +6836,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "Джерело"
 
@@ -6920,6 +6973,10 @@ msgstr "Інвентар"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "Інвентар комплекту"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7735,6 +7792,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "Одиниця"
 
@@ -8042,6 +8100,10 @@ msgstr "Потачальника нема у списку "
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/zh-Hans.po
+++ b/locale/po/zh-Hans.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese Simplified (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/zh-Hans/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "应收未收"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "應收交易"
 
@@ -370,7 +372,7 @@ msgstr "新增預算"
 msgid "Add Business"
 msgstr "新增业务"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "連絡人"
 
@@ -1856,6 +1870,7 @@ msgstr "目前"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "幣別"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "客戶"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "客户历史"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "日期"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "說明"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "巳扩大"
 
@@ -3708,8 +3734,9 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "发票"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "发票日期"
 
@@ -4287,6 +4315,7 @@ msgstr "五月"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "備忘錄"
 
@@ -4411,6 +4440,10 @@ msgstr "名稱"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "編號"
 
@@ -4729,6 +4769,10 @@ msgstr "十月"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "订单"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "价格"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "数量"
 
@@ -5624,10 +5673,10 @@ msgstr "季度"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "報價單"
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "已收到"
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "收據"
 
@@ -6103,10 +6153,10 @@ msgstr "銷售發票/應收帳交易編號"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "銷貨單"
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "付運"
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr "海运至"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "來源"
 
@@ -6915,6 +6968,10 @@ msgstr "库存"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "把製成品入貨"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "單位"
 
@@ -8037,6 +8095,10 @@ msgstr "沒有此供應商的記錄！"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/zh-Hant.po
+++ b/locale/po/zh-Hant.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese Traditional (http://app.transifex.com/ledgersmb/"
 "ledgersmb/language/zh-Hant/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "应收未收"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "應收交易"
 
@@ -370,7 +372,7 @@ msgstr "新增預算"
 msgid "Add Business"
 msgstr "新增业务"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "連絡人"
 
@@ -1856,6 +1870,7 @@ msgstr "目前"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "幣別"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "客戶"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "客户历史"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "日期"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "說明"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "巳扩大"
 
@@ -3708,8 +3734,9 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "发票"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "发票日期"
 
@@ -4287,6 +4315,7 @@ msgstr "五月"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "備忘錄"
 
@@ -4411,6 +4440,10 @@ msgstr "名稱"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "編號"
 
@@ -4729,6 +4769,10 @@ msgstr "十月"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "订单"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "价格"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "数量"
 
@@ -5624,10 +5673,10 @@ msgstr "季度"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "報價單"
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "已收到"
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "收據"
 
@@ -6103,10 +6153,10 @@ msgstr "銷售發票/應收帳交易編號"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "銷貨單"
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "付運"
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr "海运至"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "來源"
 
@@ -6915,6 +6968,10 @@ msgstr "库存"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "把製成品入貨"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "單位"
 
@@ -8037,6 +8095,10 @@ msgstr "沒有此供應商的記錄！"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/zh_CN.po
+++ b/locale/po/zh_CN.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese (China) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/zh_CN/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "应收未收"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "应收交易"
 
@@ -370,7 +372,7 @@ msgstr "新增預算"
 msgid "Add Business"
 msgstr "新增业务"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增仓库"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "连络人"
 
@@ -1856,6 +1870,7 @@ msgstr "目前"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "币别"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "客户"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "客户历史"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "日期"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "说明"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "巳扩大"
 
@@ -3708,8 +3734,9 @@ msgstr "转移的存货"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "发票"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "发票日期"
 
@@ -4287,6 +4315,7 @@ msgstr "五月"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "备忘录"
 
@@ -4411,6 +4440,10 @@ msgstr "名称"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "编号"
 
@@ -4729,6 +4769,10 @@ msgstr "十月"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "订单"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下单日期"
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "价格"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "数量"
 
@@ -5624,10 +5673,10 @@ msgstr "季度"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "报价单"
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "巳收到"
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "收据"
 
@@ -6103,10 +6153,10 @@ msgstr "銷售發票/應收帳交易編號"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "销货单"
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "船"
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr "海运至"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "来源"
 
@@ -6915,6 +6968,10 @@ msgstr "库存"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "盘点"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "单位"
 
@@ -8037,6 +8095,10 @@ msgstr "档案没有此供应商"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/locale/po/zh_TW.po
+++ b/locale/po/zh_TW.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
-"POT-Creation-Date: 2025-04-21 08:27+0000\n"
+"POT-Creation-Date: 2025-04-21 08:35+0000\n"
 "PO-Revision-Date: 2015-12-24 17:27+0000\n"
 "Language-Team: Chinese (Taiwan) (http://app.transifex.com/ledgersmb/ledgersmb/"
 "language/zh_TW/)\n"
@@ -116,7 +116,8 @@ msgstr ""
 msgid "AP transaction"
 msgstr ""
 
-#: old/bin/am.pl:321 UI/Reports/filters/unapproved.html:6
+#: old/bin/am.pl:321 UI/Contact/divs/credit.html:218
+#: UI/Contact/divs/credit.html:219 UI/Reports/filters/unapproved.html:6
 #: UI/setup/complete.html:82 UI/setup/confirm_operation.html:135
 #: sql/Pg-database.sql:2310
 msgid "AR"
@@ -139,9 +140,10 @@ msgstr ""
 msgid "AR Outstanding"
 msgstr "應收未收"
 
-#: UI/Contact/divs/credit.html:379 templates/demo/ar_transaction.html:16
-#: templates/demo/ar_transaction.html:31 templates/demo/ar_transaction.tex:49
-#: sql/Pg-database.sql:2408 sql/Pg-database.sql:2421
+#: UI/Contact/divs/credit.html:379 t/data/04-complex_template.html:325
+#: templates/demo/ar_transaction.html:16 templates/demo/ar_transaction.html:31
+#: templates/demo/ar_transaction.tex:49 sql/Pg-database.sql:2408
+#: sql/Pg-database.sql:2421
 msgid "AR Transaction"
 msgstr "應收交易"
 
@@ -370,7 +372,7 @@ msgstr "新增預算"
 msgid "Add Business"
 msgstr "新增業務"
 
-#: sql/Pg-database.sql:2348
+#: UI/business_units/list_classes.html:84 sql/Pg-database.sql:2348
 msgid "Add Class"
 msgstr ""
 
@@ -528,6 +530,10 @@ msgstr "新增供應商歸還"
 msgid "Add Warehouse"
 msgstr "新增倉庫"
 
+#: UI/budgetting/budget_entry.html:7
+msgid "Add budget"
+msgstr ""
+
 #: UI/Contact/divs/wage.html:78
 msgid "Add/Change Deductions"
 msgstr ""
@@ -662,10 +668,10 @@ msgstr ""
 #: UI/Reports/filters/invoice_outstanding.html:192
 #: UI/Reports/filters/invoice_search.html:341 UI/Reports/filters/orders.html:190
 #: UI/payments/payment2.html:349 templates/demo/ap_transaction.html:155
-#: templates/demo/ar_transaction.html:151 templates/demo/ar_transaction.tex:145
-#: templates/demo/invoice.html:195 templates/demo/invoice.tex:172
-#: templates/demo/invoice.tex:236 templates/demo/printPayment.html:52
-#: templates/demo/product_receipt.html:101
+#: templates/demo/ap_transaction.tex:127 templates/demo/ar_transaction.html:151
+#: templates/demo/ar_transaction.tex:145 templates/demo/invoice.html:195
+#: templates/demo/invoice.tex:172 templates/demo/invoice.tex:236
+#: templates/demo/printPayment.html:52 templates/demo/product_receipt.html:101
 #: templates/demo/product_receipt.tex:136 templates/demo/purchase_order.html:103
 #: templates/demo/purchase_order.tex:136 templates/demo/sales_order.html:106
 #: templates/demo/sales_order.tex:138 templates/demo/sales_quotation.html:88
@@ -734,6 +740,10 @@ msgstr ""
 
 #: old/lib/LedgerSMB/Batch.pm:166
 msgid "Any"
+msgstr ""
+
+#: templates/demo/check_base.tex:67 templates/demo/receipt.tex:80
+msgid "Applied"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/payment.pm:1366
@@ -1590,10 +1600,14 @@ msgstr ""
 
 #: old/bin/io.pl:1672 UI/Reports/filters/contact_search.html:75
 #: templates/demo/bin_list.html:77 templates/demo/packing_list.html:68
-#: templates/demo/pick_list.html:68 templates/demo/product_receipt.html:76
-#: templates/demo/purchase_order.html:77
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:68
+#: templates/demo/pick_list.tex:96 templates/demo/product_receipt.html:76
+#: templates/demo/product_receipt.tex:122 templates/demo/purchase_order.html:77
+#: templates/demo/purchase_order.tex:122
 #: templates/demo/request_quotation.html:77
-#: templates/demo/sales_quotation.html:62 sql/Pg-database.sql:240
+#: templates/demo/request_quotation.tex:123
+#: templates/demo/sales_quotation.html:62 templates/demo/sales_quotation.tex:92
+#: sql/Pg-database.sql:240
 msgid "Contact"
 msgstr "連絡人"
 
@@ -1856,6 +1870,7 @@ msgstr "目前"
 #: UI/payments/use_overpayment1.html:42 UI/payments/use_overpayment2.html:90
 #: UI/timecards/timecard-week.html:76 UI/timecards/timecard.html:120
 #: templates/demo/printPayment.html:68 templates/demo/statement.html:72
+#: templates/demo/statement.tex:58
 msgid "Currency"
 msgstr "幣別"
 
@@ -1888,8 +1903,9 @@ msgstr ""
 #: UI/Contact/divs/credit.html:15 UI/Reports/filters/aging.html:14
 #: UI/Reports/filters/invoice_outstanding.html:9
 #: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:7
-#: UI/business_units/edit.html:81 UI/payments/payments_filter.html:39
-#: UI/payments/use_overpayment1.html:28 UI/payments/use_overpayment2.html:23
+#: UI/business_units/edit.html:81 UI/payments/payments_detail.html:4
+#: UI/payments/payments_filter.html:39 UI/payments/use_overpayment1.html:28
+#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:149
 #: sql/Pg-database.sql:238
 msgid "Customer"
 msgstr "客戶"
@@ -1902,7 +1918,7 @@ msgstr ""
 msgid "Customer History"
 msgstr "客戶歷史"
 
-#: UI/Contact/divs/credit.html:382
+#: UI/Contact/divs/credit.html:382 t/data/04-complex_template.html:334
 msgid "Customer Invoice"
 msgstr ""
 
@@ -2037,13 +2053,16 @@ msgstr ""
 #: templates/demo/ar_transaction.html:58 templates/demo/ar_transaction.html:148
 #: templates/demo/ar_transaction.tex:93 templates/demo/ar_transaction.tex:144
 #: templates/demo/bin_list.html:76 templates/demo/invoice.html:84
-#: templates/demo/invoice.html:192 templates/demo/invoice.tex:235
-#: templates/demo/packing_list.html:67 templates/demo/packing_list.tex:103
-#: templates/demo/pick_list.html:67 templates/demo/pick_list.tex:96
-#: templates/demo/printPayment.html:70 templates/demo/request_quotation.html:75
-#: templates/demo/sales_quotation.html:60 templates/demo/statement.html:65
-#: templates/demo/statement.tex:56 templates/demo/timecard.html:56
-#: templates/demo/timecard.tex:44
+#: templates/demo/invoice.html:192 templates/demo/invoice.tex:149
+#: templates/demo/invoice.tex:235 templates/demo/packing_list.html:67
+#: templates/demo/packing_list.tex:103 templates/demo/pick_list.html:67
+#: templates/demo/pick_list.tex:96 templates/demo/printPayment.html:70
+#: templates/demo/product_receipt.tex:121 templates/demo/purchase_order.tex:121
+#: templates/demo/request_quotation.html:75
+#: templates/demo/request_quotation.tex:122
+#: templates/demo/sales_quotation.html:60 templates/demo/sales_quotation.tex:91
+#: templates/demo/statement.html:65 templates/demo/statement.tex:56
+#: templates/demo/timecard.html:56 templates/demo/timecard.tex:44
 msgid "Date"
 msgstr "日期"
 
@@ -2283,6 +2302,7 @@ msgid "Deleting..."
 msgstr ""
 
 #: templates/demo/invoice.tex:167 templates/demo/request_quotation.html:110
+#: templates/demo/request_quotation.tex:139
 msgid "Delivery"
 msgstr ""
 
@@ -2415,13 +2435,16 @@ msgstr ""
 #: templates/demo/invoice.tex:166 templates/demo/packing_list.html:92
 #: templates/demo/packing_list.tex:129 templates/demo/pick_list.html:92
 #: templates/demo/pick_list.tex:115 templates/demo/printPayment.html:48
-#: templates/demo/product_receipt.html:96 templates/demo/purchase_order.html:98
-#: templates/demo/request_quotation.html:107 templates/demo/sales_order.html:101
+#: templates/demo/product_receipt.html:96 templates/demo/product_receipt.tex:133
+#: templates/demo/purchase_order.html:98 templates/demo/purchase_order.tex:133
+#: templates/demo/request_quotation.html:107
+#: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:101
 #: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:83
-#: templates/demo/timecard.html:91 templates/demo/timecard.html:99
-#: templates/demo/timecard.tex:54 templates/demo/timecard.tex:56
-#: templates/demo/work_order.html:100 templates/demo/work_order.tex:140
-#: sql/Pg-database.sql:2291 sql/Pg-database.sql:2296
+#: templates/demo/sales_quotation.tex:103 templates/demo/timecard.html:91
+#: templates/demo/timecard.html:99 templates/demo/timecard.tex:54
+#: templates/demo/timecard.tex:56 templates/demo/work_order.html:100
+#: templates/demo/work_order.tex:140 sql/Pg-database.sql:2291
+#: sql/Pg-database.sql:2296
 msgid "Description"
 msgstr "說明"
 
@@ -2455,7 +2478,7 @@ msgstr ""
 
 #: templates/demo/invoice.html:114 templates/demo/invoice.tex:171
 #: templates/demo/sales_order.html:105 templates/demo/sales_order.tex:137
-#: templates/demo/sales_quotation.html:87
+#: templates/demo/sales_quotation.html:87 templates/demo/sales_quotation.tex:105
 msgid "Disc %"
 msgstr ""
 
@@ -2559,6 +2582,7 @@ msgstr ""
 #: templates/demo/ar_transaction.html:62 templates/demo/ar_transaction.tex:94
 #: templates/demo/invoice.html:85 templates/demo/invoice.tex:150
 #: templates/demo/receipt.tex:80 templates/demo/statement.html:66
+#: templates/demo/statement.tex:56
 msgid "Due"
 msgstr ""
 
@@ -2888,7 +2912,8 @@ msgid "Entered at: [_1]"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/contact.pm:314
-#: lib/LedgerSMB/Scripts/report_aging.pm:144 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Scripts/report_aging.pm:144 UI/Contact/divs/notes.html:44
+#: sql/Pg-database.sql:728
 msgid "Entity"
 msgstr ""
 
@@ -3026,6 +3051,7 @@ msgid "Experimental features"
 msgstr ""
 
 #: old/bin/io.pl:252 templates/demo/invoice.html:115
+#: templates/demo/request_quotation.tex:140
 msgid "Extended"
 msgstr "總價"
 
@@ -3708,8 +3734,9 @@ msgstr "轉移的存貨！"
 #: lib/LedgerSMB/Scripts/payment.pm:941 old/bin/am.pl:996 old/bin/io.pl:1087
 #: old/bin/is.pl:1405 old/bin/is.pl:271 old/bin/printer.pl:48
 #: UI/templates/widget.html:51 templates/demo/invoice.html:20
-#: templates/demo/invoice.tex:142 templates/demo/printPayment.html:44
-#: sql/Pg-database.sql:729 sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
+#: templates/demo/invoice.html:36 templates/demo/invoice.tex:142
+#: templates/demo/printPayment.html:44 sql/Pg-database.sql:729
+#: sql/Pg-database.sql:2308 sql/Pg-database.sql:2407
 msgid "Invoice"
 msgstr "發票"
 
@@ -3735,7 +3762,8 @@ msgstr ""
 #: lib/LedgerSMB/Report/Contact/History.pm:125
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:96 old/bin/aa.pl:783 old/bin/ir.pl:463
 #: old/bin/is.pl:554 UI/Reports/filters/invoice_outstanding.html:158
-#: UI/Reports/filters/invoice_search.html:307
+#: UI/Reports/filters/invoice_search.html:307 templates/demo/check_base.tex:66
+#: templates/demo/receipt.tex:79
 msgid "Invoice Date"
 msgstr "發票日期"
 
@@ -4287,6 +4315,7 @@ msgstr "五月"
 #: old/bin/is.pl:932 UI/Reports/filters/gl.html:73
 #: UI/Reports/filters/gl.html:297 UI/journal/journal_entry.html:159
 #: UI/payments/payment2.html:348 templates/demo/ap_transaction.html:154
+#: templates/demo/ap_transaction.tex:127
 msgid "Memo"
 msgstr "備忘錄"
 
@@ -4411,6 +4440,10 @@ msgstr "名稱"
 msgid "Name:"
 msgstr ""
 
+#: UI/accounts/edit.html:191
+msgid "Negative balance heading"
+msgstr ""
+
 #: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:127 sql/Pg-database.sql:2354
 msgid "Net Book Value"
 msgstr ""
@@ -4429,6 +4462,10 @@ msgstr ""
 
 #: UI/asset/begin_approval.html:5
 msgid "New Asset Report Search"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "New Password"
 msgstr ""
 
 #: UI/reconciliation/new_report.html:8
@@ -4673,14 +4710,17 @@ msgstr ""
 #: old/bin/pe.pl:277 UI/Contact/divs/credit.html:30
 #: UI/Contact/divs/credit.html:97 UI/Contact/divs/credit.html:98
 #: UI/am-taxes.html:16 templates/demo/bin_list.html:99
-#: templates/demo/invoice.html:108 templates/demo/invoice.tex:165
-#: templates/demo/packing_list.html:91 templates/demo/pick_list.html:91
+#: templates/demo/bin_list.tex:120 templates/demo/invoice.html:108
+#: templates/demo/invoice.tex:165 templates/demo/packing_list.html:91
+#: templates/demo/packing_list.tex:128 templates/demo/pick_list.html:91
+#: templates/demo/pick_list.tex:114 templates/demo/printPayment.html:44
 #: templates/demo/product_receipt.html:95 templates/demo/product_receipt.tex:133
 #: templates/demo/purchase_order.html:97 templates/demo/purchase_order.tex:133
 #: templates/demo/request_quotation.html:106
 #: templates/demo/request_quotation.tex:138 templates/demo/sales_order.html:100
-#: templates/demo/sales_quotation.html:59 templates/demo/sales_quotation.html:82
-#: templates/demo/sales_quotation.tex:103 templates/demo/work_order.html:99
+#: templates/demo/sales_order.tex:134 templates/demo/sales_quotation.html:59
+#: templates/demo/sales_quotation.html:82 templates/demo/sales_quotation.tex:103
+#: templates/demo/work_order.html:99 templates/demo/work_order.tex:139
 msgid "Number"
 msgstr "編號"
 
@@ -4729,6 +4769,10 @@ msgstr "十月"
 
 #: old/bin/is.pl:810
 msgid "Off Hold"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Old Password"
 msgstr ""
 
 #: lib/LedgerSMB/Report/Inventory/History.pm:129
@@ -4796,10 +4840,12 @@ msgstr "訂單"
 #: templates/demo/ap_transaction.html:72 templates/demo/ap_transaction.tex:82
 #: templates/demo/ar_transaction.html:70 templates/demo/ar_transaction.tex:99
 #: templates/demo/bin_list.html:75 templates/demo/invoice.html:86
-#: templates/demo/packing_list.html:66 templates/demo/pick_list.html:66
-#: templates/demo/purchase_order.html:74 templates/demo/purchase_order.tex:121
-#: templates/demo/sales_order.html:77 templates/demo/sales_order.tex:121
-#: templates/demo/statement.html:64 templates/demo/work_order.html:76
+#: templates/demo/invoice.tex:150 templates/demo/packing_list.html:66
+#: templates/demo/packing_list.tex:102 templates/demo/pick_list.html:66
+#: templates/demo/pick_list.tex:95 templates/demo/purchase_order.html:74
+#: templates/demo/purchase_order.tex:121 templates/demo/sales_order.html:77
+#: templates/demo/sales_order.tex:121 templates/demo/statement.html:64
+#: templates/demo/statement.tex:55 templates/demo/work_order.html:76
 msgid "Order #"
 msgstr ""
 
@@ -4808,7 +4854,8 @@ msgid "Order By"
 msgstr ""
 
 #: old/bin/oe.pl:1849 old/bin/oe.pl:434 templates/demo/purchase_order.html:75
-#: templates/demo/sales_order.html:78 templates/demo/work_order.html:77
+#: templates/demo/sales_order.html:78 templates/demo/sales_order.tex:121
+#: templates/demo/work_order.html:77
 msgid "Order Date"
 msgstr "下單日期"
 
@@ -5390,9 +5437,10 @@ msgid "Prefix"
 msgstr ""
 
 #: old/bin/io.pl:249 templates/demo/invoice.tex:170
-#: templates/demo/product_receipt.html:99 templates/demo/purchase_order.html:101
-#: templates/demo/sales_order.html:104 templates/demo/sales_quotation.html:86
-#: templates/demo/sales_quotation.tex:105
+#: templates/demo/product_receipt.html:99 templates/demo/product_receipt.tex:135
+#: templates/demo/purchase_order.html:101 templates/demo/purchase_order.tex:135
+#: templates/demo/sales_order.html:104 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.html:86 templates/demo/sales_quotation.tex:105
 msgid "Price"
 msgstr "價格"
 
@@ -5603,8 +5651,9 @@ msgstr ""
 #: templates/demo/purchase_order.tex:134
 #: templates/demo/request_quotation.html:108
 #: templates/demo/request_quotation.tex:139 templates/demo/sales_order.html:102
-#: templates/demo/sales_quotation.html:84 templates/demo/sales_quotation.tex:104
-#: templates/demo/work_order.html:101
+#: templates/demo/sales_order.tex:135 templates/demo/sales_quotation.html:84
+#: templates/demo/sales_quotation.tex:104 templates/demo/work_order.html:101
+#: templates/demo/work_order.tex:140
 msgid "Qty"
 msgstr "數量"
 
@@ -5624,10 +5673,10 @@ msgstr "季"
 #: lib/LedgerSMB/Report/Inventory/Search.pm:311
 #: lib/LedgerSMB/Report/Orders.pm:242 old/bin/io.pl:1154 old/bin/io.pl:1161
 #: old/bin/oe.pl:1229 old/bin/oe.pl:244 old/bin/printer.pl:61
-#: UI/Contact/divs/credit.html:388 templates/demo/sales_quotation.html:16
-#: templates/demo/sales_quotation.html:33 templates/demo/sales_quotation.tex:85
-#: sql/Pg-database.sql:1576 sql/Pg-database.sql:2285 sql/Pg-database.sql:2417
-#: sql/Pg-database.sql:2432
+#: UI/Contact/divs/credit.html:388 t/data/04-complex_template.html:352
+#: templates/demo/sales_quotation.html:16 templates/demo/sales_quotation.html:33
+#: templates/demo/sales_quotation.tex:85 sql/Pg-database.sql:1576
+#: sql/Pg-database.sql:2285 sql/Pg-database.sql:2417 sql/Pg-database.sql:2432
 msgid "Quotation"
 msgstr "報價單"
 
@@ -5722,6 +5771,7 @@ msgid "Rebuild/Upgrade?"
 msgstr ""
 
 #: old/bin/io.pl:185 old/bin/oe.pl:1884 templates/demo/bin_list.html:104
+#: templates/demo/bin_list.tex:123
 msgid "Recd"
 msgstr "已收到"
 
@@ -5737,8 +5787,8 @@ msgstr ""
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:21 sql/Pg-database.sql:2266
-#: sql/Pg-database.sql:2344
+#: UI/payments/payment1.html:21 UI/payments/payments_detail.html:6
+#: sql/Pg-database.sql:2266 sql/Pg-database.sql:2344
 msgid "Receipts"
 msgstr "收據"
 
@@ -6103,10 +6153,10 @@ msgstr "銷售發票/應收帳交易編號"
 
 #: old/bin/am.pl:1001 old/bin/am.pl:752 old/bin/io.pl:1092 old/bin/is.pl:1031
 #: old/bin/oe.pl:1212 old/bin/oe.pl:255 old/bin/printer.pl:71
-#: UI/Contact/divs/credit.html:385 templates/demo/sales_order.html:16
-#: templates/demo/sales_order.html:33 templates/demo/sales_order.tex:115
-#: sql/Pg-database.sql:1574 sql/Pg-database.sql:2272 sql/Pg-database.sql:2412
-#: sql/Pg-database.sql:2425
+#: UI/Contact/divs/credit.html:385 t/data/04-complex_template.html:343
+#: templates/demo/sales_order.html:16 templates/demo/sales_order.html:33
+#: templates/demo/sales_order.tex:115 sql/Pg-database.sql:1574
+#: sql/Pg-database.sql:2272 sql/Pg-database.sql:2412 sql/Pg-database.sql:2425
 msgid "Sales Order"
 msgstr "銷貨單"
 
@@ -6619,7 +6669,8 @@ msgid "Seventy"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/order.pm:70 old/bin/io.pl:177 old/bin/oe.pl:1880
-#: templates/demo/packing_list.html:96 templates/demo/pick_list.html:94
+#: templates/demo/packing_list.html:96 templates/demo/packing_list.tex:131
+#: templates/demo/pick_list.html:94 templates/demo/pick_list.tex:116
 #: sql/Pg-database.sql:2282
 msgid "Ship"
 msgstr "付運"
@@ -6659,11 +6710,11 @@ msgid "Ship to"
 msgstr "付運至"
 
 #: old/bin/is.pl:526 old/bin/oe.pl:1833 old/bin/oe.pl:655
-#: templates/demo/bin_list.html:80 templates/demo/invoice.html:89
-#: templates/demo/invoice.tex:153 templates/demo/packing_list.html:71
-#: templates/demo/packing_list.tex:108 templates/demo/pick_list.html:71
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.tex:124
-#: templates/demo/purchase_order.tex:124
+#: templates/demo/bin_list.html:80 templates/demo/bin_list.tex:99
+#: templates/demo/invoice.html:89 templates/demo/invoice.tex:153
+#: templates/demo/packing_list.html:71 templates/demo/packing_list.tex:108
+#: templates/demo/pick_list.html:71 templates/demo/pick_list.tex:99
+#: templates/demo/product_receipt.tex:124 templates/demo/purchase_order.tex:124
 #: templates/demo/request_quotation.html:79
 #: templates/demo/request_quotation.tex:125
 #: templates/demo/sales_quotation.html:64 templates/demo/sales_quotation.tex:94
@@ -6780,8 +6831,10 @@ msgstr ""
 #: UI/payments/payment2.html:281 UI/payments/payment2.html:347
 #: UI/payments/payments_detail.html:315 UI/reconciliation/report.html:138
 #: UI/reconciliation/report.html:263 UI/reconciliation/report.html:336
-#: templates/demo/ap_transaction.html:153 templates/demo/ar_transaction.html:150
-#: templates/demo/invoice.html:194 templates/demo/printPayment.html:50
+#: templates/demo/ap_transaction.html:153 templates/demo/ap_transaction.tex:127
+#: templates/demo/ar_transaction.html:150 templates/demo/ar_transaction.tex:144
+#: templates/demo/invoice.html:194 templates/demo/invoice.tex:235
+#: templates/demo/printPayment.html:50
 msgid "Source"
 msgstr "來源"
 
@@ -6915,6 +6968,10 @@ msgstr "庫存"
 #: old/bin/ic.pl:1977 old/bin/ic.pl:2084 sql/Pg-database.sql:2397
 msgid "Stock Assembly"
 msgstr "把製成品入貨"
+
+#: UI/users/preferences.html:15
+msgid "Strength"
+msgstr ""
 
 #: UI/users/preferences.html:109
 msgid "Stylesheet"
@@ -7730,6 +7787,7 @@ msgstr ""
 #: UI/Reports/filters/search_goods.html:287 UI/payroll/income.html:68
 #: templates/demo/invoice.tex:169 templates/demo/product_receipt.tex:135
 #: templates/demo/purchase_order.tex:135 templates/demo/sales_order.tex:136
+#: templates/demo/sales_quotation.tex:104
 msgid "Unit"
 msgstr "單位"
 
@@ -8037,6 +8095,10 @@ msgstr "沒有此供應商的記錄！"
 
 #: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105 UI/Reports/filters/gl.html:241
 msgid "Vendor/Customer"
+msgstr ""
+
+#: UI/users/preferences.html:15
+msgid "Verify"
 msgstr ""
 
 #: UI/setup/confirm_operation.html:122

--- a/utils/devel/extract-template-translations
+++ b/utils/devel/extract-template-translations
@@ -1,4 +1,6 @@
 #!/usr/bin/perl
+use warnings;
+use strict;
 
 my %dict;
 
@@ -33,27 +35,27 @@ while (<>) {
         if ( $cont ) {
             $line =~ s/'\s*_\s*'//g;
         }
-        if ($line =~ m/(?<!make)text\s*\(\s*"((\\.|[^"])*)"/) {
-            my $match = $1;
+        if (my @matches = $line =~ m/(?<!make)text\s*\(\s*"((?:\\.|[^"])*)"/g) {
+            foreach my $match (@matches) {
+                if ($match !~ m/(?<!\\)\$/g) {
+                    &ensure_entry($match);
+                    push @{$dict{$match}}, "#: $file:$line_no";
+                }
+                else {
+                    warn "$file:$line_no: Direct variable interpolation not supported; use bracketed ([_1]) syntax! ($match)";
+                }
+            }
+        }
+        elsif (@matches = $line =~ m/(?<!make)text\s*\(\s*'((?:''|[^'])*)'/g) {
+            foreach my $match (@matches) {
+                # recode 'match' to double quoting
+                $match =~ s/''/'/g;
+                $match =~ s/\\/\\\\/g;
+                $match =~ s/"/\\"/g;
 
-            if ($match !~ m/(?<!\\)\$/g) {
                 &ensure_entry($match);
                 push @{$dict{$match}}, "#: $file:$line_no";
             }
-            else {
-                warn "$file:$line_no: Direct variable interpolation not supported; use bracketed ([_1]) syntax! ($match)";
-            }
-        }
-        elsif ($line =~ m/(?<!make)text\s*\(\s*'((''|[^'])*)'/) {
-            my $match = $1;
-
-            # recode 'match' to double quoting
-            $match =~ s/''/'/g;
-            $match =~ s/\\/\\\\/g;
-            $match =~ s/"/\\"/g;
-
-            &ensure_entry($match);
-            push @{$dict{$match}}, "#: $file:$line_no";
         }
         $line = ''; $line_no += $cont; $cont = 0;
     }


### PR DESCRIPTION
When locating strings for translation, process _all_ strings on a line, not just the first.

This adds a number of previously missed strings into the translation lexicon.
