### PR TITLE
Fix route transition from ServerUI to native components

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -116,7 +116,7 @@ export default {
     },
     beforeRouteLeave() {
         this.machine.send("unloadContent");
-        return this.machine.current === "unloaded";
+        return this.machine.state.value === "unloaded";
     },
     created() {
         let maindiv = document.getElementById("maindiv");


### PR DESCRIPTION
The 'current' attribute is undefined (no idea how this ever worked?); go through `state.value` to determine the name of the state.