### PR TITLE
Deprecate the template guide

### DIFF
--- a/doc/templating/templating-guide.tex
+++ b/doc/templating/templating-guide.tex
@@ -24,6 +24,10 @@
 \newcommand{\lsmbn}{LedgerSMB}
 \newcommand{\lsmbt}{LedgerSMB::Template}
 
+\usepackage{background}
+\backgroundsetup{contents={DEPRECATED}, scale={8}}
+\usepackage{hyperref}
+
 \title{Templating for LedgerSMB v. \version}
 \author{The LedgerSMB Core Team}
 \date{\today}
@@ -33,6 +37,12 @@
 Copyright \copyright 2007 The LedgerSMB Core Team. Permission
 is granted to copy, distribute and/or modify this document under the
 terms of the GNU General Public License version 2.
+
+\vspace{1cm}
+\Large{\textbf{As of Jan 5, 2026, this document is deprecated and no longer maintained.}}
+
+\vspace{1cm}
+See the LedgerSMB book at \url{https:book.ledgersmb.org} for the definitive source of information on Templating.
 
 \tableofcontents{}
 %\listoffigures


### PR DESCRIPTION
This content has been moved into the book, which serves as the definitive source.