### PR TITLE
Upgrade Workflow dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -123,7 +123,7 @@ requires 'Text::Markdown';
 requires 'Throwable';
 requires 'URI';
 requires 'URI::Escape';
-requires 'Workflow', '2.06';
+requires 'Workflow', '2.07'; # 2.07 Fixes 'return;' back to 'return undef;'
 requires 'Workflow::Action', '2.06';
 requires 'Workflow::Condition', '2.06';
 requires 'Workflow::Context', '2.06';


### PR DESCRIPTION
The Workflow dependency 2.06 has the $context->param() function return nothing instead of 'undef' in list context if the parameter does not exist. This is a cause for much confusion and bugs; fortunately 2.07 fixes that.
