### PR TITLE
Ensure Dojo parsing after loading the same route a second time

### DIFF
--- a/UI/src/components/ServerUI.machines.js
+++ b/UI/src/components/ServerUI.machines.js
@@ -77,10 +77,13 @@ function isOkResponse(ctx, { data }) {
 }
 
 async function updateContent(ctx) {
-    ctx.view.content = ctx.content;
+    ctx.view.content = "";
     let p = new Promise((resolve) => {
         ctx.view.$nextTick(() => {
-            resolve();
+            ctx.view.content = ctx.content;
+            ctx.view.$nextTick(() => {
+                resolve();
+            });
         });
     });
     await p;


### PR DESCRIPTION
When loading the same (menu) route twice (e.g. Preferences), the controls stop working, because they are unloaded from Dojo. They are supposed to be reloaded, but Dojo skips that step. Apparently, it knows the DOM subtree has already been parsed. To ensure correct handling, clear the content and reset the same content after Vue has established the empty content as new content, causing both Vue as well as Dojo to see the route's content as new and in need of processing.
