### PR TITLE
Fix inactive Login button on login page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ commands:
             # when this file is changed, this key will fail
             - v1-yarn-deps-1.11-{{ checksum "UI/yarn.lock" }}
             # Find the most recently generated cache used from any branch
-            - v1-yarn-deps-1.11-
+            - v2-yarn-deps-1.11-
 
       - run:
           name: Make JS + README
@@ -146,7 +146,7 @@ commands:
             make readme
 
       - save_cache:
-          key: v1-yarn-1.11-deps-{{ checksum "UI/yarn.lock" }}
+          key: v2-yarn-1.11-deps-{{ checksum "UI/yarn.lock" }}
           paths:
             - UI/node_modules
 

--- a/UI/src/views/LoginPage.machines.js
+++ b/UI/src/views/LoginPage.machines.js
@@ -93,7 +93,7 @@ function createLoginMachine(initialContext) {
                 transitionFormValid("input", "ready"),
                 transitionFormInvalid("input", "invalid"),
             ),
-            final: state(),
+            final: state(transition("input", "ready")),
             error: state(),
         }, initialCtx => initialCtx),
         () => {},


### PR DESCRIPTION
When navigating back to the login page using the Back button, the Login button remains disabled, no matter what. The only way to activate it again is to reload the login page (F5 or Ctrl-R).

This change accepts any edit in the input fields to enable the Login button.