### PR TITLE
Simplify use of configuration hashes in ledgersmb.yaml

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,7 @@ requires 'perl', '5.38.0';
 requires 'Array::PrintCols';
 requires 'Archive::Zip';
 recommends 'Authen::SASL';
-requires 'Beam::Wire';
+requires 'Beam::Wire', '1.031';
 requires 'CGI::Emulate::PSGI';
 requires 'CGI::Parse::PSGI';
 requires 'Cookie::Baker', '0.10'; # for 'samesite' attribute

--- a/doc/conf/ledgersmb.yaml
+++ b/doc/conf/ledgersmb.yaml
@@ -136,11 +136,9 @@ mail:
 # Several settings used throughout the application which have no
 # natural common top-level topic by which they can be combined
 miscellaneous:
-  $class: Beam::Wire
-  config:
-    backup_email_from: ''
-    max_upload_size: 4194304
-    proxy_ip: 127.0.0.1/8 ::1/128 ::ffff:127.0.0.1/108
+  backup_email_from: ''
+  max_upload_size: 4194304
+  proxy_ip: 127.0.0.1/8 ::1/128 ::ffff:127.0.0.1/108
 
 # !book: output_formatter
 #
@@ -183,15 +181,13 @@ output_formatter:
 #
 # Centralized list of paths referenced elsewhere in this configuration
 paths:
-  $class: Beam::Wire
-  config:
-    locale: ./locale/po
-    sql: ./sql
-    sql_data: ./locale
-    templates: ./templates
-    UI: ./UI
-    UI_cache: lsmb_templates
-    workflows:
+  locale: ./locale/po
+  sql: ./sql
+  sql_data: ./locale
+  templates: ./templates
+  UI: ./UI
+  UI_cache: lsmb_templates
+  workflows:
     - ./workflows
     - ./custom_workflows
 


### PR DESCRIPTION
Beam::Wire 1.031 supports traversal of bare hashes using $ref, eliminating the need to instantiate a Beam::Wire object on every intermediate level being traversed. (Yes, this was possible with $path, but (a) that's deprecated now and (b) using that keyword would add a slew of extra dependencies -- which is why we didn't use either. The old config is fully forward compatible; this is just simpler.
