### PR TITLE
Fix posting payment/receipt reversal batches

### DIFF
--- a/old/lib/LedgerSMB/Batch.pm
+++ b/old/lib/LedgerSMB/Batch.pm
@@ -259,11 +259,11 @@ sub post {
     my $id = $self->{id} // '';
     my $batch_class_id = $self->{batch_class_id} // '';
     $log->info("Deleting batch $id of class $batch_class_id");
-    if (not ($batch_class_id ne ''
-             and ($batch_class_id == BC_PAYMENT
-                  or $batch_class_id == BC_PAYMENT_REVERSAL
-                  or $batch_class_id == BC_RECEIPT
-                  or $batch_class_id == BC_RECEIPT_REVERSAL))) {
+    if ($batch_class_id
+        and not ($batch_class_id == BC_PAYMENT
+                 or $batch_class_id == BC_PAYMENT_REVERSAL
+                 or $batch_class_id == BC_RECEIPT
+                 or $batch_class_id == BC_RECEIPT_REVERSAL)) {
         # payments and receipts (and reversals) are part of a transaction
         # which may already have been approved, meaning that 'batch-approve'
         # isn't available...


### PR DESCRIPTION
Before this fix, posting this type of batch throws an error 'action batch-approve not in state POSTED'.
