### PR TITLE
Fix database change `notify-import-financial-report-templates.sql`

### DIFF
--- a/sql/changes/1.8/notify-import-financial-report-templates.sql@1
+++ b/sql/changes/1.8/notify-import-financial-report-templates.sql@1
@@ -5,7 +5,7 @@
 
 select pg_notify(
   'upgrade.' || current_database(),
-  $json${"type":"feedback","content":"As of 1.8, the balance sheet and income statement templates used to generate downloaded documents, have been moved to the database. Please go to \"System > Templates\" and upload the templates provided in the templates/ directory. Until this action is completed, these reports are available only in the UI, but the download links will not work."}$json$)
+  $json${"type":"feedback","content":"As of 1.8, the balance sheet and income statement templates used to generate downloaded documents, have been moved to the database. Please go to "System > Templates" and upload the templates provided in the templates/ directory. Until this action is completed, these reports are available only in the UI, but the download links will not work.$json$)
  where (select count(*) from template) > 0
    and (not exists (select 1
                       from template


### PR DESCRIPTION
When upgrading databases prior to 1.8, there's a check relating to balance sheet and income statement templates having been moved to the database.

If these templates have been loaded into the database, the check passes without issue. If not, a notification should be generated.

The notification was defined with malformed json, causing the following fatal error if triggered during setup:

`, or } expected while parsing object/hash, at character offset 176 (before "System > Templates" ...") at
/srv/ledgersmb/lib/LedgerSMB/Database/Change.pm line 336.`

The bug is corrected in this PR.