### PR TITLE
Restore protection of transactions in closed periods

### DIFF
--- a/sql/changes/1.14/centralized-transdate.sql
+++ b/sql/changes/1.14/centralized-transdate.sql
@@ -19,5 +19,7 @@ alter table gl
   drop column transdate;
 
 
-
-
+create trigger transactions_prevent_closed
+  before insert or update
+  on transactions
+  for each row execute function prevent_closed_transactions();


### PR DESCRIPTION
Since the protection was dropped from the AR/AP/GL tables due to their loss of the role.
