### PR TITLE
Implement balance sheet report split by currency

### DIFF
--- a/UI/Reports/balance_sheet.html
+++ b/UI/Reports/balance_sheet.html
@@ -6,7 +6,8 @@ DRILLBASE = 'journal.pl?sort=transdate&amp;category=X'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
        _ '&amp;col_accno=Y&amp;__action=search&amp;col_running_balance=Y';
 
-max_path_depth = report.rheads.max_path_depth;
+max_row_path_depth = report.rheads.max_path_depth;
+max_col_path_depth = report.cheads.max_path_depth;
 IF report.legacy_hierarchy ;
    hierarchy = 'flat-hierarchy';
 ELSE ;
@@ -23,7 +24,7 @@ END ;
 <table class="balancesheet" style="border-collapse: collapse">
 <colgroup class="headings">
 [% i = 1;
-   WHILE i <= max_path_depth;
+   WHILE i <= max_row_path_depth;
      '  <col class="level' _ i _ '" />';
      i = i + 1;
    END;
@@ -31,19 +32,33 @@ END ;
 </colgroup>
 <colgroup class="values">
 [% i = 1;
-   WHILE i <= report.cheads.ids.size;
+     FOREACH col IN report.sorted_col_ids ;
+     IF  report.cheads.ids.$col.is_leaf;
+        NEXT;
+     END;
      '  <col class="values' _ i _ '" />';
      i = i + 1;
    END;
 %]
 </colgroup>
   <thead>
+  [% head_level = 1;
+     WHILE head_level <= max_col_path_depth ; %]
     <tr class="report-head">
-      <th colspan="[% max_path_depth %]"> </th>
-      [% FOREACH col IN report.sorted_col_ids -%]
-      <th>[% report.cheads.ids.$col.props.description %]</th>
+      <th colspan="[% max_row_path_depth %]"></th>
+      [% FOREACH col IN report.sorted_col_ids;
+         IF report.cheads.ids.$col.props.section_for;
+            NEXT;
+         END;
+         IF head_level == report.cheads.ids.$col.path.size -%]
+      <th data-id="[% col %]"
+          colspan="[% report.cheads.ids.$col.leaves %]"
+          rowspan="[% report.cheads.ids.$col.is_leaf ? (max_col_path_depth - report.cheads.ids.$col.path.size + 1) : 1 %]">[% report.cheads.ids.$col.props.description %]</th>
+      [% END %]
       [% END -%]
     </tr>
+    [% head_level = head_level + 1;
+       END %]
   </thead>
   <tbody>
 [% FOREACH row IN report.sorted_row_ids ;
@@ -82,7 +97,10 @@ END ;
 </th><th colspan="[% report.cheads.ids.size %]" [% class %]>
 [% ELSE -%]
 [% row_data.props.row_description %]</th>
-[% FOREACH col IN report.sorted_col_ids -%]
+[% FOREACH col IN report.sorted_col_ids;
+         IF not report.cheads.ids.$col.is_leaf;
+            NEXT;
+         END; -%]
   <td class="amount [% clazz %]"><a href="[%
  DRILLBASE _ '&amp;accno=' _ row_data.props.account_number
            _ '&amp;to_date=' _ report.cheads.ids.$col.props.to_date %]">[% report.cells.$row.$col %]</a></td>[% END %]

--- a/UI/Reports/filters/balance_sheet.html
+++ b/UI/Reports/filters/balance_sheet.html
@@ -181,6 +181,17 @@
              %]
         </div>
         <div class="input_row">
+          [%
+             label_pos = -1;  # Something leaks label_pos...
+             PROCESS input element_data = {
+             label = text('Split by foreign currencies')    #'
+             name = 'fx_split'
+             type = 'checkbox'
+             value = 1
+             };
+             %]
+        </div>
+        <div class="input_row">
           <div class="label">
             [% text('Hierarchy type') %]
           </div>

--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -350,6 +350,8 @@ body {
 
 #PNL th {
     padding-left: 5px;
+    text-align: left;
+    vertical-align: top;
 }
 
 #PNL table {

--- a/lib/LedgerSMB/Report/Axis.pm
+++ b/lib/LedgerSMB/Report/Axis.pm
@@ -125,6 +125,37 @@ sub _new_elem {
     return $subtree->{$step};
 }
 
+=item classify_leaves
+
+Calculates the number of leaf subnodes on every level in the
+tree that constitutes the axis. It sets the C<is_leaf> indicator
+on leaf nodes and sets the C<leaves> key to the calculated value.
+
+=cut
+
+sub _classify_leaves {
+    my ($subtree) = @_;
+
+    if (not $subtree->{children}
+        or not $subtree->{children}->%*) {
+        $subtree->{leaves} = 1;
+        $subtree->{is_leaf} = 1;
+        return 1;
+    }
+
+    my $leaves = 0;
+    for my $child (values $subtree->{children}->%*) {
+        $leaves += _classify_leaves( $child );
+    }
+    return $subtree->{leaves} = $leaves;
+}
+
+sub classify_leaves {
+    my $self = shift;
+
+    _classify_leaves( $_ ) for (values $self->tree->%*);
+}
+
 =item sort
 
 Returns an array reference with axis IDs, alphabetically sorted

--- a/lib/LedgerSMB/Report/Balance_Sheet.pm
+++ b/lib/LedgerSMB/Report/Balance_Sheet.pm
@@ -73,9 +73,37 @@ has timing => (is => 'ro', isa => 'Str', default => 'ultimo');
 
 =item incl_accnos
 
+Boolean. True to include account numbers as well as account descriptions.
+
+Default: False; only includes account descriptions.
+
 =cut
 
 has incl_accnos => (is => 'ro', isa => 'Bool');
+
+=item fx_split
+
+Allowed values:
+
+=over 8
+
+=item C<undef> or empty string
+
+Default; does not include foreign currencies in the report
+
+=item C<split>
+
+Splits the base currency amount by currency into additional columns.
+
+=item C<amounts>
+
+
+
+=back
+
+=cut
+
+has fx_split => (is => 'ro');
 
 =back
 
@@ -88,104 +116,245 @@ the balance sheet.
 
 =cut
 
+sub _row_handlers_gifi {
+    my ($earn_id) = @_;
+    return (
+        sub {
+            my ($line) = @_;
+            return ($line->{account_type} eq 'H')
+                ? []
+                : [ [ $line->{account_category},
+                      $line->{gifi} ],
+                    [ $line->{account_category} ],
+                ];
+        },
+        sub {
+            my ($line) = @_;
+            $line->{account_number} = $line->{gifi};
+            $line->{account_description} = $line->{gifi_description};
+            $line->{order} = $line->{account_number};
+            return $line;
+        });
+}
+
+sub _row_handlers_legacy {
+    my ($earn_id) = @_;
+    return (
+        sub {
+            my ($line) = @_;
+            if ($line->{account_type} eq 'A'
+                && ($line->{account_category} eq 'E'
+                    || $line->{account_category} eq 'I')) {
+                # If the 'earn_id' configuration is missing,
+                #  this is the case we hit
+                # (the query doesn't know which node to aggregate into)
+                return [ [ 'QL', 'Q', 'q' ],
+                         [ 'QL', 'Q' ],
+                         [ 'QL' ],
+                    ];
+            }
+            elsif ($line->{account_type} eq 'A') {
+                if ($line->{account_category} eq 'A') {
+                    return [ [ $line->{account_category},
+                               $line->{account_number} ],
+                             [ $line->{account_category} ],
+                        ];
+                }
+                else {
+                    return [ [ 'QL',
+                               $line->{account_category},
+                               $line->{account_number} ],
+                             [ 'QL',
+                               $line->{account_category} ],
+                             [ 'QL' ],
+                        ];
+                }
+            }
+            elsif ($line->{account_type} eq 'H'
+                   && $line->{account_id} == $earn_id) {
+                # If the 'earn_id' is configured, we hit this case
+                # be sure to map the heading
+                return [ [ 'QL', 'Q', 'q' ],
+                         [ 'QL', 'Q' ],
+                         [ 'QL' ],
+                    ];
+            }
+            return [];
+        },
+        sub {
+            my ($line) = @_;
+            if ($line->{account_type} eq 'A'
+                && ($line->{account_category} eq 'E'
+                    || $line->{account_category} eq 'I')) {
+                return undef;
+            }
+            return $line;
+        });
+}
+
+sub _row_handlers_default {
+    my ($earn_id) = @_;
+    return (
+        sub {
+            my ($line) = @_;
+            return [ ($line->{account_type} eq 'H')
+                     ? $line->{heading_path}
+                     : [ ( @{$line->{heading_path}},
+                           $line->{account_number})
+                     ],
+                ];
+        },
+        sub {
+            my ($line) = @_;
+            $line->{order} = $line->{account_number};
+            return $line;
+        });
+}
+
+sub _header_descriptions {
+    my ($self) = @_;
+
+    if ($self->gifi || $self->legacy_hierarchy) {
+        return (
+            E => {
+                account_number   => 'E',
+                account_category => 'E',
+                account_type     => 'H',
+                account_description => $self->Text('Expenses')
+            },
+            I => {
+                account_number   => 'I',
+                account_category => 'I',
+                account_type     => 'H',
+                account_description => $self->Text('Income')
+            },
+            A => {
+                order => '1',
+                account_number   => '',
+                account_category => 'A',
+                account_type     => 'H',
+                account_description => $self->Text('Assets')
+            },
+            QL => {
+                order => '2',
+                account_number => '',
+                account_category => 'QL',
+                account_type     => 'H',
+                account_description => $self->Text('Equity & Liabilities')
+            },
+            L => {
+                order => '2',
+                account_number => '',
+                account_category => 'L',
+                account_type     => 'H',
+                heading_path     => [ 'QL' ],
+                account_description => $self->Text('Liabilities')
+            },
+            Q => {
+                order => '3',
+                account_number => '',
+                account_category => 'Q',
+                account_type     => 'H',
+                heading_path     => [ 'QL' ],
+                account_description => $self->Text('Equity')
+            },
+            q => {
+                order => '1',
+                account_number => '',
+                account_category => '',
+                account_type     => 'A',
+                heading_path     => [ 'QL', 'Q' ],
+                account_description => $self->Text('Current earnings')
+            });
+    }
+    else {
+        return map {
+            $_->{accno} => {
+                account_number      => $_->{accno},
+                account_description => $_->{description}
+            }
+        } $self->call_dbmethod(funcname => 'account__all_headings');
+    };
+}
+
 sub run_report {
     my ($self) = @_;
 
+    my $column_order = 1;
     die $self->Text('Required period type')
            if $self->comparison_periods and $self->interval eq 'none';
     my @lines = $self->call_dbmethod(funcname => 'report__balance_sheet');
     my ($row) = $self->call_procedure(funcname => 'setting_get',
                                       args => [ 'earn_id' ]);
     my $earn_id = ($row && $row->{value}) ? $row->{value} : -1;
-    my $row_map = ($self->gifi) ?
-        sub { my ($line) = @_;
-              return ($line->{account_type} eq 'H')
-                  ? []
-                  : [ [ $line->{account_category},
-                        $line->{gifi} ],
-                      [ $line->{account_category} ],
-                  ];
-        } : ($self->legacy_hierarchy) ?
-        sub { my ($line) = @_;
-              if ($line->{account_type} eq 'A'
-                  && ($line->{account_category} eq 'E'
-                      || $line->{account_category} eq 'I')) {
-                  # If the 'earn_id' configuration is missing,
-                  #  this is the case we hit
-                  # (the query doesn't know which node to aggregate into)
-                  return [ [ 'QL', 'Q', 'q' ],
-                           [ 'QL', 'Q' ],
-                           [ 'QL' ],
-                      ];
-              }
-              elsif ($line->{account_type} eq 'A') {
-                  if ($line->{account_category} eq 'A') {
-                      return [ [ $line->{account_category},
-                                 $line->{account_number} ],
-                               [ $line->{account_category} ],
-                          ];
-                  }
-                  else {
-                      return [ [ 'QL',
-                                 $line->{account_category},
-                                 $line->{account_number} ],
-                               [ 'QL',
-                                 $line->{account_category} ],
-                               [ 'QL' ],
-                          ];
-                  }
-              }
-              elsif ($line->{account_type} eq 'H'
-                     && $line->{account_id} == $earn_id) {
-                  # If the 'earn_id' is configured, we hit this case
-                  # be sure to map the heading
-                  return [ [ 'QL', 'Q', 'q' ],
-                           [ 'QL', 'Q' ],
-                           [ 'QL' ],
-                      ];
-              }
-              return [];
-        } :
-        sub { my ($line) = @_;
-              return [ ($line->{account_type} eq 'H')
-                       ? $line->{heading_path}
-                       : [ ( @{$line->{heading_path}},
-                             $line->{account_number})
-                       ],
-                  ];
-        };
-    my $row_props = ($self->gifi) ?
-        sub { my ($line) = @_;
-              $line->{account_number} = $line->{gifi};
-              $line->{account_description} = $line->{gifi_description};
-              $line->{order} = $line->{account_number};
-              return $line;
-        } : ($self->legacy_hierarchy) ?
-        sub { my ($line) = @_;
-              if ($line->{account_type} eq 'A'
-                  && ($line->{account_category} eq 'E'
-                      || $line->{account_category} eq 'I')) {
-                  return undef;
-              }
-              return $line;
-         } :
-         sub { my ($line) = @_;
-               $line->{order} = $line->{account_number};
-               return $line; };
+
+    my ($row_map, $row_props);
+    if ($self->gifi) {
+        ($row_map, $row_props) = _row_handlers_gifi($earn_id);
+    }
+    elsif ($self->legacy_hierarchy) {
+        ($row_map, $row_props) = _row_handlers_legacy($earn_id);
+    }
+    else {
+        ($row_map, $row_props) = _row_handlers_default($earn_id);
+    }
 
     my $col_id = $self->cheads->map_path($self->column_path_prefix);
-    $self->cheads->id_props($col_id,
-                            { description => $self->date_to->to_output($self->{formatter_options}),
-                              to_date     => $self->date_to->to_output($self->{formatter_options}),
-                            });
+    $self->cheads->id_props(
+        $col_id,
+        {
+            description => $self->date_to->to_output($self->{formatter_options}),
+            to_date     => $self->date_to->to_output($self->{formatter_options}),
+            order       => $column_order++
+        });
+
+    if ($self->fx_split) {
+        my @currencies = sort { lc $a cmp lc $b } keys { map { $_->{curr} => 1 } @lines }->%*;
+        $col_id = $self->cheads->map_path( [ $self->column_path_prefix->@*, 'total' ] );
+        $self->cheads->id_props(
+            $col_id,
+            { description => $self->Text('Total'), order => $column_order++ });
+        my $of_which_id = $self->cheads->map_path( [ $self->column_path_prefix->@*, 'of_which' ] );
+        $self->cheads->id_props(
+            $of_which_id,
+            { description => $self->Text('Of which:'), order => $column_order++ });
+        for my $curr (@currencies) {
+            my $curr_col_id = $self->cheads->map_path( [ $self->column_path_prefix->@*, 'of_which', $curr ] );
+            $self->cheads->id_props(
+                $curr_col_id,
+                { description => $curr, order => $column_order++ });
+
+            if ($self->fx_split eq 'amounts') {
+                my $amt_col_id = $self->cheads->map_path(
+                    [ $self->column_path_prefix->@*, $curr, 'fx_amount' ] );
+                $self->cheads->id_props(
+                    $amt_col_id,
+                    { description => $self->Text('FX [_1]', $curr),
+                      order       => $column_order++ });
+            }
+        }
+    }
 
     for my $line (@lines) {
-        my $props = &$row_props($line);
-        my $paths = &$row_map($line);
+        my $props = $row_props->($line);
+        my $paths = $row_map->($line);
 
+        my $curr_col_id;
+        $curr_col_id =
+            $self->cheads->map_path( [ $self->column_path_prefix->@*, 'of_which', $line->{curr} ] )
+            if $self->fx_split;
         for my $path (@$paths) {
             my $row_id = $self->rheads->map_path($path);
             $self->accum_cell_value($row_id, $col_id, $line->{amount});
+            if ($self->fx_split) {
+                $self->accum_cell_value($row_id, $curr_col_id, $line->{amount});
+
+                if ($self->fx_split eq 'amounts') {
+                    my $amt_col_id = $self->cheads->map_path(
+                        [ $self->column_path_prefix->@*, $line->{curr}, 'fx_amount' ] );
+                    $self->accum_cell_value($row_id, $amt_col_id, $line->{amount_tc});
+                }
+            }
             $self->rheads->id_props($row_id, $props)
                 if defined $props;
 
@@ -194,60 +363,7 @@ sub run_report {
     }
 
     # Header rows don't have descriptions
-    my %header_desc;
-    if ($self->gifi || $self->legacy_hierarchy) {
-        %header_desc = ( 'E' => { 'account_number' => 'E',
-                                  'account_category' => 'E',
-                                  'account_type' => 'H',
-                                  'account_description' =>
-                                      $self->Text('Expenses') },
-                         'I' => { 'account_number' => 'I',
-                                  'account_category' => 'I',
-                                  'account_type' => 'H',
-                                  'account_description' =>
-                                      $self->Text('Income') },
-                         'A' => { 'order' => '1',
-                                  'account_number' => '',
-                                  'account_category' => 'A',
-                                  'account_type' => 'H',
-                                  'account_description' =>
-                                      $self->Text('Assets') },
-                         'QL' => { 'order' => '2',
-                                  'account_number' => '',
-                                  'account_category' => 'QL',
-                                  'account_type' => 'H',
-                                  'account_description' =>
-                                      $self->Text('Equity & Liabilities') },
-                         'L' => { 'order' => '2',
-                                  'account_number' => '',
-                                  'account_category' => 'L',
-                                  'account_type' => 'H',
-                                  'heading_path' => [ 'QL' ],
-                                  'account_description' =>
-                                      $self->Text('Liabilities') },
-                         'Q' => { 'order' => '3',
-                                  'account_number' => '',
-                                  'account_category' => 'Q',
-                                  'account_type' => 'H',
-                                  'heading_path' => [ 'QL' ],
-                                  'account_description' =>
-                                      $self->Text('Equity') },
-                         'q' => { 'order' => '1',
-                                  'account_number' => '',
-                                  'account_category' => '',
-                                  'account_type' => 'A',
-                                  'heading_path' => [ 'QL', 'Q' ],
-                                  'account_description' =>
-                                      $self->Text('Current earnings') },
-            );
-    }
-    else {
-        %header_desc =
-            map { $_->{accno} => { 'account_number' => $_->{accno},
-                                   'account_description' => $_->{description} }
-            }
-            $self->call_dbmethod(funcname => 'account__all_headings');
-    };
+    my %header_desc = $self->_header_descriptions;
     for my $id (grep { ! defined $_->{props} } values %{$self->rheads->ids}) {
         $self->rheads->id_props($id->{id}, $header_desc{$id->{accno}});
     }

--- a/lib/LedgerSMB/Report/Hierarchical.pm
+++ b/lib/LedgerSMB/Report/Hierarchical.pm
@@ -230,6 +230,8 @@ before '_render' => sub {
 
     $self->sorted_row_ids($self->rheads->sort);
     $self->sorted_col_ids($self->cheads->sort);
+    $self->cheads->classify_leaves($self->cheads);
+
     $_->{path_depth} = scalar($_->{path}->@*) for values  $self->rheads->ids->%*;
     $_->{path_depth} = scalar($_->{path}->@*) for values  $self->cheads->ids->%*;
     my $row_max_depth =
@@ -251,7 +253,7 @@ before '_render' => sub {
     for (map { $_->{props} } values $self->rheads->ids->%*) {
         if ($_->{section_for}) {
             $_->{heading_props} = $self->rheads->ids->{$_->{section_for}}->{props};
-            $_->{row_description} = $_->{heading_props}->{account_number};
+            $_->{row_description} = $_->{heading_props}->{account_description};
         }
         else {
             $_->{row_description} = ($self->incl_accnos && $_->{account_number})

--- a/templates/demo/balance_sheet.html
+++ b/templates/demo/balance_sheet.html
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  2.1
-   Date:     2025-08-30
+   Version:  2.2
+   Date:     2025-08-31
    File:     balance_sheet.html
    Set:      demo
 
@@ -11,6 +11,7 @@ releases. No explicit versioning was applied before 2021-01-04.
 Version   Changes
 2.0       Created clickable section heads to collapse parts of hierarchical reports
 2.1       Simplify indentation calculations; many values are provided as variables as-of 1.13
+2.2       Support sections in the column dimension (used for foreign currency reports)
 
 -?>
 <!DOCTYPE html>
@@ -129,6 +130,8 @@ Version   Changes
 
 #PNL th {
     padding-left: 5px;
+    text-align: left;
+    vertical-align: top;
 }
 
 #PNL table {
@@ -284,7 +287,8 @@ th {
       }
   </script></head><?lsmb
 
-max_path_depth = report.rheads.max_path_depth;
+max_col_path_depth = report.cheads.max_path_depth;
+max_row_path_depth = report.rheads.max_path_depth;
 IF report.legacy_hierarchy ;
    hierarchy = 'flat-hierarchy';
 ELSE ;
@@ -305,7 +309,7 @@ END ;
     <table class="balancesheet c1">
       <colgroup class="headings">
         <?lsmb i = 1;
-        WHILE i <= max_path_depth;
+        WHILE i <= max_row_path_depth;
         '  <col class="level' _ i _ '" />';
         i = i + 1;
         END;
@@ -313,18 +317,32 @@ END ;
       </colgroup>
       <colgroup class="values">
         <?lsmb i = 1;
-        WHILE i <= report.cheads.ids.size;
+        FOREACH col IN report.sorted_col_ids ;
+        IF  report.cheads.ids.$col.is_leaf;
+           NEXT;
+        END;
         '  <col class="values' _ i _ '" />';
         i = i + 1;
         END;
         ?>
       </colgroup>
       <thead>
+      <?lsmb head_level = 1;
+        WHILE head_level <= max_col_path_depth ; ?>
         <tr class="report-head">
-          <th colspan="<?lsmb max_path_depth ?>">
-          </th><?lsmb FOREACH col IN report.sorted_col_ids -?>
-          <th><?lsmb report.cheads.ids.$col.props.description ?></th><?lsmb END -?>
+          <th colspan="<?lsmb max_row_path_depth ?>"></th>
+          <?lsmb FOREACH col IN report.sorted_col_ids;
+         IF report.cheads.ids.$col.props.section_for;
+            NEXT;
+         END;
+         IF head_level == report.cheads.ids.$col.path.size -?>
+      <th data-id="<?lsmb col ?>"
+          colspan="<?lsmb report.cheads.ids.$col.leaves ?>"
+          rowspan="<?lsmb report.cheads.ids.$col.is_leaf ? (max_col_path_depth - report.cheads.ids.$col.path.size + 1) : 1 ?>"><?lsmb report.cheads.ids.$col.props.description ?></th>
+       <?lsmb END -?><?lsmb END ?>
         </tr>
+        <?lsmb head_level = head_level + 1;
+        END ?>
       </thead>
       <tbody>
         <?lsmb FOREACH row IN report.sorted_row_ids ;
@@ -361,7 +379,11 @@ END ;
           row_data.props.row_description ?></th>
           <th colspan="<?lsmb report.cheads.ids.size ?>" <?lsmb class ?>>
           <?lsmb ELSE -?>
-          <?lsmb row_data.props.row_description ?></th><?lsmb FOREACH col IN report.sorted_col_ids -?>
+          <?lsmb row_data.props.row_description ?></th><?lsmb FOREACH col IN report.sorted_col_ids;
+         IF not report.cheads.ids.$col.is_leaf;
+            NEXT;
+         END;
+          -?>
           <td class="amount <?lsmb clazz ?>">
             <?lsmb report.cells.$row.$col ?>
           </td><?lsmb END ?><?lsmb END ?>

--- a/templates/demo/balance_sheet.tex
+++ b/templates/demo/balance_sheet.tex
@@ -1,7 +1,7 @@
 <?lsmb#   This is a comment block; it's ignored by the template engine.
 
-   Version:  1.3
-   Date:     2025-08-02
+   Version:  1.4
+   Date:     2025-08-31
    File:     balance_sheet.tex
    Set:      demo
 
@@ -13,13 +13,22 @@ Version   Changes
 1.2       Fixed company address not showing
 1.3       Simplify indentation calculations; as of 1.13, many pre-calculated
           values are provided as variables
+1.4       Support for sections in the column dimension (used for
+          foreign currency reports)
 
 -?>
 <?lsmb FILTER latex { format="$FORMAT($PROCESSOR)" } -?>
 
 <?lsmb
-  max_path_depth = report.rheads.max_path_depth;
-  last_col_no = max_path_depth + 1 + report.sorted_col_ids.size;
+  max_col_path_depth = report.cheads.max_path_depth;
+  max_row_path_depth = report.rheads.max_path_depth;
+  leaf_columns = 0;
+  FOREACH col IN report.sorted_col_ids ;
+    IF report.cheads.ids.$col.is_leaf ;
+      leaf_columns = leaf_columns + 1;
+    END;
+  END;
+  last_col_no = max_row_path_depth + 1 + leaf_columns;
   IF report.legacy_hierarchy ;
      hierarchy = 'flat-hierarchy';
   ELSE ;
@@ -30,6 +39,7 @@ Version   Changes
 
 \documentclass[10pt]{article}
 \usepackage{longtable}
+\usepackage{multirow}
 \usepackage[<?lsmb SETTINGS.papersize ?>paper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \begin{document}
 \renewcommand\baselinestretch{1.2}\selectfont
@@ -47,17 +57,28 @@ Version   Changes
 \end{center}
 
 
-\begin{longtable}{@{\extracolsep{10pt}}<?lsmb l = 'l'; l.repeat(max_path_depth) -?>p{2cm}<?lsmb
+\begin{longtable}{@{\extracolsep{10pt}}<?lsmb l = 'l'; l.repeat(max_row_path_depth) -?>p{2cm}<?lsmb
  l = 'r'; l.repeat(report.sorted_col_ids.size); -?>}
 \\
-\multicolumn{<?lsmb max_path_depth ?>}{l}{} &%
+<?lsmb head_level = 1;
+  WHILE head_level <= max_col_path_depth; ?>
+\multicolumn{<?lsmb max_row_path_depth ?>}{l}{} &%
 <?lsmb
  FOREACH col IN report.sorted_col_ids;
-     ' & \shortstack{';
+     IF report.cheads.ids.$col.props.section_for;
+        NEXT;
+     END;
+     IF head_level == report.cheads.ids.$col.path.size ;
+     ' & \multicolumn{'; report.cheads.ids.$col.leaves ; '}{l}{\multirow{'; report.cheads.ids.$col.is_leaf ? (max_col_path_depth - report.cheads.ids.$col.path.size + 1) : 1 ; '}{*}{\shortstack{';
      report.cheads.ids.$col.props.description ;
-     '} ';
+     '}}} ';
+     ELSIF head_level > report.cheads.ids.$col.path.size ;
+       ' & ';
+     END;
  END;
  ?> \\
+ <?lsmb head_level = head_level + 1;
+ END ?>
 \\
 <?lsmb FOREACH row IN report.sorted_row_ids;
   row_data = report.rheads.ids.$row;
@@ -89,7 +110,10 @@ Version   Changes
 %
 & %
 <?lsmb FOREACH col IN report.sorted_col_ids;
-  ' & '; report.cells.$row.$col;
+     IF report.cheads.ids.$col.props.section_for;
+        NEXT;
+     END;
+     ' & '; report.cells.$row.$col;
 END; -?>
 %
 \\


### PR DESCRIPTION
This PR implements a new checkmark, which then adds columns showing the foreign currencies in the balance sheet (with their local currency amounts):

<img width="463" height="440" alt="image" src="https://github.com/user-attachments/assets/90f0208b-4627-4986-b55e-f7da63c965de" />


Here's the checkmark which adds the extra columns:

<img width="482" height="456" alt="image" src="https://github.com/user-attachments/assets/f07f3fc2-bb7e-43f3-a4d3-90dca3357aa9" />


In order to understand what to do, the Balance_Sheet.pm `run_report` method was refactored to be able to see its actual operations. Document templates have also been updated to support the new functionality.