### PR TITLE
Set the default balance sheet date to 'today'

### DIFF
--- a/UI/Reports/filters/balance_sheet.html
+++ b/UI/Reports/filters/balance_sheet.html
@@ -92,7 +92,7 @@
              PROCESS input element_data = {
              label = text('As per')
              name = 'to_date'
-             value = to_date
+             value = (to_date OR 'today')
              type = 'date'
              size = 12
              };

--- a/xt/lib/PageObject/App/Report/Filters/BalanceSheet.pm
+++ b/xt/lib/PageObject/App/Report/Filters/BalanceSheet.pm
@@ -30,7 +30,9 @@ sub _verify {
 sub run {
     my ($self, %options) = @_;
 
-    $self->find('.//input[@id="to-date"]')->send_keys($options{date});
+    my $date_widget = $self->find('.//input[@id="to-date"]');
+    $date_widget->clear;
+    $date_widget->send_keys($options{date});
     my $btn = $self->find('*button', text => 'Continue');
     $btn->click;
     $self->session->page->body->maindiv->wait_for_content(replaces => $btn);


### PR DESCRIPTION
The 'today' string is a hint to the JS client to fill the current client date in the date entry box.

Fixes #9525