### PR TITLE
Upgrade dojo webpack plugin dependency

### DIFF
--- a/UI/package.json
+++ b/UI/package.json
@@ -74,7 +74,7 @@
     "css-minimizer-webpack-plugin": "8.0.0",
     "cssnano": "8.0.1",
     "dojo-util": "1.17.3",
-    "dojo-webpack-plugin": "3.0.9",
+    "dojo-webpack-plugin": "3.0.14",
     "ejs-loader": "0.5.0",
     "eslint": "9.39.4",
     "eslint-config-eslint": "13.0.0",


### PR DESCRIPTION
This should enable upgrading the vulnerable 'tmp' dependency.
