### PR TITLE
1.11 fix #8843 AP/AR Batch Import screen typo

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,10 @@
 Changelog for 1.11 Series
 Released 2023-10-03
 
+Changelog for 1.11.25
+* Fix typo on AR/AP Import Batch screen (#8843)
+
+
 Changelog for 1.11.24
 * Fix entity search by country
 

--- a/UI/src/views/ImportCSV-AA-Batch.vue
+++ b/UI/src/views/ImportCSV-AA-Batch.vue
@@ -53,7 +53,7 @@ export default {
               <dd></dd>
               <dt>ap</dt>
               <dd></dd>
-              <dt>escription</dt>
+              <dt>description</dt>
               <dd></dd>
               <dt>invnumber</dt>
               <dd></dd>


### PR DESCRIPTION
Backport fix for typo on AP/AR Batch Import Screen.
No change to functionality.