### PR TITLE
Fix link to invoice from payments screen

### DIFF
--- a/UI/payments/payment2.html
+++ b/UI/payments/payment2.html
@@ -194,7 +194,7 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
       <tbody>
       <tr class="[% alternating_style %] open-item-row">
         <td class="invoice-number"
-            ><a href="erp.pl?__action=root#[% row.invoice.href %]"
+            ><a href="erp.pl#[% row.invoice.href %]"
                 target="_blank">[% row.invoice.number %]</a>
         </td>
         [% # we can use an href to link this invoice number to the invoice %]


### PR DESCRIPTION
Follow-up to 2ee3f158eb93b0aa4bad6709e9f294b39ad0d615 which renames action 'root' to '__default'.
