### PR TITLE
Fix inactive Login button on login page

### DIFF
--- a/UI/src/views/LoginPage.machines.js
+++ b/UI/src/views/LoginPage.machines.js
@@ -110,7 +110,7 @@ function createLoginMachine(initialContext) {
                     transitionFormValid("input", "ready"),
                     transitionFormInvalid("input", "invalid")
                 ),
-                final: state(),
+                final: state(transition("input", "ready")),
                 error: state()
             },
             (initialCtx) => initialCtx


### PR DESCRIPTION
When navigating back to the login page using the Back button, the Login button remains disabled, no matter what. The only way to activate it again is to reload the login page (F5 or Ctrl-R).

This change accepts any edit in the input fields to enable the Login button.
