### PR TITLE
Fix orphan date separators in report filenames

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -422,12 +422,12 @@ sub output_name {
 
     $name = $name . '_' . $self->from_date->to_output
             if $self->can('from_date')
-               and defined $self->from_date
-               and defined $self->from_date->to_output;
+               and $self->from_date
+               and $self->from_date->to_output;
     $name = $name . '-' . $self->to_date->to_output
             if $self->can('to_date')
-               and defined $self->to_date
-               and defined $self->to_date->to_output;
+               and $self->to_date
+               and $self->to_date->to_output;
 
     return $name;
 }


### PR DESCRIPTION
For report file exports (csv, ods, pdf, etc), the auto-generated filename can include the date range for the report. The `-` and `_` date separators were being included regardless of whether a "from date" or "to date" applied.

This PR fixed `_-` being appended to the filenames of reports with no date range filter specified.