### PR TITLE
Wrap Dojo Then-ables to ES6 Promise semantics for async/await integration

### DIFF
--- a/UI/src/components/ServerUI.js
+++ b/UI/src/components/ServerUI.js
@@ -1,5 +1,6 @@
 /** @format */
 
+import { promisify } from "@/promisify";
 import { h, inject, ref } from "vue";
 import { useI18n } from "vue-i18n";
 
@@ -75,7 +76,7 @@ export default {
 
             let d = registry.byId("errorDialog");
             d.set("content", errstr);
-            d.show();
+            await promisify(d.show());
         },
         _interceptClick(dnode) {
             let href = dnode.getAttribute("href");

--- a/UI/src/components/ServerUI.machines.js
+++ b/UI/src/components/ServerUI.machines.js
@@ -1,5 +1,6 @@
 /** @format */
 
+import { promisify } from "@/promisify";
 import {
     action,
     createMachine,
@@ -90,13 +91,7 @@ async function updateContent(ctx) {
 }
 
 async function parseContent(ctx) {
-    let maindiv = document.getElementById("maindiv");
-    let p = new Promise((resolve) => {
-        parser.parse(maindiv).then(() => {
-            resolve();
-        });
-    });
-    await p;
+    await promisify(parser.parse(document.getElementById("maindiv")));
     ctx.view.notify({
         title: ctx.options.done || ctx.view.$t("Loaded")
     });

--- a/UI/src/main-vue.js
+++ b/UI/src/main-vue.js
@@ -1,5 +1,6 @@
 /** @format */
 
+import { promisify } from "./promisify";
 import { createApp } from "vue";
 import router from "@/router";
 import { createI18n } from "vue-i18n";
@@ -68,13 +69,12 @@ if (document.getElementById("main")) {
     appName = "#login";
 } else {
     /* In case we're running a "setup.pl" page */
-    dojoParser.parse(document.body).then(() => {
-        const l = document.getElementById("loading");
-        if (l) {
-            l.style.display = "none";
-        }
-        document.body.setAttribute("data-lsmb-done", "true");
-    });
+    await promisify(dojoParser.parse(document.body));
+    const l = document.getElementById("loading");
+    if (l) {
+        l.style.display = "none";
+    }
+    document.body.setAttribute("data-lsmb-done", "true");
 }
 if (app) {
     app.config.compilerOptions.isCustomElement = (tag) =>

--- a/UI/src/promisify.js
+++ b/UI/src/promisify.js
@@ -1,0 +1,28 @@
+/** @format */
+
+export async function promisify(dojoThenable) {
+    return await new Promise((resolve, reject) => {
+        dojoThenable.then(
+            (value) => {
+                let rv = value;
+                if (value && typeof value.then === "function") {
+                    if (
+                        (value.isResolved && value.isResolved()) ||
+                        (value.isFulfilled && value.isFulfilled())
+                    ) {
+                        if (Object.hasOwn(value, "then")) {
+                            // 'un-thennable', to prevent infinite loop
+                            delete value.then;
+                        }
+                    } else {
+                        rv = promisify(value);
+                    }
+                }
+                resolve(rv);
+            },
+            (err) => {
+                reject(err);
+            }
+        );
+    });
+}

--- a/UI/src/views/LsmbMain.vue
+++ b/UI/src/views/LsmbMain.vue
@@ -2,6 +2,7 @@
 
 <script>
 /* global require */
+import { promisify } from "../promisify";
 import { provide, computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import Toaster from "@/components/Toaster";
@@ -93,7 +94,7 @@ export default {
             this.onMenuSelectedUpdate(newValue);
         }
     },
-    mounted() {
+    async mounted() {
         window.__lsmbLoadLink = (url) => {
             let tgt = url.replace(/^https?:\/\/(?:[^@/]+)/, "");
             if (!tgt.startsWith("/")) {
@@ -101,11 +102,11 @@ export default {
             }
             this.$router.push(tgt);
         };
-        let m = document.getElementById("main");
-        dojoParser.parse(m).then(() => {
-            document.body.setAttribute("data-lsmb-done", "true");
-        });
-        this.menuStore.initialize();
+        await Promise.all([
+            this.menuStore.initialize(),
+            promisify(dojoParser.parse(document.getElementById("main")))
+        ]);
+        document.body.setAttribute("data-lsmb-done", "true");
     },
     beforeUpdate() {
         document.body.removeAttribute("data-lsmb-done");


### PR DESCRIPTION
This change linearizes code for easier legibility and better integration with Vue 3 and Quasar. It also removes some of the surprize from using Dojo return values where both immediate and promise (thennable) return values are supported -- some Dojo return values are thennable, but resolved.
