### PR TITLE
Report the starting and ending balances in the debit/credit columns

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -389,6 +389,18 @@ sub _exclude_from_totals {
     return {};
 }
 
+=head2 _exclude_row_from_totals( $row )
+
+Returns true when the row needs to be excluded from
+the calculated totals; C<$row> is a hashref to the column data.
+
+The default implementation returns C<false>.
+
+=cut
+
+sub _exclude_row_from_totals {
+    return '';
+}
 
 =head2 render(renderer => \&renderer($template_name, $report, $vars, $clean_vars) )
 
@@ -552,15 +564,17 @@ sub _render {
                 };
             }
 
-            for my $k (keys %$r){
-                next if $exclude->{$k};
+            unless ($self->_exclude_row_from_totals( $r )) {
+                for my $k (keys %$r){
+                    next if $exclude->{$k};
 
-                if ($r->{$k} isa 'LedgerSMB::PGNumber' ){
-                    $total_row->{$k} //= LedgerSMB::PGNumber->bzero;
-                    $total_row->{$k}->badd($r->{$k});
-                    if ($subtotal) {
-                        $subtotal->{$k} //= LedgerSMB::PGNumber->bzero;
-                        $subtotal->{$k}->badd($r->{$k});
+                    if ($r->{$k} isa 'LedgerSMB::PGNumber' ){
+                        $total_row->{$k} //= LedgerSMB::PGNumber->bzero;
+                        $total_row->{$k}->badd($r->{$k});
+                        if ($subtotal) {
+                            $subtotal->{$k} //= LedgerSMB::PGNumber->bzero;
+                            $subtotal->{$k}->badd($r->{$k});
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Before, the starting and ending balances were only reported in the 'running balance' column, which isn't shown by default. That makes for a rather weird experience when the (empty) starting and ending balance rows are shown regardless. With this change, these rows are no longer empty.
