### PR TITLE
Fix two tax field derefs and set default transaction date (#9107)

### DIFF
--- a/lib/LedgerSMB/Routes/ERP/API/Invoices.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Invoices.pm
@@ -546,7 +546,7 @@ sub _post_invoices {
             #
             my $sth = $env->{'lsmb.db'}->prepare(
                 q|
-                    SELECT a.accno as category, a.description, t.rate, a.id
+                    SELECT a.accno as category, a.description, t.rate, a.id, t.chart_id
                       FROM account a JOIN tax t ON t.chart_id = a.id
                       WHERE a.accno = ?
                       AND coalesce(validto::timestamp, 'infinity')
@@ -618,6 +618,20 @@ sub _post_invoices {
         uniq map { $_->{part}->{id} } $inv->{lines}->@*
         );
 
+    $inv->{transdate} //= $inv->{crdate};
+    $inv->{crdate} //= $inv->{transdate};
+    if (not $inv->{transdate}) {
+        $env->{'psgix.logger'}->(
+            {
+                level => 'info',
+                message => 'No transaction date supplied; setting default' });
+        my ($now) = $env->{'lsmb.db'}->selectrow_array('SELECT NOW()::date')
+            or die $env->{'lsmb.db'}->errstr;
+
+        $inv->{crdate} =
+            $inv->{transdate} =
+            $now;
+    }
 
     # Step 2: Run the price matrix
     if (keys %part_qty) {
@@ -719,7 +733,9 @@ sub _post_invoices {
           or die $env->{'lsmb.db'}->errstr;
         $sth->execute($inv->{eca}->{id}, $inv->{transdate})
             or die $sth->errstr;
-        $inv->{taxes} = $sth->fetchall_hashref('accno');
+        while (my $ref = $sth->fetchrow_hashref('NAME_lc')) {
+            $inv->{taxes}->{$ref->{accno}} = { tax => $ref };
+        }
         die $sth->errstr
             if $sth->err;
         if (keys $inv->{taxes}->%* and keys %part_qty) {
@@ -780,25 +796,35 @@ sub _post_invoices {
                 my $pass = 0;
 
                 for my $tax (@taxes) {
-                    next unless exists $part_tax{$line->{part}->{id}}->{$tax->{accno}};
-                    if ($pass != $tax->{pass}) {
+                    $env->{'psgix.logger'}->(
+                        {
+                            level => 'debug',
+                            message => "Considering tax $tax->{tax}->{accnon} for part $line->{part}->{id}" });
+                    next unless exists $part_tax{$line->{part}->{id}}->{$tax->{tax}->{accno}};
+                    $env->{'psgix.logger'}->(
+                        {
+                            level => 'debug',
+                            message => "processing tax for part ID $line->{part}->{id}" });
+                    if ($pass != $tax->{tax}->{pass}) {
                         $base += $passtax;
                         $passtax = 0;
-                        $pass = $tax->{pass};
+                        $pass = $tax->{tax}->{pass};
                     }
 
-                    my $amount = $base*$tax->{rate};
-                    $line->{taxes}->{$tax->{accno}} = {
-                        base   => $base,
-                        rate   => $tax->{rate},
+                    my $amount = $base*$tax->{tax}->{rate};
+                    $line->{taxes}->{$tax->{tax}->{accno}} = {
+                        'base-amount'   => $base,
+                        rate   => $tax->{tax}->{rate},
                         amount => $amount,
                     };
-                    $inv->{taxes}->{$tax->{accno}}->{base}   += $base;
-                    $inv->{taxes}->{$tax->{accno}}->{amount} += $amount;
+                    $inv->{taxes}->{$tax->{tax}->{accno}}->{'base-amount'}   += $base;
+                    $inv->{taxes}->{$tax->{tax}->{accno}}->{amount} += $amount;
+                    $inv->{taxes}->{$tax->{tax}->{accno}}->{tax} = $tax->{tax};
                 }
             }
         }
     }
+
     ###BUG: These amounts in don't have these names in the invoice resource!!!
     $inv->{taxes_total} =
         reduce { $a + $b->{amount} } LedgerSMB::PGNumber->new(0), values $inv->{taxes}->%*;
@@ -953,7 +979,7 @@ sub _post_invoices {
         |)
         or die $env->{'lsmb.db'}->errstr;
     for my $tax (values $inv->{taxes}->%*) {
-        $asth->execute($inv_id, undef, $tax->{tax}->{id},
+        $asth->execute($inv_id, undef, $tax->{tax}->{chart_id},
                        -$sign*$tax->{amount}, -$sign*$tax->{amount},
                        $inv->{currency}, $inv->{transdate},
                        $tax->{source}, $tax->{memo})


### PR DESCRIPTION
* Fix two tax field derefs and set default transaction date

* Align 'taxes' key between calculated and provided code paths

* Align tax calculation between provided and calculated taxes

* Align 'base-amount' naming between provided and calculated taxes
