### PR TITLE
Add missing scenario name

### DIFF
--- a/xt/66-cucumber/11-ar/customer_history_report.feature
+++ b/xt/66-cucumber/11-ar/customer_history_report.feature
@@ -7,7 +7,7 @@ Background:
   Given a standard test company named "standard-customer-history"
     And a logged in admin user
 
-Scenario:
+Scenario: Run the Customer History report
  Given a vendor "Vendor A"
   When I navigate the menu and select the item at "AR > Reports > Customer History"
   Then I should see the Purchase History Search screen


### PR DESCRIPTION
Found due to 'uninitialized variable' warning in Pherkin
