### PR TITLE
Make setup.pl schema path consistent for login and upgrade operations

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -907,6 +907,7 @@ sub upgrade {
 
     my $settings = $request->{_wire}->get( 'setup_settings' );
     my $auth_db = ($settings and $settings->{auth_db}) // 'postgres';
+    $database->{connect_data}->{options} = "-c search_path=$database->{schema},public";
     my $dbinfo = $database->get_info($auth_db);
     my $upgrade_type = "$dbinfo->{appname}/$dbinfo->{version}";
     my $locale = $request->{_locale};


### PR DESCRIPTION
When logging in to setup.pl, the `public` database schema is included in the search path, after that configured in `ledgersmb.yaml`.

This patch is to use the same search path during the upgrade operation, where previously only the configuration file schema was used.

Previously a database created in the `public` schema would be offered for upgrade, but then the upgrade would fail with a cryptic error `Upgrade workflow error: no next step for ''`.

Now a more relevant error is displayed, indicating that the schema set in `ledgersmb.yaml` does not exist in the current database.
