### PR TITLE
COGS repairs after fixing allocated numbers

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -10,7 +10,7 @@ requires 'CGI::Emulate::PSGI';
 requires 'CGI::Parse::PSGI';
 requires 'Config::IniFiles';
 requires 'Cookie::Baker', '0.10'; # for 'samesite' attribute
-requires 'DBD::Pg', '3.3.0';
+requires 'DBD::Pg', '3.5.0';      # Due to being able to escape '?' placeholders
 requires 'DBI', '1.635';
 requires 'Data::UUID';
 requires 'DateTime';

--- a/lib/LedgerSMB/Admin/Command/upgrade.pm
+++ b/lib/LedgerSMB/Admin/Command/upgrade.pm
@@ -39,6 +39,8 @@ sub run {
 
     if (!$modules_only) {
         die 'Non-modules-only modes not implemented yet!';
+        # TODO: When we *do* implement the regular upgrades,
+        # remember to '$db->run_postupgrade_hooks'
     }
     my $connect_data = {
         $self->config->get('connect_data')->%*,

--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -789,10 +789,7 @@ sub run_postupgrade_hooks {
     while (my $hook = $sth->fetchrow_hashref('NAME_lc')) {
         my $data = $json->decode( $hook->{value} );
         if (not exists $postupgrade_actions{$data->{action}}) {
-            ...;
-            # TODO: report the correct error here...
-
-            next; # skip to the next upgrade hook when this one failed
+            die $self->logger->error("Post-upgrade action '$data->{action}' not defined");
         }
 
         my $action_module = $postupgrade_actions{$data->{action}};

--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -41,6 +41,7 @@ use DBI;
 use File::Spec;
 use File::Temp;
 use JSON::PP;
+use Module::Runtime qw( use_module );
 use PGObject::Util::DBAdmin v1.6.2;
 use Scope::Guard;
 use XML::LibXML;
@@ -55,6 +56,8 @@ use LedgerSMB::Database::Loadorder;
 
 our $VERSION = '1.2';
 
+# en/decode in-memory data that's already correct "internal Unicode"; not UTF-8
+my $json = JSON::PP->new->utf8(0);
 
 
 around BUILDARGS => sub {
@@ -750,6 +753,60 @@ sub create_and_load {
 }
 
 
+=head2 $db->run_postupgrade_hooks()
+
+This routine runs upgrade hooks registered during upgrade. Upgrade hooks
+allow parts of the upgrade process to register processing to be done once
+the upgrade is done, meaning the schema and modules are all up-to-date.
+
+=cut
+
+my %postupgrade_actions = (
+    'cogs-allocation'         => 'LedgerSMB::Database::PostUpgrade::CogsAllocation',
+    'cogs-allocation-cleanup' => 'LedgerSMB::Database::PostUpgrade::CogsAllocationCleanup',
+    );
+
+sub run_postupgrade_hooks {
+    my ($self) = @_;
+
+    my $dbh = $self->connect(
+        {
+            PrintError => 0,
+            AutoCommit => 0,
+            RaiseError => 0
+        });
+    my $sth = $dbh->prepare(<<~'SQL') or die $dbh->errstr;
+        SELECT *
+          FROM defaults
+         WHERE setting_key LIKE 'post-upgrade-run:%'
+               AND (NOT value::jsonb \? 'run-after'
+                    OR (value::jsonb->>'run-after')::date < CURRENT_DATE)
+        SQL
+    my $dsh = $dbh->prepare(q{DELETE FROM defaults WHERE setting_key = ?})
+        or die $dbh->errstr;
+
+    $sth->execute or die $sth->errstr;
+    while (my $hook = $sth->fetchrow_hashref('NAME_lc')) {
+        my $data = $json->decode( $hook->{value} );
+        if (not exists $postupgrade_actions{$data->{action}}) {
+            ...;
+            # TODO: report the correct error here...
+
+            next; # skip to the next upgrade hook when this one failed
+        }
+
+        my $action_module = $postupgrade_actions{$data->{action}};
+        use_module($action_module)->run({ dbh => $dbh }, $data->{args});
+
+        # delete the hook
+        $dsh->execute( $hook->{setting_key} );
+    }
+
+    $dbh->commit;
+    $dbh->disconnect;
+    return undef;
+}
+
 =head2 $db->upgrade_modules($loadorder, $version)
 
 This routine upgrades modules as required with a patch release upgrade.
@@ -839,8 +896,6 @@ Returns an arrayref of hashes with the following keys:
 =back
 
 =cut
-
-my $json = JSON::PP->new;
 
 sub list_changes {
     my ($self, %args) = @_;

--- a/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
@@ -1,0 +1,92 @@
+
+use v5.36;
+use warnings;
+use experimental qw( signatures );
+
+package LedgerSMB::Database::PostUpgrade::CogsAllocation;
+
+=head1 NAME
+
+LedgerSMB::Database::PostUpgrade::CogsAllocation - Post-Upgrade reallocation of COGS
+
+=head1 SYNOPSIS
+
+
+
+=head1 DESCRIPTION
+
+
+
+=head1 METHODS
+
+=head2 $class->run( $context, $args )
+
+This class method expects a database handle C<dbh> in the C<$context>. Additionally,
+it expects a list of parts in C<$args->{parts_ids}> identifying the parts for which
+COGS might need adjustment.
+
+=cut
+
+sub run($class, $context, $args) {
+    my $parts_ids = $args->{parts_ids} // [];
+
+    my $dbh = $context->{dbh};
+    my ($last_entry) = $dbh->selectrow_array('SELECT max(entry_id) FROM acc_trans');
+
+    # COGS follows FIFO, so allocate oldest transdates and invoice IDs first
+    my $sth = $dbh->prepare(<<~'SQL') or die $dbh->errstr;
+      SELECT i.*
+        FROM invoice i
+             JOIN transactions t
+                  ON i.trans_id = t.id
+       WHERE t.approved
+             AND i.parts_id = ?
+             AND qty < 0
+             AND (qty + allocated) <> 0
+      ORDER BY t.transdate ASC, i.id ASC
+      SQL
+    my $rah = $dbh->prepare(<<~'SQL') or die $dbh->errstr;
+      SELECT cogs__add_for_ap_line(?, CURRENT_DATE)
+      SQL
+
+
+    foreach my $parts_id ($parts_ids->@*) {
+        $sth->execute( $parts_id )
+            or die $sth->errstr;
+
+        while (my $inv = $sth->fetchrow_hashref('NAME_lc')) {
+            $rah->execute($inv->{id})
+                or die $rah->errstr;
+
+            my ($allocated) = $rah->fetchrow_array();
+            die $rah->errstr if $rah->err;
+
+            last if $allocated == 0;
+        }
+    }
+
+
+    $dbh->do(
+        <<~'SQL',
+        UPDATE acc_trans
+           SET memo = 'Added due to COGS adjustment at database upgrade'
+         WHERE entry_id > ?
+        SQL
+        {}, # attrs
+        $last_entry)
+        or die $dbh->errstr;
+
+    return undef;
+}
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2025 The LedgerSMB Core Team
+
+This file is licensed under the GNU General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
+
+1;

--- a/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
@@ -15,7 +15,9 @@ LedgerSMB::Database::PostUpgrade::CogsAllocation - Post-Upgrade reallocation of 
 
 =head1 DESCRIPTION
 
-
+This post-upgrade action ensures that all available purchased parts are allocated to
+available sold parts as part of the COGS calculation. This post-processing is required
+after fixing the allocated numbers for COGS as done by C<sql/changes/1.11/cogs-allocation.sql>.
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
@@ -48,16 +48,29 @@ sub run($class, $context, $args) {
       ORDER BY t.transdate ASC, i.id ASC
       SQL
     my $rah = $dbh->prepare(<<~'SQL') or die $dbh->errstr;
-      SELECT cogs__add_for_ap_line(?, CURRENT_DATE)
+      SELECT cogs__add_for_ap_line(?, ?)
       SQL
 
+    # If there's no value in the defaults table, use "today"
+    # If the value in the defaults table is "NULL",
+    #  use the regular COGS posting logic
+    # If the value in the defaults table is a date,
+    #  post corrections on that specific date
+    my @date_setting = $dbh->selectrow_array(<<~'SQL');
+      SELECT "value"::date
+        FROM defailts
+       WHERE setting_key = 'migration:cogs-allocation-posting-date'
+      UNION ALL
+      SELECT CURRENT_DATE
+      SQL
+    die $dbh->errstr if $dbh->err;
 
     foreach my $parts_id ($parts_ids->@*) {
         $sth->execute( $parts_id )
             or die $sth->errstr;
 
         while (my $inv = $sth->fetchrow_hashref('NAME_lc')) {
-            $rah->execute($inv->{id})
+            $rah->execute($inv->{id}, $date_setting[0])
                 or die $rah->errstr;
 
             my ($allocated) = $rah->fetchrow_array();
@@ -66,7 +79,6 @@ sub run($class, $context, $args) {
             last if $allocated == 0;
         }
     }
-
 
     $dbh->do(
         <<~'SQL',
@@ -77,6 +89,10 @@ sub run($class, $context, $args) {
         {}, # attrs
         $last_entry)
         or die $dbh->errstr;
+    $dbh->do(<<~'SQL') or die $dbh->errstr;
+        DELETE FROM defaults
+              WHERE setting_key = 'migration:cogs-allocation-posting-date'
+        SQL
 
     return undef;
 }

--- a/lib/LedgerSMB/Database/PostUpgrade/CogsAllocationCleanup.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/CogsAllocationCleanup.pm
@@ -1,0 +1,47 @@
+
+use v5.36;
+use warnings;
+use experimental qw( signatures );
+
+package LedgerSMB::Database::PostUpgrade::CogsAllocationCleanup;
+
+=head1 NAME
+
+LedgerSMB::Database::PostUpgrade::CogsAllocationCleanup - Cleanup of backup tables created on upgrade
+
+=head1 SYNOPSIS
+
+
+
+=head1 DESCRIPTION
+
+
+
+=head1 METHODS
+
+=head2 $class->run( $context, $args )
+
+This class method expects a database handle C<dbh> in the C<$context>.
+
+=cut
+
+sub run($class, $context, $args) {
+    my $parts_ids = $args->{parts_ids} // [];
+
+    $context->{dbh}->do(q{DROP TABLE IF EXISTS invoice_before_cogs_allocation_fix})
+        or die $context->{dbh}->errstr;
+
+    return undef;
+}
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2025 The LedgerSMB Core Team
+
+This file is licensed under the GNU General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
+
+1;

--- a/lib/LedgerSMB/Database/PostUpgrade/CogsAllocationCleanup.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/CogsAllocationCleanup.pm
@@ -15,7 +15,9 @@ LedgerSMB::Database::PostUpgrade::CogsAllocationCleanup - Cleanup of backup tabl
 
 =head1 DESCRIPTION
 
-
+This post-upgrade action removes the C<invoice_before_cogs_allocation_fix> table which
+is created as part of the upgrade script in C<sql/changes/1.11/cogs-allocation.sql>. The
+upgrade script schedules this action to be run 5 years in the future.
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1639,6 +1639,7 @@ sub _rebuild_modules {
     $database->upgrade_modules('LOADORDER', $LedgerSMB::VERSION)
         or die 'Upgrade failed.';
 
+    $database->run_postupgrade_hooks;
 
     $logger->info('Completed database upgrade run ' . $database->upgrade_run_id);
     return;

--- a/sql/changes/1.11/cogs-allocation.sql
+++ b/sql/changes/1.11/cogs-allocation.sql
@@ -1,0 +1,182 @@
+/*
+  This file contains a fix to be run when ./sql/consistency/00050-cogs-allocated-consistency.sql
+  reports failed lines.
+ */
+
+
+create or replace function pg_temp.drop_ar_allocation(in_parts_id int, in_excess numeric)
+  returns numeric language plpgsql as
+  $$
+  DECLARE
+    t_inv RECORD;
+    correction NUMERIC;
+BEGIN
+  IF in_excess = 0 THEN
+    RETURN 0;
+  END IF;
+
+  FOR t_inv IN
+    SELECT i.*
+      FROM invoice i
+           JOIN transactions t
+                ON i.trans_id = t.id
+     WHERE i.allocated <> 0
+       AND i.qty > 0
+       AND t.approved
+     ORDER BY t.transdate DESC, i.id DESC
+  LOOP
+    -- AR 'allocated' numbers are negative!
+    correction := GREATEST(t_inv.allocated, in_excess);
+    UPDATE invoice
+       SET allocated = t_inv.allocated - correction
+     WHERE id = t_inv.id;
+
+    in_excess := in_excess - correction;
+    IF in_excess >= 0 THEN
+      RETURN 0;
+    END IF;
+  END LOOP;
+  RAISE WARNING 'Dropped all available ar allocation for part %; % remaining', in_parts_id, in_excess;
+  RETURN -1;
+END;
+  $$;
+
+
+create or replace function pg_temp.drop_ap_allocation(in_parts_id int, in_excess numeric)
+  returns numeric language plpgsql as
+  $$
+  DECLARE
+    t_inv RECORD;
+    correction NUMERIC;
+BEGIN
+  IF in_excess = 0 THEN
+    RETURN 0;
+  END IF;
+
+  FOR t_inv IN
+    SELECT i.*
+      FROM invoice i
+           JOIN transactions t
+                ON i.trans_id = t.id
+     WHERE i.allocated <> 0
+       AND i.qty < 0
+       AND t.approved
+     ORDER BY t.transdate DESC, i.id DESC
+  LOOP
+    -- AP 'allocated' numbers are positive!
+    correction := LEAST(t_inv.allocated, in_excess);
+    UPDATE invoice
+       SET allocated = t_inv.allocated - correction
+     WHERE id = t_inv.id;
+
+    in_excess := in_excess - correction;
+    IF in_excess <= 0 THEN
+      RETURN 0;
+    END IF;
+  END LOOP;
+  RAISE WARNING 'Dropped all available ap allocation for part %; % remaining', in_parts_id, in_excess;
+  RETURN -1;
+END;
+  $$;
+
+
+-- Start by fixing the cogs allocated amounts
+CREATE TEMPORARY TABLE allocated_balances AS
+  SELECT parts_id,
+         sum(case when qty<0 then allocated else 0 end) as allocated_purchased,
+         -1*sum(case when qty>0 then allocated else 0 end) as allocated_sold
+    FROM invoice i
+         JOIN transactions t
+              ON i.trans_id = t.id
+   WHERE t.approved
+  GROUP BY parts_id;
+
+-- Only store anything in this table if we're going to run the correction below
+-- Copying the entire invoice table is a bit overkill, but then again, using
+-- triggers is much more complex
+CREATE TABLE invoice_before_cogs_allocation_fix AS
+  SELECT *
+    FROM invoice
+   WHERE (select count(*)
+            from allocated_balances
+           where allocated_purchased <> allocated_sold) > 0;
+
+SELECT CASE WHEN allocated_purchased > allocated_sold THEN pg_temp.drop_ap_allocation(parts_id, allocated_purchased - allocated_sold)
+       ELSE pg_temp.drop_ar_allocation(parts_id, allocated_purchased - allocated_sold)
+       END
+  FROM allocated_balances
+ WHERE allocated_purchased <> allocated_sold;
+
+-- Delete the lines which were not changed
+DELETE FROM invoice_before_cogs_allocation_fix ibf
+ WHERE EXISTS (select 1
+                 from invoice i
+                where i.id = ibf.id
+                  and i.allocated = ibf.allocated);
+
+/*
+  In the degenerate case, we need to allocate COGS. Envision a scenario where a sales invoice has
+  been created at 450 units of a part, sold short (not in inventory). A purchase invoice is created
+  at 300 units. The purchase invoice is saved twice, allocating 450 units to the sales invoice (this bug).
+  This results in 150 units allocated in the purchase invoice and 150 unallocated.
+
+  When the above runs, the allocation in the sales invoice is reduced to 150 to align the purchased and
+  sold allocated balances, resulting in 300 units needing allocation in the sales invoice and 150 units
+  available for allocation in the purchase invoice.
+
+  Concluding: to fix COGS in this scenario, an adjustment of 150 units allocated to the sales invoice
+  is required, consuming all purchased units (and leaving another 150 units to be purchased and allocated
+  to the invoice at a later point in time).
+
+  Similarly, envision a scenario where a purchase invoice has been created at 450 units of a part and a
+  sales invoice has been created at 300 units. The sales invoice is saved twice, allocating 450 units in
+  the purchase invoice (but only allocating 150 units of the sales invoice).
+
+  When the above runs, the allocation in the purchase invoice is reduced to 150 to align the sold and
+  purchased allocated balances, resulting in 150 units in the sales invoice needing allocation (with
+  300 available from the purchase invoice).
+
+  Concluding: to fix COGS in this scenario, an adjustment of 150 units allocated to the sales invoice
+  is required, consuming 150 of the 300 available purchased units.
+
+
+  Both scenarios leave the cost of purchased units available and in need of allocation to sales invoices.
+  The routine cogs__add_for_ap_line() serves this purpose. For this COGS fix, we want a slightly different
+  version: the regular version posts COGS at the transaction date of the invoice; here, we want it to post
+  on "today" rather than the closest date possible to the posting date of the invoice.
+
+ */
+
+DO $$
+BEGIN
+  IF EXISTS (select 1 from invoice_before_cogs_allocation_fix) THEN
+    INSERT INTO defaults (setting_key, "value")
+       SELECT 'post-upgrade-run:cogs-allocation' AS setting_key,
+              jsonb_build_object('action', 'cogs-allocation',
+                                 'args', jsonb_build_object('parts_ids', jsonb_agg(parts_id)))
+         FROM allocated_balances;
+
+    INSERT INTO defaults (setting_key, "value")
+    VALUES ('post-upgrade-run:cogs-allocation-cleanup',
+            jsonb_build_object('action', 'cogs-allocation-cleanup',
+                               'run-after', (CURRENT_DATE + '5 years'::interval)::date::text,
+                               'args', null));
+
+  ELSE
+    DROP TABLE invoice_before_cogs_allocation_fix;
+
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop routines which are updated with new function signatures in this fix
+DROP FUNCTION IF EXISTS cogs__add_for_ap(
+  in_parts_id int,
+  in_qty numeric,
+  in_lastcost numeric
+);
+
+DROP FUNCTION IF EXISTS cogs__add_for_ap_line(
+  in_invoice_id int
+);
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -162,6 +162,7 @@ mc/delete-migration-validation-data.sql
 1.11/workflow-for-aa-transactions.sql
 1.11/fix-assembly-cogs.sql
 1.11/trigger-invoice-allocated-delete.sql
+1.11/cogs-allocation.sql
 # 1.12 changes
 1.12/migrate_to_identity.sql
 1.12/add-stored-order-quote-taxes.sql

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -24,8 +24,8 @@ BEGIN;
 
     -- Validate required functions
 
-    SELECT has_function('cogs__add_for_ap',ARRAY['integer','numeric','numeric']);
-    SELECT has_function('cogs__add_for_ap_line',ARRAY['integer']);
+    SELECT has_function('cogs__add_for_ap',ARRAY['integer','numeric','numeric','date']);
+    SELECT has_function('cogs__add_for_ap_line',ARRAY['integer','date']);
     SELECT has_function('cogs__add_for_ar',ARRAY['integer','numeric']);
     SELECT has_function('cogs__add_for_ar_line',ARRAY['integer']);
     SELECT has_function('cogs__reverse_ap',ARRAY['integer','numeric']);

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -6,6 +6,7 @@ use warnings;
 use Carp;
 use PageObject;
 use MIME::Base64;
+use Time::HiRes;
 use Test::More;
 
 use Module::Runtime qw(use_module);
@@ -170,6 +171,7 @@ sub click_menu {
             # menu item found; held in $item
             my $expanded = $item->get_attribute('aria-expanded');
             $item->click unless ($expanded and $expanded eq 'true');
+            sleep 0.1;
 
             # the node and its children are siblings in the DOM tree
             # continue the search from one level up...


### PR DESCRIPTION
Adds infrastructure to run post-upgrade processes so as to be able to trigger the COGS repairs (allocation of purchased units freed by fixing the allocated numbers).

Fixes #8974
