### PR TITLE
Revert use of infix operator In

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -155,7 +155,6 @@ requires 'Pod::Find';
 requires 'Scope::Guard', '0.10';
 requires 'Session::Storage::Secure';
 requires 'String::Random';
-requires 'Syntax::Operator::In';
 requires 'Template', '2.14';
 requires 'Template::Parser';
 requires 'Template::Provider';

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -1,6 +1,5 @@
 
 use v5.38;
-use Syntax::Operator::In;
 
 package LedgerSMB::Scripts::configuration;
 
@@ -347,7 +346,8 @@ sub sequence_screen {
     }
     $request->{setting_keys} = [
         grep {
-           not ($_->{name} in:eq qw(customernumber vendornumber employeenumber))
+            my $name = $_->{name};
+            not grep { $name eq $_ } qw(customernumber vendornumber employeenumber);
         } $request->{setting_keys}->@*
         ];
     return $request->{_wire}->get('ui')


### PR DESCRIPTION
This PR will restore our coverage numbers; they were broken before, not due to the move to Perl 5.38, but due to the use of Syntax::Operator::In (unfortunately, because it's a very nice feature!)