### PR TITLE
Align layout of I/S and B/S with default GL Search layout

### DIFF
--- a/UI/Reports/PNL.html
+++ b/UI/Reports/PNL.html
@@ -4,7 +4,7 @@ account_data = report.account_data;
 FORMATS = LIST_FORMATS();
 DRILLBASE = 'journal.pl?sort=transdate&amp;col_eca_name=Y&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
-       _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
+       _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y&amp;col_eca_name=Y'
        _ '&amp;col_accno=Y&amp;__action=search&amp;col_running_balance=Y';
 
 max_path_depth = report.rheads.max_path_depth;

--- a/UI/Reports/balance_sheet.html
+++ b/UI/Reports/balance_sheet.html
@@ -3,7 +3,7 @@
 FORMATS = LIST_FORMATS();
 DRILLBASE = 'journal.pl?sort=transdate&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
-       _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
+       _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y&amp;col_eca_name=Y'
        _ '&amp;col_accno=Y&amp;__action=search&amp;col_running_balance=Y';
 
 max_path_depth = report.rheads.max_path_depth;


### PR DESCRIPTION
The standard GL Search layout contains ECA names on relevant transactions; the drilldown didn't before this change.
