### PR TITLE
Adding taxtotal for printing

### DIFF
--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1259,15 +1259,18 @@ sub retrieve_invoice {
                        WHERE ac.trans_id = ?|);
         $tax_sth->execute($form->{id});
         my $reverse = $form->{reverse} ? -1 : 1;
+        my $taxtotal = LedgerSMB::PGNumber->new(0);
         while (my $taxref = $tax_sth->fetchrow_hashref('NAME_lc')){
               $form->{manual_tax} = 1;
               my $taccno = $taxref->{accno};
               $form->{"mt_amount_$taccno"} = $taxref->{amount} * $reverse;
+              $taxtotal = $taxtotal + $form->{"mt_amount_$taccno"};
               $form->{"mt_rate_$taccno"}  = $taxref->{rate};
               $form->{"mt_basis_$taccno"} = $taxref->{tax_basis} * $reverse;
               $form->{"mt_memo_$taccno"}  = $taxref->{memo};
               $form->{"mt_ref_$taccno"}  = $taxref->{source};
         }
+        $form->{inv_tax_total} = $taxtotal;
 
         # retrieve individual items
         $query = qq|


### PR DESCRIPTION
Currently it isn't possible to get the total of sales taxes on the invoice.  This patchmakes this possible.

I will be forward porting this to 1.13 shortly and until this it will be WIP.