### PR TITLE
Fix 1.13 db changes

### DIFF
--- a/sql/changes/1.13/drop-inheritance-notes-translations.sql
+++ b/sql/changes/1.13/drop-inheritance-notes-translations.sql
@@ -44,7 +44,7 @@ select setval('journal_note_id_seq',
               false);
 
 
-drop table note;
+drop table note cascade;
 
 alter table account_heading_translation no inherit "translation";
 alter table account_translation no inherit "translation";

--- a/sql/changes/1.13/missing-fkeys.sql
+++ b/sql/changes/1.13/missing-fkeys.sql
@@ -76,7 +76,8 @@ select distinct language_code, 'created by migration'
       from partsgroup_translation
   ) lc
          left join "language" l on lc.language_code = l.code
- where l.code is null;
+ where l.code is null
+ and lc.language_code is not null;
 
 alter table account_heading_translation
   add foreign key (language_code) references language (code);


### PR DESCRIPTION
Fix for two db changes being introduced for 1.13.

Given this branch is still in active development, and not yet released, the 'broken' files
have not been preserved by copying with a `@1` suffix as we'd do for a production release. 
