### PR TITLE
Adding taxtotal for printing

### DIFF
--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -594,12 +594,14 @@ sub retrieve_invoice {
                        WHERE ac.trans_id = ?|);
         $tax_sth->execute($form->{id});
         my $reverse = $form->{reverse} ? -1 : 1;
+        my $taxtotal = LedgerSMB::PGNumber->new(0);
         while (my $taxref = $tax_sth->fetchrow_hashref('NAME_lc')){
               $form->db_parse_numeric(sth=>$tax_sth,hashref=>$taxref);
               $form->{manual_tax} = 1;
               my $taccno = $taxref->{accno};
               $form->{"mt_amount_$taccno"} =
                   LedgerSMB::PGNumber->new($taxref->{amount} * -1 * $reverse);
+              $taxtotal = $taxtotal + $form->{"mt_amount_$taccno"};
               $form->{"mt_rate_$taccno"}  = $taxref->{rate};
               $form->{"mt_basis_$taccno"} =
                   LedgerSMB::PGNumber->new($taxref->{tax_basis} * -1 * $reverse);
@@ -607,6 +609,7 @@ sub retrieve_invoice {
               $form->{"mt_ref_$taccno"}  = $taxref->{source};
         }
     }
+    $form->{inv_tax_total} = $taxtotal;
 
     $form->{$_} = $form->get_setting($_)
         for (qw/ inventory_accno_id income_accno_id

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1253,15 +1253,18 @@ sub retrieve_invoice {
                        WHERE ac.trans_id = ?|);
         $tax_sth->execute($form->{id});
         my $reverse = $form->{reverse} ? -1 : 1;
+        my $taxtotal = LedgerSMB::PGNumber->new(0);
         while (my $taxref = $tax_sth->fetchrow_hashref('NAME_lc')){
               $form->{manual_tax} = 1;
               my $taccno = $taxref->{accno};
               $form->{"mt_amount_$taccno"} = $taxref->{amount} * $reverse;
+              $taxtotal = $taxtotal + $form->{"mt_amount_$taccno"};
               $form->{"mt_rate_$taccno"}  = $taxref->{rate};
               $form->{"mt_basis_$taccno"} = $taxref->{tax_basis} * $reverse;
               $form->{"mt_memo_$taccno"}  = $taxref->{memo};
               $form->{"mt_ref_$taccno"}  = $taxref->{source};
         }
+        $form->{inv_tax_total} = $taxtotal;
 
         # retrieve individual items
         $query = qq|


### PR DESCRIPTION
Template::Toolkit doesn't give us arithmetic operations (numbers are stringified), so this just adds a total for the taxes to the form on retrieval for printing purposes.