### PR TITLE
1.12 fix upgrade check for financial report templates

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,10 @@
 Changelog for 1.12 Series
 Released 2024-12-14
 
+Changelog for 1.12.9
+* Fix check for financial report templates when upgrading pre-1.8 databases
+
+
 Changelog for 1.12.8
 * Fix non-posted transactions being included in Tax Forms (#8774)
 * Fix visual hint for non-posted payments on invoices and transactions (#8544)

--- a/sql/changes/1.8/notify-import-financial-report-templates.sql@1
+++ b/sql/changes/1.8/notify-import-financial-report-templates.sql@1
@@ -5,7 +5,7 @@
 
 select pg_notify(
   'upgrade.' || current_database(),
-  $json${"type":"feedback","content":"As of 1.8, the balance sheet and income statement templates used to generate downloaded documents, have been moved to the database. Please go to \"System > Templates\" and upload the templates provided in the templates/ directory. Until this action is completed, these reports are available only in the UI, but the download links will not work."}$json$)
+  $json${"type":"feedback","content":"As of 1.8, the balance sheet and income statement templates used to generate downloaded documents, have been moved to the database. Please go to "System > Templates" and upload the templates provided in the templates/ directory. Until this action is completed, these reports are available only in the UI, but the download links will not work.$json$)
  where (select count(*) from template) > 0
    and (not exists (select 1
                       from template


### PR DESCRIPTION
Backport fix for `sql/changes/1.8/notify-import-financial-report-templates.sql`
to 1.12