### PR TITLE
Set Renovate minimum release age to 2 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
     "cpanfile": {
         "enabled": false
     },
+    "minimumReleaseAge": "3 days",
     "packageRules": [
         {
             "matchManagers": [


### PR DESCRIPTION
Yarn has a minimum release age of 1 day, so our pipeline currently gets stuck when the release isn't 1 day old when renovate adds a package to the renovation PRs.
