### PR TITLE
Fix overpayments 1.12

### DIFF
--- a/UI/payments/use_overpayment2.html
+++ b/UI/payments/use_overpayment2.html
@@ -177,6 +177,11 @@
                           id="entity_id_$i"
                           name="entity_id_$i"
                           value=data.entity_id } %]
+    [% PROCESS input element_data = {
+                          type="hidden"
+                          id="entity_name_$i"
+                          name="entity_name_$i"
+                          value=data.entity_name } %]
    </td>
    <td align="center"> [% data.invoice_date %]
     [% PROCESS input element_data = {
@@ -216,72 +221,6 @@
                                                                           name="checkbox_$i" } %]</td>
   </tr>
   [% END -%]
-  [% FOREACH data IN avble_invoices; # Loop through selected entity invoices
-         IF not data.amount; data.amount = 0; END; -%]
-  [% i = i + 1; j = i % 2; alterning_style = "listrow$j" -%]
-  <tr class="[% alterning_style %]">
-   <td align="center"> <a href="[% data.invoice.href %]">[% data.invoice.number %]</a>
-    [% PROCESS input element_data = {
-                          type="hidden"
-                          id="invnumber_$i"
-                          name="invnumber_$i"
-                          value=data.invoice.number } %]
-    [% PROCESS input element_data = {
-                          type="hidden"
-                          id="invoice_id_$i"
-                          name="invoice_id_$i"
-                          value=data.invoice.id } %]
-    [% PROCESS input element_data = {
-                          type="hidden"
-                          id="is_invoice_$i"
-                          name="invoice_id_$i"
-                          value=data.invoice.is_invoice } %]
-   </td>
-   <td align="center"> [% data.entity_name %]
-    [% PROCESS input element_data = {
-                          type="hidden"
-                          id="entity_id_$i"
-                          name="entity_id_$i"
-                          value=data.entity_id  } %]
-   </td>
-   <td align="center"> [% data.invoice_date %]
-    [% PROCESS input element_data = {
-                          type="hidden"
-                          id="invoice_date_$i"
-                          name="invoice_date_$i"
-                          value=data.invoice_date } %]
-   </td >
-   <td align="right"> [% data.due %]
-    [% PROCESS input element_data = {
-                          type="hidden"
-                          id="due_$i"
-                          name="due_$i"
-                          value=data.due } %]
-   </td>
-   [% IF data.repeated_invoice == 'true' -%]
-    <td align="center"> &nbsp; </td>
-   [% END -%]
-   <td align="center"> [% data.selected_accno.ovp_accno %]
-    [% PROCESS input element_data = {
-                          type="hidden"
-                          id="selected_accno_$i"
-                          name="selected_accno_$i"
-                          value=data.selected_accno.id _ '--' _ data.selected_accno.ovp_accno
-                          } %]
-   </td>
-   <td align="center">
-    [% PROCESS input element_data = {
-                          name="amount_$i"
-                          id="amount_$i"
-                          value=data.amount } %]
-    [% subtotal_inv = subtotal_inv + data.amount -%]
-   </td>
-   <td align="center">
-          [% PROCESS input element_data = {
-                                type="checkbox"
-                                name="checkbox_$i" } %]</td>
-  </tr>
-  [% END -%]
   [% i = i + 1; j = i % 2; alterning_style = "listrow$j" -%]
   <tr class="[% alterning_style %]">
    <td align="center">[% PROCESS input element_data = {
@@ -301,8 +240,7 @@
                                 value_attr = 'value'
                                 text_attr = 'name'
                                 options = vc_list
-                                default_values = [ request.new_entity_id ]
-                                default_blank = 1
+                                default_values = []
            } %]
    </td>
    <td align="center">N/A</td>

--- a/UI/payments/use_overpayment2.html
+++ b/UI/payments/use_overpayment2.html
@@ -186,7 +186,7 @@
                           value=data.invoice_date  } %]
    </td>
    <td align="right"> [% data.applied_due -%]
-    [% PROCESS input element_data  {
+    [% PROCESS input element_data = {
                           type="hidden"
                           id="due_$i"
                           name="due_$i"
@@ -231,6 +231,11 @@
                           id="invoice_id_$i"
                           name="invoice_id_$i"
                           value=data.invoice.id } %]
+    [% PROCESS input element_data = {
+                          type="hidden"
+                          id="is_invoice_$i"
+                          name="invoice_id_$i"
+                          value=data.invoice.is_invoice } %]
    </td>
    <td align="center"> [% data.entity_name %]
     [% PROCESS input element_data = {
@@ -380,6 +385,11 @@
    </td>
   </tr>
  </table>
+     [% PROCESS input element_data = {
+                          type="hidden"
+                          id="count"
+                          name="count"
+                          value=i } %]
  [% FOREACH item IN hiddens -%]
    [% INCLUDE input element_data=item %]
  [% END -%]

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1673,7 +1673,7 @@ sub use_overpayment2 {
 
     #list all the vendor/customer
     @vc_info = $Payment->get_entity_credit_account();
-    push @vclist = {}; # inserting a blank at the start
+    push @vc_info, {}; # inserting a blank at the start
     for my $ref (0 .. $#vc_info) {
         my ($name) = split(/:/, $vc_info[$ref]->{name});
         push @vc_list, { value            => $vc_info[$ref]->{id},
@@ -1749,7 +1749,6 @@ sub use_overpayment2 {
         $Selected_entity =
             LedgerSMB::DBObject::Payment->new(%$Payment);
         $Selected_entity->{invnumber} = $request->{new_invoice} ;
-        my $id = $Payment->{new_entity_id};
         my ($id,$name,$vc_discount_accno) =
             split(/--/, $request->{new_entity_id});
         my ($ovp_chart_id, $ovp_selected_accno) =
@@ -1775,7 +1774,7 @@ sub use_overpayment2 {
                     invoice       => {
                         number     => $ref->{invnumber},
                         id         => $ref->{invoice_id},
-                        is_invoice => $ref->{invoice}
+                        is_invoice => $ref->{invoice},
                         href       => $uri },
                     entity_name       => $n_name,
                     vc_discount_accno => $vc_discount_accno,

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -2031,8 +2031,8 @@ sub post_overpayment {
     for my $key (keys %entity_list)
     {
         my $list_key = $entity_list{$key};
-        for my $field (qw(amount cash_account_id source memo transaction_id
-                          ovp_payment_id)) {
+        # CT:  This logic should be eliminated once fixes are in master and 1.12
+        for my $field (qw(amount cash_account_id source memo transaction_id)) {
             $list_key->{$field} =
                 $list_key->{"array_$field"};
         }

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1646,8 +1646,8 @@ sub use_overpayment2 {
             $ui_exchangerate = {
                 id => 'exrate',
                 name => 'exrate',
-                value => "$exchangerate", 
-                text =>  "$exchangerate" 
+                value => "$exchangerate",
+                text =>  "$exchangerate"
             };
         } else {
             $ui_exchangerate = {
@@ -1874,7 +1874,7 @@ sub post_overpayment {
     for my $count (1 .. $request->{count})
     {
 
-        if ($request->{"checkbox_$count"} or !$request->{"amount_$count"})
+        if ($request->{"checkbox_$count"} or not $request->{"amount_$count"})
         {
             $count++;
             next;

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1609,6 +1609,7 @@ sub use_overpayment2 {
     my @hiddens;
     my $vc_entity_info;
     my $default_currency;
+    my $n_name;
     my %amount_to_be_used;
     my $count;
     my $warning = $Payment->{'warning'};
@@ -1678,6 +1679,7 @@ sub use_overpayment2 {
         push @vc_list, { value            => $vc_info[$ref]->{id},
                          name            => $name,
                          vc_discount_accno => $vc_info[$ref]->{discount}};
+        my $n_name = $name if $vc_info[$ref]->{id} = $Payment->{new_entity_id};
     }
 
 
@@ -1775,7 +1777,7 @@ sub use_overpayment2 {
                         id         => $ref->{invoice_id},
                         is_invoice => $ref->{invoice}
                         href       => $uri },
-                    entity_name       => $name,
+                    entity_name       => $n_name,
                     vc_discount_accno => $vc_discount_accno,
                     entity_id        => qq|$Selected_entity->{entity_credit_id}--$name|,
                     invoice_date        => $ref->{invoice_date},

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1610,8 +1610,6 @@ sub use_overpayment2 {
     my $vc_entity_info;
     my $default_currency;
     my %amount_to_be_used;
-    my %ovp_repeated_invoices;
-    my %invoice_id_amount_to_pay;
     my $count;
     my $warning = $Payment->{'warning'};
 
@@ -1638,19 +1636,17 @@ sub use_overpayment2 {
     $default_currency = $Payment->get_default_currency();
 
 
-    # WE NEED TO KNOW IF WE ARE USING A CURRENCY THAT NEEDS AN EXCHANGERATE
     if ($default_currency ne $request->{curr} ) {
-        # DOES THE CURRENCY IN USE HAS AN EXCHANGE RATE?, IF SO
-        # WE MUST SET THE VALUE, OTHERWISE THE UI WILL HANDLE IT
         $exchangerate = $Payment->{exrate};
 
         if ($exchangerate) {
+            # Double quotes are needed due to interactions of TemplateTooklit
+            # and Math::BigFloat and subtypes
             $ui_exchangerate = {
                 id => 'exrate',
                 name => 'exrate',
-                value => "$exchangerate", #THERE IS A STRANGE BEHAVIOUR WITH THIS,
-                text =>  "$exchangerate"  #IF I DONT USE THE DOUBLE QUOTES, IT WILL PRINT THE ADDRESS
-                    #THERE MUST BE A REASON FOR THIS, I MUST RETURN TO IT LATER
+                value => "$exchangerate", 
+                text =>  "$exchangerate" 
             };
         } else {
             $ui_exchangerate = {
@@ -1659,8 +1655,7 @@ sub use_overpayment2 {
         }
     }
     else {
-        # WE MUST SET EXCHANGERATE TO 1 FOR THE MATHS SINCE WE
-        # ARE USING THE DEFAULT CURRENCY
+        # Default currency
         $exchangerate = 1;
         $ui_exchangerate = {
             id => 'exrate',
@@ -1677,6 +1672,7 @@ sub use_overpayment2 {
 
     #list all the vendor/customer
     @vc_info = $Payment->get_entity_credit_account();
+    push @vclist = {}; # inserting a blank at the start
     for my $ref (0 .. $#vc_info) {
         my ($name) = split(/:/, $vc_info[$ref]->{name});
         push @vc_list, { value            => $vc_info[$ref]->{id},
@@ -1689,84 +1685,48 @@ sub use_overpayment2 {
     #lets see which invoice do we have printed
     while ($Payment->{"entity_id_$count"})
     {
+        # we should rename the checkbox to remove_ or ignore_
         if ($Payment->{"checkbox_$count"})
         {
             $count++;
             next;
         }
 
-        # the "ovp_repeated_invoices" hash will store the conbination
-        # of invoice id and overpayment account, if this convination has
-        # already printed do not print it again
-        $ovp_repeated_invoices{$Payment->{"invoice_id_$count"}} //= {};
+        $ui_to_use_subtotal += $Payment->{"amount_$count"};
 
-        my $ovp_inv_payment =
-                $ovp_repeated_invoices{$Payment->{"invoice_id_$count"}};
-
-        if ($ovp_inv_payment->{$Payment->{"selected_accno_$count"}}
-            != $Payment->{"selected_accno_$count"}) {
-
-            $ovp_inv_payment->{$Payment->{"selected_accno_$count"}} =
-                $Payment->{"selected_accno_$count"};
-
-            # the "repeated invoice" flag will check if this invoice has
-            # already been printed, if it does, do not print the apply
-            # discount checkbox in the UI
-
-            if (! $ovp_inv_payment->{repeated_invoice}){
-                $ovp_inv_payment->{optional_discount} =
-                    $Payment->{"optional_discount_$count"};
-                $ovp_inv_payment->{repeated_invoice} = 'false';
-            } else{
-                $ovp_inv_payment->{repeated_invoice} = 'true';
-            }
-
-            $ui_to_use_subtotal += $Payment->{"amount_$count"};
-
-            my ($id,$name) = split(/--/, $Payment->{"entity_id_$count"});
-            my ($ovp_chart_id, $ovp_selected_accno) =
+        my ($id,$name) = split(/--/, $Payment->{"entity_id_$count"});
+        my ($ovp_chart_id, $ovp_selected_accno) =
                 split(/--/, $Payment->{"selected_accno_$count"});
-            my $applied_due =
-                ($ovp_inv_payment->{optional_discount})
-                ? $Payment->{"due_$count"}
-            : $Payment->{"due_$count"} + $Payment->{"discount_$count"};
+        my $applied_due = $Payment->{"due_$count"};
 
-            $amount_to_be_used{"$ovp_selected_accno"} +=
-                $Payment->{"amount_$count"};
-            # this hash will keep track of the amount to be paid of an
-            # specific invoice_id, this amount could not be more than the
-            # due of that invoice.
-            $invoice_id_amount_to_pay{qq|$Payment->{"invoice_id_$count"}|} +=
-                $Payment->{"amount_$count"};
-            if($invoice_id_amount_to_pay{qq|$Payment->{"invoice_id_$count"}|}
-               > $applied_due) {
-                $warning .= $locale->text('The amount of the invoice number').qq| $Payment->{"invnumber_$count"} |.$locale->text('is lesser than the amount to be paid').qq|\n|;
-            }
-            ###################################################################
-            #    ojo no me gusta como esta implementado
-            ###################################################################
-            if($Payment->{"amount_$count"} < 0){
-                $warning .= $locale->text('The amount of the invoice number').qq| $Payment->{"invnumber_$count"} |.$locale->text('is lesser than 0').qq|\n|;
-            }
-            #lets make the href for the invoice
-            my $uri = $Payment->script();
-            $uri .= '.pl?__action=edit&id='
-                . $Payment->{"invoice_id_$count"} . '&login='
-                . $request->{login};
+        $amount_to_be_used{$ovp_selected_accno} += $Payment->{"amount_$count"};
 
-            push @ui_selected_inv,
+        if($Payment->{"amount_$count"} > $applied_due) {
+                $warning .= $locale->text('The amount of the invoice number [_1] is less than the amount to be paid.', $Payment->{"invnumber_$count"});
+        }
+
+        if($Payment->{"amount_$count"} < 0){
+            $warning .= $locale->text('The amount of the invoice number [_1] is less than 0', $Payment->{"invnumber_$count"});
+        }
+
+        #lets make the href for the invoice
+        my $uri = $Payment->script($Payment->{"is_invoice_$count"});
+        $uri .= '.pl?__action=edit&id='
+            . $Payment->{"invoice_id_$count"} . '&login='
+            . $request->{login};
+
+        push @ui_selected_inv,
             {
                 invoice           => {
-                    number => $Payment->{"invnumber_$count"},
-                    id     => $Payment->{"invoice_id_$count"},
-                    href   => $uri },
+                    number     => $Payment->{"invnumber_$count"},
+                    id         => $Payment->{"invoice_id_$count"},
+                    is_invoice => $Payment->{"is_invoice_$count"},
+                    href       => $uri },
                 entity_name        => $name,
                 entity_id          => $Payment->{"entity_id_$count"},
                 vc_discount_accno     => $Payment->{"vc_discount_accno_$count"},
                 invoice_date       => $Payment->{"invoice_date_$count"},
                 applied_due        => $applied_due,
-                optional_discount => $ovp_inv_payment->{optional_discount},
-                repeated_invoice  => $ovp_inv_payment->{repeated_invoice},
                 due                => $Payment->{"due_$count"},
                 discount        => $Payment->{"discount_$count"},
                 selected_accno    => {
@@ -1774,14 +1734,12 @@ sub use_overpayment2 {
                     ovp_accno => $ovp_selected_accno },
                 amount             => $Payment->{"amount_$count"}
             } unless ($seen_invoices{$Payment->{"invoice_id_$count"}}++);
-        }
-        $count++;
     }
+    $count++;
 
 
     #lets search which available invoice do we have for the selected entity
-    if (($Payment->{new_entity_id} != $Payment->{entity_credit_id})
-        && ! $Payment->{new_checkbox})
+    if ($Payment->{new_entity_id})
     {
         $request->{entity_credit_id} = $Payment->{new_entity_id};
         # lets create an object who has the entity_credit_id of the
@@ -1800,60 +1758,36 @@ sub use_overpayment2 {
         @avble_invoices = $Selected_entity->get_open_invoice();
         for my $ref (@avble_invoices) {
             # Checking for repeated invoices
-            my $ovp_rep_invoice = $ovp_repeated_invoices{$ref->{invoice_id}};
-
-            if ($ovp_rep_invoice->{$Selected_entity->{new_accno}}
-                != $Selected_entity->{new_accno}){
-                $ovp_rep_invoice->{$Selected_entity->{new_accno}} =
-                    $Selected_entity->{new_accno};
-
-                # the "repeated invoice" flag will check if this invoice has
-                # already been printed, if it does, do not print the apply
-                # discount checkbox in the UI
-                if (!$ovp_rep_invoice->{repeated_invoice}){
-                    $ovp_rep_invoice->{repeated_invoice} = 'false';
-                } else{
-                    $ovp_rep_invoice->{repeated_invoice} = 'true';
-                }
-
-
-                if (!$ovp_rep_invoice->{optional_discount}){
-                    $ovp_rep_invoice->{optional_discount} = 'true';
-                }
-
-                $invoice_id_amount_to_pay{qq|$avble_invoices[$ref]->{invoice_id}|} +=
-                    $Selected_entity->{new_amount};
-                $ui_to_use_subtotal += $Selected_entity->{new_amount};
-                $amount_to_be_used{$ovp_selected_accno} +=
+            $ui_to_use_subtotal += $Selected_entity->{new_amount};
+            $amount_to_be_used{$ovp_selected_accno} +=
                     $Selected_entity->{new_amount};
 
                 #lets make the href for the invoice
-                my $uri = $Payment->script();
-                $uri .= '.pl?__action=edit&id='. $ref->{invoice_id}
+            my $uri = $Payment->script($ref->{invoice});
+            $uri .= '.pl?__action=edit&id='. $ref->{invoice_id}
                 . '&login=' . $request->{login};
 
-                my $name = $ref->{legal_name};
+            my $name = $ref->{legal_name};
 
-                push @ui_avble_invoices, {
+            push @ui_selected_inv, {
                     invoice       => {
-                        number => $ref->{invnumber},
-                        id     => $ref->{invoice_id},
-                        href   => $uri },
+                        number     => $ref->{invnumber},
+                        id         => $ref->{invoice_id},
+                        is_invoice => $ref->{invoice}
+                        href       => $uri },
                     entity_name       => $name,
                     vc_discount_accno => $vc_discount_accno,
                     entity_id        => qq|$Selected_entity->{entity_credit_id}--$name|,
-                    invoice_date        => $avble_invoices[$ref]->{invoice_date},
+                    invoice_date        => $ref->{invoice_date},
                     applied_due       => $Payment->{"due_$count"},
-                    repeated_invoice  => $ovp_rep_invoice->{repeated_invoice},
                     due            => $ref->{due},
                     discount          => $ref->{discount},
                     selected_accno    => {
                         id       => $ovp_chart_id,
                         ovp_accno => $ovp_selected_accno },
                     amount        => $Selected_entity->{new_amount}
-                } unless ($seen_invoices{$ref}->{invoice_id}++);
-             }
-        }
+            } unless ($seen_invoices{$ref->{invoice_id}}++);
+         }
     }
 
 

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1784,7 +1784,7 @@ sub use_overpayment2 {
         # selected entity
         $Selected_entity =
             LedgerSMB::DBObject::Payment->new(%$Payment);
-        $Selected_entity->{invnumber} = $Selected_entity->{new_invoice} ;
+        $Selected_entity->{invnumber} = $request->{new_invoice} ;
 
         my ($id,$name,$vc_discount_accno) =
             split(/--/, $Selected_entity->{new_entity_id});

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1882,6 +1882,7 @@ sub post_overpayment {
             next;
         }
 
+        # complication -- this does not set $entity_name
         my ($entity_id, $entity_name) =
             split(/--/, $request->{"entity_id_$count"});
         my ($ovp_chart_id, $ovp_selected_accno) =
@@ -2031,7 +2032,7 @@ sub post_overpayment {
         my $list_key = $entity_list{$key};
         for my $field (qw(amount cash_account_id source memo transaction_id
                           ovp_payment_id)) {
-            $list_key->{$key} =
+            $list_key->{$field} =
                 $list_key->{"array_$field"};
         }
 

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1876,7 +1876,7 @@ sub post_overpayment {
     while ($request->{"entity_id_$count"})
     {
 
-        if ($request->{"checkbox_$count"})
+        if ($request->{"checkbox_$count"} or !$request->{"amount_$count"})
         {
             $count++;
             next;

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1871,8 +1871,7 @@ sub post_overpayment {
     #let's store all unused invoice in entity_unused_ovp, it will be
 
     #lets see which invoice do we have, and reorganize them by vendor/customer
-    my $count=1;
-    while ($request->{"entity_id_$count"})
+    for my $count (1 .. $request->{count})
     {
 
         if ($request->{"checkbox_$count"} or !$request->{"amount_$count"})
@@ -1966,11 +1965,11 @@ sub post_overpayment {
 
         #Let's fill all our entity invoice info, if it has a discount, store it into the discount accno
         if ($list_key->{"optional_discount_$count"} && $list_key->{"amount_$count"} == $list_key->{"due_$count"}) {
-            push @{$list_key->{array_amount}}, $list_key->{"discount_$count"};
-            push @{$list_key->{array_cash_account_id}}, $list_key->{"vc_discount_accno_$count"};
-            push @{$list_key->{array_source}}, undef;
-            push @{$list_key->{array_transaction_id}}, $list_key->{"invoice_id_$count"};
-            push @{$list_key->{array_memo}}, $locale->text('Applied discount by an overpayment');
+            push @{$list_key->{amount}}, $list_key->{"discount_$count"};
+            push @{$list_key->{cash_account_id}}, $list_key->{"vc_discount_accno_$count"};
+            push @{$list_key->{source}}, undef;
+            push @{$list_key->{transaction_id}}, $list_key->{"invoice_id_$count"};
+            push @{$list_key->{memo}}, $locale->text('Applied discount by an overpayment');
             push @{$list_key->{ovp_payment_id}}, undef;
         }
 
@@ -1989,13 +1988,13 @@ sub post_overpayment {
             }
             if (@{$entity_unused_ovp{$ovp_chart_id}->{unused_overpayment}}[$unused_ovp_index]->{available} >= $tmp_ovp_amount)
             {
-                push @{$list_key->{array_amount}}, $tmp_ovp_amount;
-                push @{$list_key->{array_cash_account_id}}, $ovp_chart_id;
-                push @{$list_key->{array_source}},
+                push @{$list_key->{amount}}, $tmp_ovp_amount;
+                push @{$list_key->{cash_account_id}}, $ovp_chart_id;
+                push @{$list_key->{source}},
                 $locale->text('use of an overpayment');
-                push @{$list_key->{array_transaction_id}},
+                push @{$list_key->{transaction_id}},
                 $list_key->{"invoice_id_$count"};
-                push @{$list_key->{array_memo}}, undef;
+                push @{$list_key->{memo}}, undef;
                 push @{$list_key->{ovp_payment_id}},
                 @{$entity_unused_ovp{$ovp_chart_id}->{unused_overpayment}}[$unused_ovp_index]->{payment_id};
 
@@ -2009,11 +2008,11 @@ sub post_overpayment {
             } else{
                 $tmp_ovp_amount -= @{$entity_unused_ovp{$ovp_chart_id}->{unused_overpayment}}[$unused_ovp_index]->{available};
 
-                push @{$list_key->{array_amount}}, @{$entity_unused_ovp{$ovp_chart_id}->{unused_overpayment}}[$unused_ovp_index]->{available};
-                push @{$list_key->{array_cash_account_id}}, $ovp_chart_id;
-                push @{$list_key->{array_source}}, $locale->text('use of an overpayment');
-                push @{$list_key->{array_transaction_id}}, $list_key->{"invoice_id_$count"};
-                push @{$list_key->{array_memo}}, undef;
+                push @{$list_key->{amount}}, @{$entity_unused_ovp{$ovp_chart_id}->{unused_overpayment}}[$unused_ovp_index]->{available};
+                push @{$list_key->{cash_account_id}}, $ovp_chart_id;
+                push @{$list_key->{source}}, $locale->text('use of an overpayment');
+                push @{$list_key->{transaction_id}}, $list_key->{"invoice_id_$count"};
+                push @{$list_key->{memo}}, undef;
                 push @{$list_key->{ovp_payment_id}}, @{$entity_unused_ovp{$ovp_chart_id}->{unused_overpayment}}[$unused_ovp_index]->{payment_id};
 
                 $unused_ovp_index = $entity_unused_ovp{$ovp_chart_id}->{unused_ovp_index}++;
@@ -2029,11 +2028,6 @@ sub post_overpayment {
     for my $key (keys %entity_list)
     {
         my $list_key = $entity_list{$key};
-        # CT:  This logic should be eliminated once fixes are in master and 1.12
-        for my $field (qw(amount cash_account_id source memo transaction_id)) {
-            $list_key->{$field} =
-                $list_key->{"array_$field"};
-        }
 
         $entity_list{$key}->post_payment();
     }

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1868,6 +1868,7 @@ sub post_overpayment {
     # be used to pay the invoices
     my %entity_unused_ovp;
     my $unused_ovp_index;
+    $request->{exchangerate} = $request->{exrate} // 1;
 
     #let's store all unused invoice in entity_unused_ovp, it will be
 

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1675,20 +1675,19 @@ sub use_overpayment2 {
     @vc_info = $Payment->get_entity_credit_account();
     push @vc_info, {}; # inserting a blank at the start
     for my $ref (0 .. $#vc_info) {
-        my ($name) = split(/:/, $vc_info[$ref]->{name});
+        my ($vcname) = split(/:/, $vc_info[$ref]->{name});
         push @vc_list, { value            => $vc_info[$ref]->{id},
-                         name            => $name,
+                         name            => $vcname,
                          vc_discount_accno => $vc_info[$ref]->{discount}};
-        my $n_name = $name if $vc_info[$ref]->{id} = $Payment->{new_entity_id};
+        $n_name = $vcname if $vc_info[$ref]->{id} == $Payment->{new_entity_id};
     }
 
 
-    $count=1;
     #lets see which invoice do we have printed
-    while ($Payment->{"entity_id_$count"})
+    for my $count(1 .. $request->{count})
     {
         # we should rename the checkbox to remove_ or ignore_
-        if ($Payment->{"checkbox_$count"})
+        if ($Payment->{"checkbox_$count"} or not $Payment->{"entity_id_$count"})
         {
             $count++;
             next;
@@ -1724,7 +1723,7 @@ sub use_overpayment2 {
                     id         => $Payment->{"invoice_id_$count"},
                     is_invoice => $Payment->{"is_invoice_$count"},
                     href       => $uri },
-                entity_name        => $name,
+                entity_name        => $Payment->{"entity_name_$count"},
                 entity_id          => $Payment->{"entity_id_$count"},
                 vc_discount_accno     => $Payment->{"vc_discount_accno_$count"},
                 invoice_date       => $Payment->{"invoice_date_$count"},
@@ -1780,7 +1779,7 @@ sub use_overpayment2 {
                     vc_discount_accno => $vc_discount_accno,
                     entity_id        => qq|$Selected_entity->{entity_credit_id}--$name|,
                     invoice_date        => $ref->{invoice_date},
-                    applied_due       => $Payment->{"due_$count"},
+                    applied_due       => $ref->{due},
                     due            => $ref->{due},
                     discount          => $ref->{discount},
                     selected_accno    => {

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -518,8 +518,9 @@ Returns the script to direct a transaction to (currently ar, ap, is, or ir)
 =cut
 
 sub script {
-    my ($self) = @_;
-    if ($self->{invoice}) {
+    my ($self, $invoice) = @_;
+    $invoice //= $self->{invoice};
+    if ($invoice) {
        return $self->{account_class} == 1 ? 'ir' : 'is';
     }
     else {

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -507,6 +507,27 @@ sub get_payment_detail_data {
     return;
 }
 
+=over
+
+=item script()
+
+Returns the script to direct a transaction to (currently ar, ap, is, or ir)
+
+=back
+
+=cut
+
+sub script {
+    my ($self) = @_;
+    if ($self->{invoice}) {
+       return $self->{account_class} == 1 ? 'ir' : 'is';
+    }
+    else {
+       return $self->{account_class} == 1 ? 'ap' : 'ar';
+    }
+}
+
+
 =item post_bulk($data)
 
 This function posts the payments in bulk.


### PR DESCRIPTION
This fixes all immediately known bugs with using overpayments/prepayments.

Please note -- there are two cases where current translation of strings is broken by this patch.  This is because there were two uses of translation which concatenated variables and then concatenated further translated strings.  This is fundamentally incorrect and leads to broken translations even without these changes.  I am adding comments in line to point these out.  If the consensus is better not to backport these, I will revert those lines specifically.