### PR TITLE
Harmonize 'use v5.xx' statements across modules

### DIFF
--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -1,7 +1,7 @@
 #!/usr/bin/plackup
 #                                                      -*- mode: perl; -*-
 
-
+use v5.38;
 
 BEGIN {
     if ( $ENV{'LSMB_WORKINGDIR'}
@@ -11,8 +11,6 @@ BEGIN {
 }
 
 package LedgerSMB::FCGI;
-
-use v5.14.0;
 
 no lib '.';
 
@@ -33,9 +31,7 @@ use Plack::Builder;
 use Scalar::Util qw(reftype);
 use YAML::PP;
 
-sub merge_config_hashes {
-    my ($left, $right, $relative_entry, $path) = @_;
-    $path //= '';
+sub merge_config_hashes($left, $right, $relative_entry = undef, $path //= '') {
     my $ref_left = reftype $left;
     my $ref_right = reftype $right;
 
@@ -161,8 +157,7 @@ for my $mw ($wire->get( 'extra_middleware' )->@*) {
     $builder->add_middleware( $mw->{name}, $mw->{args}->@* );
 }
 
-sub _inject_wire {
-    my $app = shift;
+sub _inject_wire($app) {
     sub { my $env = shift; $env->{wire} = $wire; $app->($env) }
 }
 

--- a/bin/scan-coa-to-xml
+++ b/bin/scan-coa-to-xml
@@ -1,8 +1,6 @@
 #!/usr/bin/env perl
 
-use v5.020;
-use strict;
-use warnings;
+use v5.38;
 
 use Data::Dumper;
 use List::Util qw/first/;
@@ -17,17 +15,14 @@ sub strip_sq {
     return ($_[0] =~ s/(?:^'|'$)//rg) =~ s/''/'/rg;
 }
 
-sub extract_accno {
-    my $select = shift;
-
+sub extract_accno($select) {
     $select =~ m/accno\s*=\s*'([^']*)'/
        or return $select;
 
     return $1;
 }
 
-sub extract_accnos {
-    my $accnos = shift;
+sub extract_accnos($accnos) {
     my @accnos;
 
     while ($accnos =~ m/'(?<ACCNO>[^']*)'/igsx) {

--- a/cpanfile
+++ b/cpanfile
@@ -155,6 +155,7 @@ requires 'Pod::Find';
 requires 'Scope::Guard', '0.10';
 requires 'Session::Storage::Secure';
 requires 'String::Random';
+requires 'Sublike::Extended', '0.29';
 requires 'Template', '2.14';
 requires 'Template::Parser';
 requires 'Template::Provider';

--- a/doc/adr/0106-coding-style-new-perl-syntax.md
+++ b/doc/adr/0106-coding-style-new-perl-syntax.md
@@ -92,3 +92,10 @@ sub func2($u, :$v = undef) { ... }
 
 ## Annotations
 
+As of `use v5.38` the `warnings` and `signatures` features are enabled. The
+following pragmas should not be used in files declaring `use v5.38` or higher:
+
+```perl
+use warnings;
+use experimental qw( signatures );
+```

--- a/lib/LedgerSMB/Admin/Command/backup.pm
+++ b/lib/LedgerSMB/Admin/Command/backup.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Admin::Command::backup;
@@ -20,8 +19,7 @@ extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 
 
-sub run {
-    my ($self, $dbname, $filename) = @_;
+sub run($self, $dbname, $filename) {
 
     return $self->help('backup')
         if !$dbname || $dbname eq 'help';
@@ -50,8 +48,6 @@ sub run {
 }
 
 __PACKAGE__->meta->make_immutable;
-
-1;
 
 __END__
 

--- a/lib/LedgerSMB/Admin/Command/copy.pm
+++ b/lib/LedgerSMB/Admin/Command/copy.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Admin::Command::copy;
@@ -19,8 +18,7 @@ use experimental 'try'; # Work around Moose re-enabling experimenal warnings
 extends 'LedgerSMB::Admin::Command';
 use namespace::autoclean;
 
-sub run {
-    my ($self, $dbname, $newname) = @_;
+sub run($self, $dbname, $newname) {
 
     return $self->help('copy')
         if !$dbname || $dbname eq 'help';
@@ -56,8 +54,6 @@ sub run {
 }
 
 __PACKAGE__->meta->make_immutable;
-
-1;
 
 __END__
 

--- a/lib/LedgerSMB/Admin/Command/create.pm
+++ b/lib/LedgerSMB/Admin/Command/create.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Admin::Command::create;
@@ -25,15 +24,13 @@ use Getopt::Long qw(GetOptionsFromArray);
 
 has options => (is => 'ro', default => sub { {} });
 
-sub _option_spec {
-    my ($self, $command) = @_;
+sub _option_spec($self) {
     return (
         'prepare-only' => \$self->options->{'prepare-only'},
     );
 }
 
-sub run {
-    my ($self, @args) = @_;
+sub run($self, @args) {
     my $options = {};
 
     Getopt::Long::Configure(qw(bundling require_order));
@@ -96,8 +93,6 @@ sub run {
 
 
 __PACKAGE__->meta->make_immutable;
-
-1;
 
 __END__
 

--- a/lib/LedgerSMB/Admin/Command/destroy.pm
+++ b/lib/LedgerSMB/Admin/Command/destroy.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Admin::Command::destroy;
@@ -21,8 +20,7 @@ use namespace::autoclean;
 
 my $logger;
 
-sub run {
-    my ($self, $dbname) = @_;
+sub run($self, $dbname) {
 
     return $self->help('destroy')
         if !$dbname || $dbname eq 'help';
@@ -122,8 +120,7 @@ sub run {
     return 0;
 }
 
-sub _get_role_prefix {
-    my $db = shift;
+sub _get_role_prefix($db) {
 
     my $dbh = $db->connect;
     my $role_prefix;
@@ -144,8 +141,6 @@ sub _get_role_prefix {
 }
 
 __PACKAGE__->meta->make_immutable;
-
-1;
 
 __END__
 

--- a/lib/LedgerSMB/Admin/Command/restore.pm
+++ b/lib/LedgerSMB/Admin/Command/restore.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Admin::Command::restore;
@@ -25,8 +24,7 @@ use namespace::autoclean;
 
 my $schema = 'public';
 
-sub _option_spec {
-    my ($self, $command) = @_;
+sub _option_spec($self, $command) {
     my %option_spec = ();
 
     if ( $command eq 'restore' ) {
@@ -38,8 +36,7 @@ sub _option_spec {
 }
 
 
-sub run {
-    my ($self, $dbname, $filename, @args) = @_;
+sub run($self, $dbname, $filename, @args) {
 
     return $self->help('restore')
         if !$dbname || $dbname eq 'help';
@@ -90,8 +87,6 @@ sub run {
 }
 
 __PACKAGE__->meta->make_immutable;
-
-1;
 
 __END__
 

--- a/lib/LedgerSMB/Admin/Command/upgrade.pm
+++ b/lib/LedgerSMB/Admin/Command/upgrade.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Admin::Command::upgrade;
@@ -22,8 +21,7 @@ use namespace::autoclean;
 
 has modules_only => (is => 'ro');
 
-sub run {
-    my ($self, @args) = @_;
+sub run($self, @args) {
 
     my $logger = $self->logger;
 
@@ -69,8 +67,6 @@ sub run {
 
 
 __PACKAGE__->meta->make_immutable;
-
-1;
 
 __END__
 

--- a/lib/LedgerSMB/Admin/Command/user.pm
+++ b/lib/LedgerSMB/Admin/Command/user.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Admin::Command::user;
@@ -30,8 +29,7 @@ use namespace::autoclean;
 
 has options => (is => 'ro', default => sub { {} });
 
-sub _get_valid_salutation {
-    my ($self, $dbh) = @_;
+sub _get_valid_salutation($self, $dbh) {
     my $sth = $dbh->prepare('SELECT id FROM salutation WHERE salutation ilike ?');
     $sth->execute($self->options->{salutation})
         or die $dbh->errstr;
@@ -41,8 +39,7 @@ sub _get_valid_salutation {
     return $value->{id};
 }
 
-sub _get_salutation_by_id {
-    my ($self, $dbh, $id) = @_;
+sub _get_salutation_by_id($self, $dbh, $id) {
     my $sth = $dbh->prepare('SELECT salutation FROM salutation WHERE id=?');
     $sth->execute($id)
         or die $dbh->errstr;
@@ -50,9 +47,7 @@ sub _get_salutation_by_id {
     return $values->{salutation};
 }
 
-sub _get_user {
-    my ($self, $dbh, $_username) = @_;
-    $_username //= $self->options->{username};
+sub _get_user($self, $dbh, $_username = $self->options->{username}) {
 
     # Get user by username
     my $sth =
@@ -63,8 +58,7 @@ sub _get_user {
     return $user;
 }
 
-sub _get_valid_country {
-    my ($self, $dbh) = @_;
+sub _get_valid_country($self, $dbh) {
     return if !$self->options->{country};
     my $sth = $dbh->prepare('SELECT * FROM country WHERE name ilike ? OR short_name=?');
     $sth->execute($self->options->{country},uc $self->options->{country})
@@ -78,8 +72,7 @@ sub _get_valid_country {
     return;
 }
 
-sub _get_country_by_id {
-    my ($self, $dbh, $id) = @_;
+sub _get_country_by_id($self, $dbh, $id) {
     my $sth = $dbh->prepare('SELECT * FROM country WHERE id=?');
     $sth->execute($id)
         or die $dbh->errstr;
@@ -87,8 +80,7 @@ sub _get_country_by_id {
     return $values->{name};
 }
 
-sub _option_spec {
-    my ($self, $command) = @_;
+sub _option_spec($self, $command) {
     my %option_spec = ();
 
     if ( $command eq 'change'
@@ -134,8 +126,7 @@ sub _option_spec {
     return %option_spec;
 }
 
-sub _add_permissions{
-    my ($self, $dbh, $user) = @_;
+sub _add_permissions($self, $dbh, $user) {
 
     my $roles;
     @$roles = @{$user->{role_list}};
@@ -156,8 +147,7 @@ sub _add_permissions{
     return 1;
 }
 
-sub _remove_permissions{
-    my ($self, $dbh, $user) = @_;
+sub _remove_permissions($self, $dbh, $user) {
 
         my $roles;
         @$roles = @{$user->{role_list}};
@@ -178,8 +168,7 @@ sub _remove_permissions{
     return 1;
 }
 
-sub change {
-    my ($self, $dbh, $options, @args) = @_;
+sub change($self, $dbh, $options, @args) {
 
     try {
         my %options = ();
@@ -248,8 +237,7 @@ sub change {
     }
 }
 
-sub create {
-    my ($self, $dbh, $options, @args) = @_;
+sub create($self, $dbh, $options, @args) {
 
     try {
         my %options = ();
@@ -312,8 +300,7 @@ sub create {
     }
 }
 
-sub _create_employee {
-    my ($self, %args) = @_;
+sub _create_employee($self, %args) {
 
     my $dbh = $args{dbh};
 
@@ -365,8 +352,7 @@ sub _create_employee {
     return $emp;
 }
 
-sub _create_user {
-    my ($self, %args) = @_;
+sub _create_user($self, %args) {
 
     my $dbh = $args{dbh};
     my $_username = $args{username};
@@ -386,8 +372,7 @@ sub _create_user {
 
 # What about all the data attached to this user?
 # Marked inactive would be better?
-sub delete {
-    my ($self, $dbh, $options, @args) = @_;
+sub delete($self, $dbh, $options, @args) {
 
     try {
         my %options = ();
@@ -433,8 +418,7 @@ sub delete {
     }
 }
 
-sub list {
-    my ($self, $dbh, $options, $db_uri, $user) = @_;
+sub list($self, $dbh, $options, $db_uri, $user) {
 
     if (!defined $user) {
         my @users = LedgerSMB::User->get_all_users( { dbh => $dbh } );
@@ -488,8 +472,7 @@ Id     Username        Created
     return 0;
 }
 
-sub _before_dispatch {
-    my ($self, $options, @args) = @_;
+sub _before_dispatch($self, $options, @args) {
 
     my $db_uri = (@args) ? $args[0] : undef;
     my $connect_data = {
@@ -506,8 +489,6 @@ sub _before_dispatch {
 }
 
 __PACKAGE__->meta->make_immutable;
-
-1;
 
 __END__
 

--- a/lib/LedgerSMB/Database/ConsistencyChecks.pm
+++ b/lib/LedgerSMB/Database/ConsistencyChecks.pm
@@ -1,7 +1,7 @@
-package LedgerSMB::Database::ConsistencyChecks;
 
-use v5.28.0;
-use warnings;
+use v5.38;
+
+package LedgerSMB::Database::ConsistencyChecks;
 
 use Exporter 'import';
 use File::Find::Rule;
@@ -38,8 +38,7 @@ schema.
 
 =cut
 
-sub find_checks {
-    my ($path) = @_;
+sub find_checks($path) {
     my @checks = sort File::Find::Rule->new()
         ->name( '*.sql' )
         ->in( File::Spec->catdir( $path, 'consistency' ) );
@@ -51,8 +50,7 @@ sub find_checks {
 
 =cut
 
-sub load_checks {
-    my ($paths) = @_;
+sub load_checks($paths) {
 
     return [
         map {
@@ -103,8 +101,7 @@ Number of failures in case the check failed.
 
 =cut
 
-sub run_checks {
-    my ($dbh, $checks) = @_;
+sub run_checks($dbh, $checks) {
 
     for my $check ($checks->@*) {
         my $query = qq|select count(*) from ($check->{query}) x|;
@@ -129,5 +126,4 @@ your software.
 
 =cut
 
-1;
 

--- a/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/CogsAllocation.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental qw( signatures );
 
 package LedgerSMB::Database::PostUpgrade::CogsAllocation;
@@ -107,4 +106,3 @@ your software.
 
 =cut
 
-1;

--- a/lib/LedgerSMB/Database/PostUpgrade/CogsAllocationCleanup.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/CogsAllocationCleanup.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental qw( signatures );
 
 package LedgerSMB::Database::PostUpgrade::CogsAllocationCleanup;
@@ -46,4 +45,3 @@ your software.
 
 =cut
 
-1;

--- a/lib/LedgerSMB/Database/PostUpgrade/MigrationSchemaCleanup.pm
+++ b/lib/LedgerSMB/Database/PostUpgrade/MigrationSchemaCleanup.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental qw( signatures );
 
 package LedgerSMB::Database::PostUpgrade::MigrationSchemaCleanup;
@@ -47,4 +46,3 @@ your software.
 
 =cut
 
-1;

--- a/lib/LedgerSMB/FileFormats/ISO20022/CAMT053.pm
+++ b/lib/LedgerSMB/FileFormats/ISO20022/CAMT053.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::FileFormats::ISO20022::CAMT053;
@@ -35,8 +34,7 @@ not identified as a CAMT053 document.
 
 =cut
 
-sub new {
-    my ($class, $fh) = @_;
+sub new($class, $fh) {
     return unless defined $fh;
 
     my ($dom, $ns);
@@ -62,8 +60,7 @@ Returns the XML::LibXML DOM tree representing the input xml.
 
 =cut
 
-sub dom {
-    my ($self) = @_;
+sub dom($self) {
     return $self->{dom};
 }
 
@@ -90,8 +87,7 @@ Returns a flattened list with the following elements:
 
 =cut
 
-sub _decode_crdt {
-    my ($code) = @_;
+sub _decode_crdt($code) {
     die "bad debit/credit code: $code"
           unless lc($code) =~ /^(crdt|dbit)$/;
     my $ret;
@@ -99,8 +95,7 @@ sub _decode_crdt {
     return $ret // 'debit';
 }
 
-sub lineitems_simple {
-    my ($self) = @_;
+sub lineitems_simple($self) {
 
     my $xpc = XML::LibXML::XPathContext->new;
     $xpc->registerNs(
@@ -136,5 +131,3 @@ option any later version.  A copy of the license should have been included with
 your software.
 
 =cut
-
-1;

--- a/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
+++ b/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::FileFormats::OFX::BankStatement;
@@ -87,8 +86,7 @@ not identified as a OFX document.
 
 =cut
 
-sub new {
-    my ($class, $fh) = @_;
+sub new($class, $fh) {
     return unless defined $fh;
 
     my ($dom, $is_ofx);
@@ -111,8 +109,7 @@ Returns the XML::LibXML DOM tree representing the input xml.
 
 =cut
 
-sub dom {
-    my ($self) = @_;
+sub dom($self) {
     return $self->{dom};
 }
 
@@ -129,9 +126,7 @@ following elements:
 
 =cut
 
-sub transactions {
-    my ($self) = @_;
-
+sub transactions($self) {
     my $transactions = $self->dom->find('//STMTTRNRS/STMTRS/BANKTRANLIST/STMTTRN');
 
     my @transactions = map {{
@@ -154,5 +149,3 @@ option any later version.  A copy of the license should have been included with
 your software.
 
 =cut
-
-1;

--- a/lib/LedgerSMB/I18N.pm
+++ b/lib/LedgerSMB/I18N.pm
@@ -1,4 +1,6 @@
 
+use v5.38;
+
 package LedgerSMB::I18N;
 
 =head1 NAME
@@ -16,8 +18,6 @@ object from the 'language' property.
 
 =cut
 
-#use v5.24.0;
-
 use Locale::CLDR;
 use Locales unicode => 1;
 use Moose::Role;
@@ -31,8 +31,7 @@ has 'locale' => (is => 'ro',
                  lazy => 1,
                  builder => '_build_locale');
 
-sub _build_locale {
-    my ($self) = @_;
+sub _build_locale($self) {
 
     my $locale;
     if ($self->language) {
@@ -57,10 +56,8 @@ Note: The first argument must be a string constant for
 
 =cut
 
-sub Text {
-    my $self = shift;
-
-    return $self->locale->maketext(@_);
+sub Text($self, @args) {
+    return $self->locale->maketext(@args);
 }
 
 
@@ -76,10 +73,8 @@ Note: In order for the first string (if it is an inline constant string)
 
 =cut
 
-sub Maketext {
-    my $self = shift;
-
-    return $self->locale->maketext(@_);
+sub Maketext($self, @args) {
+    return $self->locale->maketext(@args);
 }
 
 
@@ -89,8 +84,7 @@ Get a country localized list to allow user selection
 
 =cut
 
-sub get_country_list {
-    my $language = shift;
+sub get_country_list($language) {
     my %regions = Locale::CLDR->new($language)->all_regions->%*;
     return [
         sort { $a->{text} cmp $b->{text} }
@@ -111,5 +105,3 @@ option any later version.  A copy of the license should have been included with
 your software.
 
 =cut
-
-1;

--- a/lib/LedgerSMB/Num2text.pm
+++ b/lib/LedgerSMB/Num2text.pm
@@ -1,7 +1,5 @@
 
-use warnings;
 use v5.38;
-use experimental qw/ signatures /;
 
 package LedgerSMB::Num2text;
 
@@ -72,5 +70,3 @@ option any later version.  A copy of the license should have been included with
 your software.
 
 =cut
-
-1;

--- a/lib/LedgerSMB/PGDate.pm
+++ b/lib/LedgerSMB/PGDate.pm
@@ -1,4 +1,6 @@
 
+use v5.38;
+
 package LedgerSMB::PGDate;
 
 =head1 NAME
@@ -14,8 +16,6 @@ The type behaves internally as a Datetime module.
 
 =cut
 
-use v5.36.1;
-use warnings;
 use parent qw(PGObject::Type::DateTime);
 
 use Carp;
@@ -142,10 +142,7 @@ defers object creation to the superclass.
 
 =cut
 
-sub new {
-    my $class = shift;
-    my @args = @_;
-
+sub new($class, @args) {
     if (! @args) {
         my $self = {};
         bless $self, $class;
@@ -165,8 +162,7 @@ This adds $n * $interval to the date, defaulting to 1 if $n is not supplied.
 
 =cut
 
-sub add_interval {
-    my ($self,$interval,$n) = @_;
+sub add_interval($self,$interval,$n = 1) {
 
     my %delta_names = (
         day => 'days',
@@ -179,7 +175,6 @@ sub add_interval {
     #Validate asked interval
     die "Bad interval: $interval" if not defined $delta_name;
 
-    $n //= 1;    # Default to 1
     $n *= MONTHS_PER_QUARTER if $interval eq 'quarter'; # A quarter is 3 months
 
     my $has_time = $self->is_time();
@@ -196,15 +191,12 @@ unless C<$format> has been specified to override it.
 
 =cut
 
-sub from_input{
-    my $self = shift;
-    my $input = shift;
-
+sub from_input($self, $input, @args) {
     return $input if $input isa __PACKAGE__ && $input->is_date;
     return __PACKAGE__->new()
         if ! $input; # matches undefined as well as ''
 
-    my %args   = (ref($_[0]) eq 'HASH') ? %{$_[0]} : @_;
+    my %args   = (ref($args[0]) eq 'HASH') ? %{$args[0]} : @args;
     my $format = $args{format} // $args{dateformat};
     croak 'LedgerSMB::PGDate No Format Set' if !$format;
 
@@ -238,8 +230,8 @@ used.  If $format is not supplied, the dateformat of the user is used.
 
 =cut
 
-sub _formatter {
-    return DateTime::Format::Strptime->new(@_);
+sub _formatter(@args) {
+    return DateTime::Format::Strptime->new(@args);
 }
 
 # Together with the memoization in PGNumber,
@@ -253,15 +245,14 @@ use overload (
     q{""}    => '_stringification',
 );
 
-sub _stringification {
+sub _stringification($self, $, $) {
     # drop the second and third parameters before calling to_output()
-    return $_[0]->to_output();
+    return $self->to_output();
 }
 
-sub to_output {
-    my $self = shift @_;
+sub to_output($self, @args) {
     return '' if not $self->is_date();
-    my %args  = (ref($_[0]) eq 'HASH')? %{$_[0]}: @_;
+    my %args  = (ref($args[0]) eq 'HASH')? %{$args[0]}: @args;
 
     my $fmt = $args{format} // $args{dateformat} // '%F';
     $fmt = $formats->{uc($fmt)} if defined $formats->{uc($fmt)};
@@ -288,8 +279,7 @@ Returns sortable key for the Date/Time value (epoch)
 
 =cut
 
-sub to_sort {
-    my $self = shift;
+sub to_sort($self) {
     return $self->epoch;
 }
 
@@ -306,6 +296,3 @@ option any later version.  A copy of the license should have been included with
 your software.
 
 =cut
-
-
-1;

--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -1,4 +1,6 @@
 
+use v5.38;
+
 package LedgerSMB::PGNumber;
 
 =head1 NAME
@@ -15,8 +17,6 @@ Math::BigFloat and can be used in this way.
 
 =cut
 
-use v5.36.1;
-use warnings;
 use parent qw(PGObject::Type::BigFloat);
 
 # try using the GMP library for Math::BigFloat for speed
@@ -66,9 +66,7 @@ use overload 'bool' => '_bool';
 
 # function to return boolean value based on the numerical value
 # of the BigFloat (zero being false)
-sub _bool {
-    my ($self) = @_;
-
+sub _bool($self, $, $) {
     return !($self == 0);
 }
 
@@ -150,8 +148,8 @@ Constructor to prevent BigFloat downgrades to BigInt
 
 =cut
 
-sub _formatter {
-    return Number::Format->new(@_);
+sub _formatter(@args) {
+    return Number::Format->new(@args);
 }
 
 # Together with the memoization in PGNumber,
@@ -160,10 +158,9 @@ sub _formatter {
 memoize('_formatter');
 
 
-sub new {
-    my $class = shift;
+sub new($class, @args) {
     local $Math::BigFloat::downgrade = undef;
-    return $class->SUPER::new(@_);
+    return $class->SUPER::new(@args);
 }
 
 =item from_input(string $input, hashref %args);
@@ -172,15 +169,12 @@ The input is formatted.
 
 =cut
 
-sub from_input {
-    my $self = shift;
-    my $string = shift;
-
+sub from_input($self, $string, @args) {
     return $string if $string isa __PACKAGE__;
     if (!defined $string || $string eq '') {
         return undef;
     }
-    my %args   = (ref($_[0]) eq 'HASH') ? %{$_[0]} : @_;
+    my %args   = (ref($args[0]) eq 'HASH') ? %{$args[0]} : @args;
     my $format = $args{format} // $args{numberformat};
     croak 'LedgerSMB::PGNumber No Format Set' if !$format;
 
@@ -234,9 +228,8 @@ Specifies the negative format
 =cut
 
 
-sub to_output {
-    my $self = shift @_;
-    my %args  = (ref($_[0]) eq 'HASH')? %{$_[0]}: @_;
+sub to_output($self, @args) {
+    my %args  = (ref($args[0]) eq 'HASH')? %{$args[0]}: @args;
     my $is_neg = $self->is_neg;
 
     my $format = $args{format} // $args{numberformat};
@@ -272,8 +265,8 @@ Returns the value for sorting purposes
 
 =cut
 
-sub to_sort {
-    return $_[0]->bstr;
+sub to_sort($self) {
+    return $self->bstr;
 }
 
 =back
@@ -288,5 +281,3 @@ your software.
 
 =cut
 
-
-1;

--- a/lib/LedgerSMB/PGTimestamp.pm
+++ b/lib/LedgerSMB/PGTimestamp.pm
@@ -1,4 +1,6 @@
 
+use v5.38;
+
 package LedgerSMB::PGTimestamp;
 
 =head1 NAME
@@ -14,8 +16,6 @@ The type behaves internally as a Datetime module.
 
 =cut
 
-use v5.36.1;
-use warnings;
 use parent qw(PGObject::Type::DateTime);
 
 use Carp;
@@ -32,9 +32,7 @@ use overload (
 __PACKAGE__->register(registry => 'default',
                       types => ['timestamp', 'timestamptz']);
 
-sub _stringify {
-    my $self = shift;
-
+sub _stringify($self, $, $) {
     # Stringify without the 'T' in the middle
     #   which is the same way Pg stringifies
     return $self->strftime('%F %T');
@@ -68,10 +66,7 @@ defers object creation to the superclass.
 
 =cut
 
-sub new {
-    my $class = shift;
-    my @args = @_;
-
+sub new($class, @args) {
     if (! @args) {
         my $self = {};
         bless $self, $class;
@@ -91,8 +86,7 @@ This adds $n * $interval to the date, defaulting to 1 if $n is not supplied.
 
 =cut
 
-sub add_interval {
-    my ($self,$interval,$n) = @_;
+sub add_interval($self, $interval, $n) {
 
     my %delta_names = (
         day => 'days',
@@ -150,10 +144,7 @@ my $fb_parser =  DateTime::Format::Strptime->new(
     on_error  => 'undef' );
 
 
-sub from_input{
-    my $self = shift;
-    my $input = shift;
-
+sub from_input($self, $input) {
     return $input if $input isa __PACKAGE__ && $input->is_date;
     return __PACKAGE__->new()
         if ! $input; # matches undefined as well as ''
@@ -176,10 +167,9 @@ used.  If $format is not supplied, the dateformat of the user is used.
 
 =cut
 
-sub to_output {
-    my $self = shift @_;
+sub to_output($self, @args) {
     return '' if not $self->is_date();
-    my %args  = (ref($_[0]) eq 'HASH')? %{$_[0]}: @_;
+    my %args  = (ref($args[0]) eq 'HASH')? %{$args[0]}: @args;
 
     my $fmt = $args{format} // $args{datetimeformat};
     if (not defined $fmt) {
@@ -208,8 +198,7 @@ Returns sortable key for the Date/Time value (epoch)
 
 =cut
 
-sub to_sort {
-    my $self = shift;
+sub to_sort($self) {
     return $self->epoch;
 }
 
@@ -226,6 +215,3 @@ option any later version.  A copy of the license should have been included with
 your software.
 
 =cut
-
-
-1;

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -1,7 +1,7 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
+use Sublike::Extended 0.29 'sub';
 
 package LedgerSMB::PSGI;
 
@@ -89,10 +89,7 @@ Returns a 'PSGI app' which handles requests for the 'old-code' scripts in old/bi
 
 =cut
 
-sub old_app {
-    my $script = shift;
-    my $wire = shift;
-
+sub old_app($script, $wire) {
     # marshall the psgi environment into the cgi environment
     # so we can re-use state from the various middlewares
     return sub {
@@ -128,13 +125,13 @@ sub old_app {
                     return;
                 }
             )->($env),
-            sub {
-                Plack::Util::header_set($_[0]->[1],
+            sub($triplet) {
+                Plack::Util::header_set($triplet->[1],
                                         'Content-Security-Policy',
                                         q{frame-ancestors 'self'});
-                if (not Plack::Util::header_exists($_[0]->[1],
+                if (not Plack::Util::header_exists($triplet->[1],
                                                    'X-LedgerSMB-App-Content')) {
-                    Plack::Util::header_push($_[0]->[1],
+                    Plack::Util::header_push($triplet->[1],
                                              'X-LedgerSMB-App-Content', 'yes');
                 }
             });
@@ -150,11 +147,8 @@ in LedgerSMB::Scripts::*.
 =cut
 
 
-sub psgi_app {
-    my $wire = shift;
-
-    return sub {
-        my $env = shift;
+sub psgi_app($wire) {
+    return sub($env) {
         my $psgi_req = Plack::Request::WithEncoding->new($env);
         my $request  = LedgerSMB->new($psgi_req, $wire);
 
@@ -192,8 +186,7 @@ sub psgi_app {
 
         return Plack::Util::response_cb(
             $res,
-            sub {
-                my $res = shift;
+            sub($res) {
                 Plack::Util::header_set($res->[1],
                                         'Content-Security-Policy',
                                         q{frame-ancestors 'self'});
@@ -208,14 +201,11 @@ appropriate PSGI handlers/apps.
 
 =cut
 
-sub _hook_psgi_logger {
-    my ($env, $settings, $router) = @_;
+sub _hook_psgi_logger($env, $settings, $router, $path) {
     my $logger_name = $settings->{logger} ? ".$settings->{logger}" : '';
     my $logger = Log::Any->get_logger(category => "LedgerSMB$logger_name");
 
-    $env->{'psgix.logger'} = sub {
-        my ($level, $msg) = @{$_[0]}{qw/ level message /};
-
+    $env->{'psgix.logger'} = sub(:$level, :$msg = undef) {
         return if not defined $msg;
 
         local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
@@ -226,8 +216,7 @@ sub _hook_psgi_logger {
     return;
 }
 
-sub _oldscript_mount {
-    my ($script, $cookie, $secret, $wire) = @_;
+sub _oldscript_mount($script, $cookie, $secret, $wire) {
     builder {
         enable '+LedgerSMB::Middleware::RequestID';
         enable 'AccessLog', format => 'Req:%{Request-Id}i %h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"';
@@ -251,8 +240,7 @@ sub _oldscript_mount {
     }
 }
 
-sub _psgiscript_mount {
-    my ($script, $cookie, $secret, $wire, $app, $open_connection) = @_;
+sub _psgiscript_mount($script, $cookie, $secret, $wire, $app, $open_connection) {
 
     builder {
         enable '+LedgerSMB::Middleware::RequestID';
@@ -279,8 +267,7 @@ sub _psgiscript_mount {
     }
 }
 
-sub _api_mount {
-    my ($cookie, $secret, $wire) = @_;
+sub _api_mount($cookie, $secret, $wire) {
     builder {
         enable '+LedgerSMB::Middleware::RequestID';
         enable 'AccessLog',
@@ -301,9 +288,7 @@ sub _api_mount {
         my $router = router 'erp/api';
         $router->hooks('before' => \&_hook_psgi_logger);
         $router->hooks(
-            'before' => sub {
-                my ($env) = @_;
-
+            'before' => sub($env, $, $, $) {
                 $env->{wire} = $wire;
                 return;
             });
@@ -311,8 +296,7 @@ sub _api_mount {
     }
 }
 
-sub _session_url_space {
-    my ($wire, $cookie, $secret) = @_;
+sub _session_url_space($wire, $cookie, $secret) {
     my $psgi_app    = psgi_app($wire);
 
     builder {
@@ -338,8 +322,7 @@ sub _session_url_space {
     }
 }
 
-sub setup_url_space {
-    my %args        = @_;
+sub setup_url_space(%args) {
     my $wire        = $args{wire};
 
     my $cookie      = $wire->get( 'cookie' )->{name} // 'LedgerSMB';
@@ -442,5 +425,3 @@ your software.
 
 =cut
 
-
-1;

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -1,4 +1,6 @@
 
+use v5.38;
+
 package LedgerSMB::Report;
 
 =head1 NAME
@@ -167,8 +169,6 @@ C<UI/reports/display_report> template will be used.
 
 =cut
 
-use v5.36.1;
-use warnings;
 
 use List::Util qw{ any pairgrep };
 use LedgerSMB::PGNumber;
@@ -370,7 +370,7 @@ reports.
 
 =cut
 
-sub set_buttons {
+sub set_buttons($self) {
     return [];
 }
 
@@ -385,7 +385,7 @@ a meaningless sum displayed on the totals row.
 
 =cut
 
-sub _exclude_from_totals {
+sub _exclude_from_totals($self) {
     return {};
 }
 
@@ -398,7 +398,7 @@ The default implementation returns C<false>.
 
 =cut
 
-sub _exclude_row_from_totals {
+sub _exclude_row_from_totals($self, $row) {
     return '';
 }
 
@@ -413,11 +413,9 @@ the template).
 
 =cut
 
-sub render {
-    my $self = shift;
-
+sub render($self, @args) {
     $self->run_report() if not defined $self->rows;
-    return $self->_render(@_);
+    return $self->_render(@args);
 }
 
 
@@ -427,8 +425,7 @@ Returns the suggested file name to be used to store the report.
 
 =cut
 
-sub output_name {
-    my $self = shift;
+sub output_name($self) {
     my $name = $self->name // '';
     $name =~ s/ /_/g;
 
@@ -451,8 +448,7 @@ set true into correctly formatted strings. Invoked as part of C<render>.
 
 =cut
 
-sub format_money_columns {
-    my ($self, $columns) = @_;
+sub format_money_columns($self, $columns) {
     my @columns = ($columns // $self->columns)->@*;
 
     for my $col (@columns){
@@ -480,10 +476,8 @@ sub format_money_columns {
 # Render the report.
 
 
-sub _render {
-    my $self = shift;
+sub _render($self, %args) {
     my $template;
-    my %args = @_;
 
     # This is a hook for other modules to use to override the default
     # template --CT
@@ -646,7 +640,7 @@ individual reports.
 
 =cut
 
-sub header_lines {
+sub header_lines($self) {
     return [];
 }
 
@@ -659,8 +653,7 @@ bc_$class_id holding the $bu_id fields.
 
 =cut
 
-sub process_bclasses {
-    my ($self, $ref) = @_;
+sub process_bclasses($self, $ref) {
     for my $bu (@{$ref->{business_units}}){
      if($bu->[1]){#avoid message:Use of uninitialized value in hash element
         push @{$ref->{$bu->[0]}}, $bu->[1]
@@ -682,5 +675,3 @@ your software.
 =cut
 
 __PACKAGE__->meta->make_immutable;
-
-1;

--- a/lib/LedgerSMB/Routes/ERP/API/Products.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Products.pm
@@ -221,9 +221,10 @@ get api '/products/partsgroups/{id}' => sub {
 put api '/products/partsgroups/{id}' => sub {
     my ($env, $r, $c, $body, $params) = @_;
 
-    $env->{'psgix.logger'}->({
-        message => "PUT /products/partsgroups/$params->{id}",
-        level => 'info' });
+    $env->{'psgix.logger'}->(
+        msg => "PUT /products/partsgroups/$params->{id}",
+        level => 'info'
+        );
     my ($ETag) = ($r->headers->header('If-Match') =~ m/^\s*(?>W\/)?"(.*)"\s*$/);
     my ($response, $meta) = _update_partsgroup(
         $c, {

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Scripts::account;
@@ -34,8 +33,7 @@ Displays a screen to create a new account.
 
 =cut
 
-sub new_account {
-    my ($request) = @_;
+sub new_account($request) {
     return _display_account_screen($request, { charttype => 'A' });
 }
 
@@ -45,8 +43,7 @@ Displays a screen to create a new Chart of Accounts heading.
 
 =cut
 
-sub new_heading {
-    my ($request) = @_;
+sub new_heading($request) {
     return _display_account_screen($request, { charttype => 'H' });
 }
 
@@ -58,8 +55,7 @@ Requires the id and charttype variables in the request to be set.
 
 =cut
 
-sub edit {
-    my ($request) = @_;
+sub edit($request) {
     my $func = 'account_get';
     my $trans_func = 'account__list_translations';
 
@@ -107,8 +103,7 @@ link:  a list of strings representing text box identifier.
 
 =cut
 
-sub _generate_links {
-    my $request = shift;
+sub _generate_links($request) {
     my @links;
     my @descriptions = $request->call_procedure(
         funcname => 'get_link_descriptions',
@@ -128,8 +123,7 @@ sub _generate_links {
      return \@links;
 }
 
-sub save {
-    my ($request) = @_;
+sub save($request) {
 
     if ( defined $request->{parent} and $request->{parent} == -1 ) {
         $request->{parent} = undef;
@@ -193,8 +187,7 @@ Saves selected translations
 
 =cut
 
-sub update_translations {
-    my ($request) = @_;
+sub update_translations($request) {
     my $trans_save_func = 'account__save_translation';
     my $trans_del_func = 'account__delete_translation';
     if ($request->{charttype} and $request->{charttype} eq 'H') {
@@ -233,15 +226,13 @@ Saves as a new account.  Deletes the id field and then calls save()
 
 =cut
 
-sub save_as_new {
-    my ($request) = @_;
+sub save_as_new($request) {
     $request->{id} = undef;
     return save($request);
 }
 
 
-sub _display_account_screen {
-    my ($request, $account) = @_;
+sub _display_account_screen($request, $account) {
     @{$account->{all_headings}} =
         $request->call_procedure(funcname => 'account_heading__list');
     $account->{custom_link_descriptions} = [
@@ -277,8 +268,7 @@ Shows the yearend screen.  No expected inputs.
 
 =cut
 
-sub yearend_info {
-    my ($request) = @_;
+sub yearend_info($request) {
     my $template = $request->{_wire}->get('ui');
     my $dbh = $request->{dbh};
     my @closing_dates = $dbh->selectall_array(
@@ -323,8 +313,7 @@ in_retention_acc_id: Account id to post retained earnings into
 
 =cut
 
-sub post_yearend {
-    my ($request) = @_;
+sub post_yearend($request) {
     $request->call_procedure(
         funcname => 'eoy_close_books',
         args     => [
@@ -346,8 +335,7 @@ period_close_date: Date up to (inclusive) which to close the books
 
 =cut
 
-sub close_period {
-    my ($request) = @_;
+sub close_period($request) {
     $request->call_procedure(
         funcname => 'eoy_create_checkpoint',
         args     => [ $request->{period_close_date} ]);
@@ -362,8 +350,7 @@ This reopens books as of $request->{reopen_date}
 
 =cut
 
-sub reopen_books {
-    my ($request) = @_;
+sub reopen_books($request) {
     $request->call_procedure(
         funcname => 'eoy_reopen_books',
         args     => [ $request->{reopen_date} ]);
@@ -383,5 +370,3 @@ your software.
 
 =cut
 
-
-1;

--- a/lib/LedgerSMB/Scripts/budgets.pm
+++ b/lib/LedgerSMB/Scripts/budgets.pm
@@ -1,4 +1,6 @@
 
+use v5.38;
+
 package LedgerSMB::Scripts::budgets;
 
 =head1 NAME
@@ -10,9 +12,6 @@ LedgerSMB::Scripts::budgets - web entry points for administration of budgets
 Budget workflow scripts.
 
 =cut
-
-use v5.36.1;
-use warnings;
 
 use LedgerSMB::Budget;
 use LedgerSMB::Business_Unit;
@@ -37,8 +36,7 @@ defaults however.
 
 =cut
 
-sub new_budget {
-    my ($request) = @_;
+sub new_budget($request) {
     $request->{rowcount} ||= 0;
     my $budget = LedgerSMB::Budget->new($request);
     return _render_screen($request, $budget);
@@ -49,8 +47,7 @@ sub new_budget {
 # used by new_budget, view_budget, and update
 # Prepares and renders screen with budget info.
 
-sub _render_screen {
-    my ($request, $budget) = @_;
+sub _render_screen($request, $budget) {
     my $additional_rows = EDIT_BUDGET_ROWS;
     $additional_rows = NEW_BUDGET_ROWS unless $budget->lines;
     $additional_rows = 0 if $budget->id;
@@ -144,8 +141,7 @@ Updates the screen.  Part of initial entry workflow only.
 
 =cut
 
-sub update {
-    my ($request) = @_;
+sub update($request, @args) {
     $request->{display_rows} = [];
     for (1 .. $request->{rowcount}){
         push @{$request->{display_rows}},
@@ -157,7 +153,7 @@ sub update {
 
     }
     $request->{rowcount} = scalar @{$request->{display_rows}} + 1;
-    return new_budget(@_);
+    return new_budget($request, @args);
 }
 
 =item view_budget
@@ -165,8 +161,7 @@ Reuuires id to be set.  Displays a budget for review.
 
 =cut
 
-sub view_budget {
-    my ($request) = @_;
+sub view_budget($request) {
     my $budget = LedgerSMB::Budget->new(%$request);
     $budget = $budget->get($request->{id});
     $budget->{display_rows} = [];
@@ -194,8 +189,7 @@ LedgerSMB::Budget properties required.  Lines represented by
 
 =cut
 
-sub save {
-    my ($request) = @_;
+sub save($request) {
     my $budget = LedgerSMB::Budget->from_input($request);
     $budget->save();
     return view_budget($budget);
@@ -206,8 +200,7 @@ Requires id.  Approves the budget.
 
 =cut
 
-sub approve {
-    my ($request) = @_;
+sub approve($request) {
     my $budget = LedgerSMB::Budget->new(%$request);
     $budget->approve;
     return view_budget($request);
@@ -218,8 +211,7 @@ Requires id.  Rejects unapproved budget and deletes it.
 
 =cut
 
-sub reject {
-    my ($request) = @_;
+sub reject($request) {
     my $budget = LedgerSMB::Budget->new(%$request);
     $budget->reject;
     return begin_search($request);
@@ -230,8 +222,7 @@ Requires id, Marks budget obsolete.
 
 =cut
 
-sub obsolete {
-    my ($request) = @_;
+sub obsolete($request) {
     my $budget = LedgerSMB::Budget->new(%$request);
     $budget->obsolete;
     return view_budget($request);
@@ -242,8 +233,7 @@ Requires id, subject, and note.  Adds a note to the budget.
 
 =cut
 
-sub add_note {
-    my ($request) = @_;
+sub add_note($request) {
     my $budget = LedgerSMB::Budget->new(%$request);
     $budget->save_note($request->{subject}, $request->{note});
     return view_budget($request);
@@ -254,8 +244,7 @@ No inputs expected or used
 
 =cut
 
-sub begin_search{
-    my ($request) = @_;
+sub begin_search($request) {
     $request->{module_name} = 'gl';
     $request->{report_name} = 'budget_search';
     use LedgerSMB::Scripts::reports;
@@ -282,5 +271,3 @@ your software.
 
 =cut
 
-
-1;

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -22,14 +22,10 @@ This module does not specify any methods.
 
 =cut
 
-use strict;
-use warnings;
-
 use LedgerSMB::I18N;
 use LedgerSMB::Setting::Sequence;
 
-sub _default_settings {
-    my ($request) = @_;
+sub _default_settings($request) {
     my $locale = $request->{_locale};
 
     my @default_settings = (
@@ -175,8 +171,7 @@ Shows the defaults screen
 
 =cut
 
-sub defaults_screen {
-    my ($request) = @_;
+sub defaults_screen($request) {
 
     my @curr = map { { curr => $_ } } $request->setting->get_currencies();
     my @defaults;
@@ -335,8 +330,7 @@ No inputs expected or used
 
 =cut
 
-sub sequence_screen {
-    my ($request) = @_;
+sub sequence_screen($request) {
     @{$request->{sequence_list}} = LedgerSMB::Setting::Sequence->list();
     my @default_settings = &_default_settings($request);
     my $locale = $request->{_locale};
@@ -360,8 +354,7 @@ Saves settings from the defaults screen
 
 =cut
 
-sub save_defaults {
-    my ($request) = @_;
+sub save_defaults($request) {
     if (!$request->is_allowed_role(
         {allowed_roles => ['system_settings_change'] })
     ){
@@ -387,8 +380,7 @@ Saves the items in the sequence screen
 
 =cut
 
-sub save_sequences {
-    my ($request) = @_;
+sub save_sequences($request) {
     for my $count (1 .. $request->{count}){
         if ($request->{"save_$count"} and $request->{"label_$count"}){
            LedgerSMB::Setting::Sequence->new(
@@ -412,4 +404,3 @@ your software.
 
 =cut
 
-1;

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Scripts::contact;
@@ -34,6 +33,7 @@ use LedgerSMB::Entity::Bank;
 use LedgerSMB::Entity::Note;
 use LedgerSMB::Entity::User;
 use LedgerSMB::File;
+use LedgerSMB::Form;
 use LedgerSMB::I18N;
 use LedgerSMB::Magic qw( EC_EMPLOYEE );
 use LedgerSMB::Part;
@@ -68,8 +68,7 @@ for (@pluginmods){
 
 =cut
 
-sub delete_entity {
-    my ($request) = @_;
+sub delete_entity($request) {
     my $entity =
            LedgerSMB::Entity::Company->get_by_cc($request->{control_code});
     $entity ||=  LedgerSMB::Entity::Person->get_by_cc($request->{control_code});
@@ -88,13 +87,12 @@ control code
 
 =cut
 
-sub get_by_cc {
-    my ($request) = @_;
+sub get_by_cc($request) {
     if ($request->{entity_class} == EC_EMPLOYEE){
         my $emp = LedgerSMB::Entity::Person::Employee->get_by_cc(
                             $request->{control_code}
         );
-        return _main_screen($request, undef, $emp);
+        return _main_screen($request, {}, $emp);
     }
     my $entity =
            LedgerSMB::Entity::Company->get_by_cc($request->{control_code});
@@ -111,7 +109,7 @@ sub get_by_cc {
 }
 
 
-=item get($self, $request, $user)
+=item get($request)
 
 Requires form var: id
 
@@ -121,8 +119,7 @@ of the company information.
 
 =cut
 
-sub get {
-    my ($request) = @_;
+sub get($request) {
     if ($request->{entity_class} && $request->{entity_class} == EC_EMPLOYEE){
         my $emp = LedgerSMB::Entity::Person::Employee->get(
                           $request->{entity_id}
@@ -148,8 +145,7 @@ sub get {
 #
 # this attaches everything other than {company} to $request and displays it.
 
-sub _main_screen {
-    my ($request, $company, $person) = @_;
+sub _main_screen($request, $company, $person) {
 
     # DIVS logic
     my @DIVS;
@@ -398,8 +394,7 @@ Saves a company and moves on to the next screen
 
 =cut
 
-sub save_employee {
-    my ($request) = @_;
+sub save_employee($request) {
     unless ($request->{control_code}){
         my ($ref) = $request->call_procedure(
                              funcname => 'setting_increment',
@@ -431,8 +426,7 @@ Generates a control code and hands off execution to other routines
 
 =cut
 
-sub generate_control_code {
-    my ($request) = @_;
+sub generate_control_code($request) {
     my ($ref) = $request->call_procedure(
                              funcname => 'setting_increment',
                              args     => ['entity_control']
@@ -456,9 +450,7 @@ Not fully documented because this will go away as soon as possible.
 
 =cut
 
-sub dispatch_legacy {
-    our ($request) = shift @_;
-    use LedgerSMB::Form;
+sub dispatch_legacy($request) {
     my $aa;
     my $inv;
     my $otype;
@@ -520,8 +512,7 @@ Dispatches to the Add (AR or AP as appropriate) transaction screen.
 
 =cut
 
-sub add_transaction {
-    my $request = shift @_;
+sub add_transaction($request) {
     return dispatch_legacy($request);
 }
 
@@ -531,8 +522,7 @@ Dispatches to the (sales or vendor, as appropriate) invoice screen.
 
 =cut
 
-sub add_invoice {
-    my $request = shift @_;
+sub add_invoice($request) {
     return dispatch_legacy($request);
 }
 
@@ -542,8 +532,7 @@ Dispatches to the sales/purchase order screen.
 
 =cut
 
-sub add_order {
-    my $request = shift @_;
+sub add_order($request) {
     return dispatch_legacy($request);
 }
 
@@ -553,8 +542,7 @@ Dispatches to the quotation/rfq screen
 
 =cut
 
-sub rfq {
-    my $request = shift @_;
+sub rfq($request) {
     return dispatch_legacy($request);
 }
 
@@ -564,10 +552,9 @@ This method creates a blank screen for entering a company's information.
 
 =cut
 
-sub add {
-    my ($request) = @_;
+sub add($request) {
     $request->{target_div} //= 'company_div';
-    return _main_screen($request, $request);
+    return _main_screen($request, $request, {});
 }
 
 =item save_company
@@ -576,8 +563,7 @@ Saves a company and moves on to the next screen
 
 =cut
 
-sub save_company {
-    my ($request) = @_;
+sub save_company($request) {
     unless ($request->{control_code}){
         my ($ref) = $request->call_procedure(
                              funcname => 'setting_increment',
@@ -591,7 +577,7 @@ sub save_company {
         created => $request->parse_date( $request->{created} ),
         );
     $request->{target_div} = 'credit_div';
-    return _main_screen($request, $company->save);
+    return _main_screen($request, $company->save, {});
 }
 
 =item save_person
@@ -600,8 +586,7 @@ Saves a person and moves on to the next screen
 
 =cut
 
-sub save_person {
-    my ($request) = @_;
+sub save_person($request) {
     if ($request->{entity_class} == EC_EMPLOYEE ){
         $request->{dob} = $request->{birthdate} if $request->{birthdate};
        return save_employee($request);
@@ -630,8 +615,7 @@ has sufficient access rights.
 
 =cut
 
-sub delete_credit {
-    my ($request) = @_;
+sub delete_credit($request) {
 
     my $credit = LedgerSMB::Entity::Credit_Account->get_by_id( $request->{credit_id} );
     if ($credit) {
@@ -646,9 +630,7 @@ This inserts or updates a credit account of the sort listed here.
 
 =cut
 
-sub save_credit {
-
-    my ($request) = @_;
+sub save_credit($request) {
     $request->{target_div} = 'credit_div';
     my $company;
 
@@ -696,8 +678,7 @@ This inserts a new credit account.
 =cut
 
 
-sub save_credit_new {
-    my ($request) = @_;
+sub save_credit_new($request) {
     delete $request->{id};
     return save_credit($request);
 }
@@ -709,8 +690,7 @@ Reload the drop-downs linked to the Class drop-down (customer/vendor)
 =cut
 
 
-sub update_credit {
-    my ($request) = @_;
+sub update_credit($request) {
     $request->{target_div} = 'credit_div';
     return get($request);
 }
@@ -721,8 +701,7 @@ Adds a location to the company as defined in the inherited object
 
 =cut
 
-sub save_location {
-    my ($request) = @_;
+sub save_location($request) {
 
     my $credit_id = $request->{credit_id};
     if ($request->{attach_to} == 1){
@@ -750,8 +729,7 @@ overwriting existing locations.
 
 =cut
 
-sub save_new_location {
-    my ($request) = @_;
+sub save_new_location($request) {
     delete $request->{location_id};
     return save_location($request);
 }
@@ -762,10 +740,9 @@ This is a synonym of get() which is preferred to use for editing operations.
 
 =cut
 
-sub edit {
-    my ($request) = @_;
+sub edit($request, @args) {
     $request->{action} = 'edit';
-    return get (@_);
+    return get($request, @args);
 }
 
 =item delete_location
@@ -774,8 +751,7 @@ Deletes the specified location
 
 =cut
 
-sub delete_location {
-    my ($request) = @_;
+sub delete_location($request) {
 
     my $credit_id=$request->{credit_id};
 
@@ -796,8 +772,7 @@ Saves the specified contact info
 
 =cut
 
-sub save_contact {
-    my ($request) = @_;
+sub save_contact($request) {
     my $credit_id = $request->{credit_id};
     if ($request->{attach_to} == 1){
        delete $request->{credit_id};
@@ -818,8 +793,7 @@ Saves the specified contact info as an additional item
 
 =cut
 
-sub save_contact_new {
-    my ($request) = @_;
+sub save_contact_new($request) {
     delete $request->{contact_id};
     delete $request->{old_contact};
 
@@ -833,8 +807,7 @@ credit id over in this case.
 
 =cut
 
-sub delete_contact {
-    my ($request) = @_;
+sub delete_contact($request) {
     LedgerSMB::Entity::Contact::delete($request);
     $request->{target_div} = 'contact_info_div';
     return get($request);
@@ -851,8 +824,7 @@ Required request variables:
 
 =cut
 
-sub delete_bank_account{
-    my ($request) = @_;
+sub delete_bank_account($request) {
     LedgerSMB::Entity::Bank->delete(
         $request->{id},
         $request->{entity_id}
@@ -867,8 +839,7 @@ Adds a bank account to a company and, if defined, an entity credit account.
 
 =cut
 
-sub save_bank_account {
-    my ($request) = @_;
+sub save_bank_account($request) {
     my $bank = LedgerSMB::Entity::Bank->new(%$request);
     $bank->save;
     $request->{target_div} = 'bank_act_div';
@@ -882,8 +853,7 @@ subject.
 
 =cut
 
-sub save_notes {
-    my ($request) = @_;
+sub save_notes($request) {
     my $note = LedgerSMB::Entity::Note->new(%$request);
     $note->save;
     return get($request);
@@ -895,8 +865,7 @@ This returns and displays the pricelist.  The id field is required.
 
 =cut
 
-sub get_pricelist {
-    my ($request) = @_;
+sub get_pricelist($request) {
     my $credit = LedgerSMB::Entity::Credit_Account->get_by_id(
        $request->{credit_id}
     );
@@ -918,8 +887,7 @@ and the description is a full text search.
 
 =cut
 
-sub save_pricelist {
-    my ($request) = @_;
+sub save_pricelist($request) {
     my $count = $request->{rowcount_pricematrix};
     my @lines;
 
@@ -977,8 +945,7 @@ sub save_pricelist {
 
 =cut
 
-sub delete_pricelist {
-    my ($request) = @_;
+sub delete_pricelist($request) {
     $request->call_procedure(
         funcname => 'pricelist__delete',
         args     => [ $request->{entry_id}, $request->{credit_id} ]);
@@ -993,8 +960,7 @@ This turns the employee into a user.
 
 =cut
 
-sub create_user {
-    my ($request) = @_;
+sub create_user($request) {
     $request->{target_div} = 'user_div';
     if ($request->close_form){
        $request->{password} = $request->{reset_password};
@@ -1024,8 +990,7 @@ This removes the user from the company.
 
 =cut
 
-sub delete_user {
-    my ($request) = @_;
+sub delete_user($request) {
     $request->{target_div} = 'user_div';
     if ($request->close_form){
        my $user = LedgerSMB::Entity::User->new(%$request);
@@ -1046,8 +1011,7 @@ This resets the user's password
 
 =cut
 
-sub reset_password {
-    my ($request) = @_;
+sub reset_password($request) {
     if ($request->close_form){
        $request->{password} = $request->{reset_password};
        my $user = LedgerSMB::Entity::User->new(%$request);
@@ -1062,8 +1026,7 @@ Saves the user's permissions
 
 =cut
 
-sub save_roles {
-    my ($request) = @_;
+sub save_roles($request) {
     my $roles = [];
 
     $request->close_form or die 'Form submission is invalid';
@@ -1098,4 +1061,3 @@ your software.
 
 =cut
 
-1;

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Scripts::import_csv;
@@ -76,8 +75,7 @@ my %template_file = (
 our $preprocess = {};
 our $postprocess = {};
 
-sub _inventory_template_setup {
-    my ($request) = @_;
+sub _inventory_template_setup($request) {
     my $sth = $request->{dbh}->prepare(
         q{SELECT concat(accno,'--',description) as value
              FROM chart_get_ar_ap(?)}
@@ -108,8 +106,7 @@ Takes two arrayrefs and returns a hashref as you'd expect from the args.
 
 =cut
 
-sub map_columns_into_hash {
-    my ($keys, $values) = @_;
+sub map_columns_into_hash($keys, $values) {
     my %rv;
 
     @rv{@$keys} = @$values;
@@ -119,8 +116,7 @@ sub map_columns_into_hash {
 
 
 
-sub _aa_multi {
-    my ($request, $entries, $arap) = @_;
+sub _aa_multi($request, $entries, $arap) {
     my $batch = LedgerSMB::Batch->new(%$request);
     $batch->{batch_number} = $request->{reference};
     $batch->{batch_date} = $request->{transdate};
@@ -216,8 +212,7 @@ sub _aa_multi {
     return 1;
 }
 
-sub _inventory_single_date {
-    my ($request, $entries, $transdate) = @_;
+sub _inventory_single_date($request, $entries, $transdate) {
     # NOTE ! This implementation largely mirrors the one
     #  in LedgerSMB::Scripts::inventory::_lines_from_form()
 
@@ -245,18 +240,15 @@ sub _inventory_single_date {
     $adjustment->save;
 }
 
-sub _process_ar_multi {
-    my  ($request, $entries) = @_;
+sub _process_ar_multi ($request, $entries) {
     return &_aa_multi($request, $entries, 'ar');
 }
 
-sub _process_ap_multi {
-    my  ($request, $entries) = @_;
+sub _process_ap_multi ($request, $entries) {
     return &_aa_multi($request, $entries, 'ap');
 }
 
-sub _process_gl_multi {
-    my ($request, $entries) = @_;
+sub _process_gl_multi($request, $entries) {
     my $dbh = $request->{dbh};
     my $batch = LedgerSMB::Batch->new(
         dbh => $dbh,
@@ -341,8 +333,7 @@ sub _process_gl_multi {
     }
 }
 
-sub _process_gl {
-    my ($request, $entries) = @_;
+sub _process_gl($request, $entries) {
     my $form = Form->new(); ## no critic
     $form->{reference} = $request->{reference};
     $form->{description} = $request->{description};
@@ -376,8 +367,7 @@ sub _process_gl {
         $request->{_user}, $form, $request->{_locale});
 }
 
-sub _process_chart {
-    my ($request, $entries) = @_;
+sub _process_chart($request, $entries) {
 
     my %imported;
     my $cfg = LedgerSMB::Company::Configuration->new(dbh => $request->{dbh});
@@ -408,8 +398,7 @@ sub _process_chart {
     return;
 }
 
-sub _process_gifi {
-    my ($request, $entries) = @_;
+sub _process_gifi($request, $entries) {
     my $dbh = $request->{dbh};
     my $sth =
         $dbh->prepare('INSERT INTO gifi (accno, description) VALUES (?, ?)')
@@ -421,8 +410,7 @@ sub _process_gifi {
     return;
 }
 
-sub _process_sic {
-    my ($request, $entries) = @_;
+sub _process_sic($request, $entries) {
     my $dbh = $request->{dbh};
     my $sth =
         $dbh->prepare('INSERT INTO sic (code, sictype, description) VALUES (?, ?, ?)') || die $dbh->errstr;;
@@ -434,8 +422,7 @@ sub _process_sic {
     return;
 }
 
-sub _process_timecard {
-    my ($request, $entries) = @_;
+sub _process_timecard($request, $entries) {
     for my $entry (@$entries) {
         my $jc = {};
         my $counter = 0;
@@ -456,16 +443,14 @@ sub _process_timecard {
     return;
 }
 
-sub _process_inventory {
-    my ($request, $entries) = @_;
+sub _process_inventory($request, $entries) {
     @$entries =
         map { map_columns_into_hash($cols->{inventory}, $_) } @$entries;
 
     return _inventory_single_date($request, $entries, $request->{transdate});
 }
 
-sub _process_inventory_multi {
-    my ($request, $entries) = @_;
+sub _process_inventory_multi($request, $entries) {
 
     @$entries =
         map { map_columns_into_hash($cols->{inventory_multi}, $_) }
@@ -482,8 +467,7 @@ sub _process_inventory_multi {
     return;
 }
 
-sub _process_parts {
-    my ($request, $entries, $columns, $acc_types) = @_;
+sub _process_parts($request, $entries, $columns, $acc_types) {
     my %table_columns =
         map { $_ => ($_ =~ s/(_accno|partsgroup)$/$1_id/r) }
         grep { $_ ne 'taxaccnos' }
@@ -546,8 +530,8 @@ sub _process_parts {
     }
 }
 
-sub _process_goods {
-    return _process_parts(@_, $cols->{goods},
+sub _process_goods(@args) {
+    return _process_parts(@args, $cols->{goods},
         { income_accno    => 'IC_sale',
           expense_accno   => 'IC_cogs',
           inventory_accno => 'IC',
@@ -555,15 +539,15 @@ sub _process_goods {
           tax_accno       => 'IC_taxpart' });
 }
 
-sub _process_services {
-    return _process_parts(@_, $cols->{services},
+sub _process_services(@args) {
+    return _process_parts(@args, $cols->{services},
         { income_accno  => 'IC_income',
           expense_accno => 'IC_expense',
           tax_accno     => 'IC_taxservice' });
 }
 
-sub _process_overhead {
-    return _process_parts(@_, $cols->{overhead},
+sub _process_overhead(@args) {
+    return _process_parts(@args, $cols->{overhead},
         { inventory_accno => 'IC',
           expense_accno   => 'IC_expense' });
 }
@@ -590,8 +574,7 @@ This parses a file, and returns a the csv in tabular format.
 
 =cut
 
-sub _parse_file {
-    my $self = shift @_;
+sub _parse_file($self) {
 
     my $handle = $self->upload('import_file');
     my $csv = Text::CSV->new({ blank_is_undef => 1, allow_whitespace => 1 });
@@ -616,8 +599,7 @@ sub _parse_file {
 This displays the begin data entry screen.
 =cut
 
-sub begin_import {
-    my ($request) = @_;
+sub begin_import($request) {
     my $template_file =
         ($template_file{$request->{type}}) ?
         $template_file{$request->{type}} : 'import_csv';
@@ -639,8 +621,7 @@ data in $request and processes it according to the dispatch tables.
 
 my $json = JSON::PP->new;
 
-sub run_import {
-    my ($request) = @_;
+sub run_import($request) {
 
     try {
         my @entries = _parse_file($request);
@@ -672,4 +653,3 @@ your software.
 
 =cut
 
-1;

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Scripts::setup;
@@ -74,8 +73,7 @@ login.pl.
 
 =cut
 
-sub authenticate {
-    my ($request) = @_;
+sub authenticate($request) {
     my $creds = $request->{_req}->env->{'lsmb.auth'}->get_credentials;
 
     return [ HTTP_UNAUTHORIZED,
@@ -90,14 +88,12 @@ sub authenticate {
 }
 
 
-sub __default {
-    my ($request) = @_;
+sub __default($request) {
     my $template = $request->{_wire}->get('ui');
     return $template->render($request, 'setup/credentials', $request);
 }
 
-sub _get_database {
-    my ($request) = @_;
+sub _get_database($request) {
     my $creds = $request->{_req}->env->{'lsmb.auth'}->get_credentials;
     $request->{login} = $creds->{login};
 
@@ -124,8 +120,7 @@ sub _get_database {
 }
 
 
-sub _init_db {
-    my ($request) = @_;
+sub _init_db($request) {
     my ($reauth, $database) = _get_database($request);
     return $reauth if $reauth;
 
@@ -151,8 +146,7 @@ Returns the main dispatch table for the versions with supported upgrades
 
 =cut
 
-sub get_dispatch_table {
-    my ($request) = @_;
+sub get_dispatch_table($request) {
     my $sl_detect = $request->{_locale}->text('SQL-Ledger database detected.');
     my $migratemsg =  $request->{_locale}->text(
                'Would you like to migrate the database?'
@@ -262,15 +256,14 @@ sub get_dispatch_table {
 }
 
 
-sub _sanity_checks {
+sub _sanity_checks() {
     my $checks = LedgerSMB::Database->verify_helpers(helpers => [ 'psql' ]);
 
     die q{Unable to execute 'psql'} unless $checks->{psql};
 }
 
 
-sub login {
-    my ($request) = @_;
+sub login($request) {
     if (!$request->{database}){
         return list_databases($request);
     }
@@ -353,8 +346,7 @@ Lists all databases as hyperlinks to continue operations.
 
 =cut
 
-sub list_databases {
-    my ($request) = @_;
+sub list_databases($request) {
     my ($reauth, $database) = _get_database($request);
     return $reauth if $reauth;
 
@@ -376,8 +368,7 @@ Lists all users in the selected database
 
 =cut
 
-sub list_users {
-    my ($request) = @_;
+sub list_users($request) {
     my ($reauth) = _init_db($request);
     return $reauth if $reauth;
 
@@ -396,8 +387,7 @@ Copies db to the name of $request->{new_name}
 
 =cut
 
-sub copy_db {
-    my ($request) = @_;
+sub copy_db($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -417,8 +407,7 @@ Backs up a full db
 
 =cut
 
-sub backup_db {
-    my $request = shift @_;
+sub backup_db($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -432,8 +421,7 @@ Backs up roles only (for all db's)
 
 =cut
 
-sub backup_roles {
-    my $request = shift @_;
+sub backup_roles($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -442,8 +430,7 @@ sub backup_roles {
 }
 
 # Private method, basically just passes the inputs on to the next screen.
-sub _begin_backup {
-    my $request = shift @_;
+sub _begin_backup($request) {
     $request->{can_email} = eval {
         # when accessing an undefined service, an exception is thrown;
         # suppress the exception: all we want to know is if there is a value
@@ -460,8 +447,7 @@ Runs the backup.  If backup_type is set to email, emails the
 
 =cut
 
-sub run_backup {
-    my $request = shift @_;
+sub run_backup($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -547,8 +533,7 @@ sub run_backup {
 
 =cut
 
-sub consistency {
-    my ($request) = @_;
+sub consistency($request) {
     my ($reauth, $database) = _get_database($request);
     return $reauth if $reauth;
 
@@ -586,8 +571,7 @@ sub consistency {
 
 =cut
 
-sub revert_migration {
-    my ($request) = @_;
+sub revert_migration($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -620,8 +604,7 @@ the user.
 
 =cut
 
-sub template_screen {
-    my ($request, $entrypoint) = @_;
+sub template_screen($request, $entrypoint) {
     $request->{template_dirs} =
         [ map { +{ text => $_, value => $_ } }
           sort keys %{ LedgerSMB::Database::Config->new(
@@ -640,8 +623,7 @@ and not the user creation screen.
 
 =cut
 
-sub _save_templates {
-    my ($request, $entrypoint) = @_;
+sub _save_templates($request, $entrypoint) {
     my $templates = LedgerSMB::Database::Config->new(
         templates_dir => $request->{_wire}->get( 'paths/templates' ),
         )->templates;
@@ -662,8 +644,7 @@ sub _save_templates {
     return;
 }
 
-sub load_templates {
-    my ($request) = @_;
+sub load_templates($request) {
 
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
@@ -736,8 +717,7 @@ my %upgrade_next_steps = (
     _load_menu             => '_complete',
     );
 
-sub _dispatch_upgrade_workflow {
-    my ($request, $step_name) = @_;
+sub _dispatch_upgrade_workflow($request, $step_name) {
 
     if (my $next = $upgrade_next_steps{$step_name}) {
         return __PACKAGE__->can($next)->($request);
@@ -746,8 +726,7 @@ sub _dispatch_upgrade_workflow {
     croak "Upgrade workflow error: no next step for '$step_name'";
 }
 
-sub _select_coa {
-    my ($request) = @_;
+sub _select_coa($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -755,8 +734,7 @@ sub _select_coa {
             or _dispatch_upgrade_workflow($request, '_select_coa'));
 }
 
-sub _process_and_run_upgrade_script {
-    my ($request, $type) = @_;
+sub _process_and_run_upgrade_script($request, $type) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -822,37 +800,32 @@ sub _process_and_run_upgrade_script {
     return;
 }
 
-sub _run_sl28_upgrade {
-    my ($request) = @_;
+sub _run_sl28_upgrade($request) {
 
     return (_process_and_run_upgrade_script($request, 'sql-ledger/2.8')
             or _dispatch_upgrade_workflow($request, '_run_sl28_upgrade'));
 }
 
-sub _run_sl30_upgrade {
-    my ($request) = @_;
+sub _run_sl30_upgrade($request) {
 
     return (_process_and_run_upgrade_script($request, 'sql-ledger/3.0')
             or _dispatch_upgrade_workflow($request, '_run_sl30_upgrade'));
 }
 
-sub _run_ls12_upgrade {
-    my ($request) = @_;
+sub _run_ls12_upgrade($request) {
 
     return (_process_and_run_upgrade_script($request, 'ledgersmb/1.2')
             or _dispatch_upgrade_workflow($request, '_run_ls12_upgrade'));
 }
 
-sub _run_ls13_upgrade {
-    my ($request) = @_;
+sub _run_ls13_upgrade($request) {
 
     return (_process_and_run_upgrade_script($request, 'ledgersmb/1.3')
             or _dispatch_upgrade_workflow($request, '_run_ls13_upgrade'));
 }
 
 
-sub _post_sl28_migration {
-    my ($request) = @_;
+sub _post_sl28_migration($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -861,8 +834,7 @@ sub _post_sl28_migration {
             or _dispatch_upgrade_workflow($request, '_post_sl28_migration'));
 }
 
-sub _post_sl30_migration {
-    my ($request) = @_;
+sub _post_sl30_migration($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -871,8 +843,7 @@ sub _post_sl30_migration {
             or _dispatch_upgrade_workflow($request, '_post_sl30_migration'));
 }
 
-sub _post_ls12_migration {
-    my ($request) = @_;
+sub _post_ls12_migration($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -881,8 +852,7 @@ sub _post_ls12_migration {
             or _dispatch_upgrade_workflow($request, '_post_ls12_migration'));
 }
 
-sub _post_ls13_migration {
-    my ($request) = @_;
+sub _post_ls13_migration($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -892,8 +862,7 @@ sub _post_ls13_migration {
 }
 
 
-sub _select_templates {
-    my ($request) = @_;
+sub _select_templates($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -902,8 +871,7 @@ sub _select_templates {
             or _dispatch_upgrade_workflow($request, '_select_templates'));
 }
 
-sub _load_templates {
-    my ($request) = @_;
+sub _load_templates($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -919,8 +887,7 @@ sub _load_templates {
 
 
 
-sub upgrade {
-    my ($request) = @_;
+sub upgrade($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -983,8 +950,7 @@ sub upgrade {
     return $template->render($request, 'setup/upgrade_info', $request);
 }
 
-sub _failed_check {
-    my ($request, $check, $sth) = @_;
+sub _failed_check($request, $check, $sth) {
 
     my %selectable_values =
         %{$check->query_selectable_values($request->{dbh})};
@@ -1092,8 +1058,7 @@ script.
 
 =cut
 
-sub fix_tests {
-    my ($request) = @_;
+sub fix_tests($request) {
 
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
@@ -1150,8 +1115,7 @@ sub fix_tests {
 
 =cut
 
-sub create_db {
-    my ($request) = @_;
+sub create_db($request) {
 
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
@@ -1195,8 +1159,7 @@ coa_lc not set:  Select the coa location code
 
 =cut
 
-sub select_coa {
-    my ($request) = @_;
+sub select_coa($request) {
     my $hdr = $request->{_req}->header( 'Accept-Language' );
     my $lang = $request->{_wire}->get( 'default_locale' )->from_header( $hdr );
     my $coa_data = LedgerSMB::Database::Config
@@ -1277,8 +1240,7 @@ button facilitates that scenario.
 
 =cut
 
-sub skip_coa {
-    my ($request) = @_;
+sub skip_coa($request) {
 
     return _dispatch_upgrade_workflow($request, '_select_coa')
 }
@@ -1291,8 +1253,7 @@ select_coa and skip_coa functions.
 
 =cut
 
-sub _render_user {
-    my ($request, $entrypoint) = @_;
+sub _render_user($request, $entrypoint) {
 
     @{$request->{salutations}} = $request->call_procedure(
         funcname => 'person__list_salutations'
@@ -1319,8 +1280,7 @@ select_coa and skip_coa functions.
 
 =cut
 
-sub _render_new_user {
-    my ($request, $entrypoint) = @_;
+sub _render_new_user($request, $entrypoint) {
 
     # One thing to remember here is that the setup.pl does not get the
     # benefit of the automatic db connection.  So in order to build this
@@ -1354,8 +1314,7 @@ Saves the administrative user, and then directs to the login page.
 
 =cut
 
-sub _save_user {
-    my ($request, $entrypoint) = @_;
+sub _save_user($request, $entrypoint) {
     $request->{entity_class} = EC_EMPLOYEE;
     $request->{name} = "$request->{last_name}, $request->{first_name}";
 
@@ -1417,8 +1376,7 @@ sub _save_user {
 
 
 
-sub _post_migration_schema_upgrade {
-    my ($request, $database, $entrypoint) = @_;
+sub _post_migration_schema_upgrade($request, $database, $entrypoint) {
     my $dbh = $request->{dbh};
     my $guard = Scope::Guard->new(
         sub {
@@ -1457,8 +1415,7 @@ sub _post_migration_schema_upgrade {
     return;
 }
 
-sub _load_menu {
-    my ($request) = @_;
+sub _load_menu($request) {
     my ($reauth, $database) = _init_db($request);
     return $reauth if $reauth;
 
@@ -1474,8 +1431,7 @@ sub _load_menu {
 
 =cut
 
-sub _create_initial_user {
-    my ($request) = @_;
+sub _create_initial_user($request) {
     return _render_new_user($request, '_create_initial_user')
         unless $request->{username};
 
@@ -1483,8 +1439,7 @@ sub _create_initial_user {
             or _dispatch_upgrade_workflow($request, '_create_initial_user'));
 }
 
-sub add_user {
-    my ($request) = @_;
+sub add_user($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -1497,8 +1452,7 @@ sub add_user {
 
 =cut
 
-sub edit_user_roles {
-    my ($request) = @_;
+sub edit_user_roles($request) {
 
     my $reauth;
     ($reauth) = _init_db($request)
@@ -1540,8 +1494,7 @@ sub edit_user_roles {
 
 =cut
 
-sub save_user_roles {
-    my ($request) = @_;
+sub save_user_roles($request) {
 
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
@@ -1583,8 +1536,7 @@ sub save_user_roles {
 
 =cut
 
-sub reset_password {
-    my ($request) = @_;
+sub reset_password($request) {
 
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
@@ -1607,8 +1559,8 @@ sub reset_password {
 Cancels work.  Returns to login screen.
 
 =cut
-sub cancel{
-    return __default(@_);
+sub cancel(@args) {
+    return __default(@args);
 }
 
 =item force
@@ -1617,8 +1569,7 @@ Force work.  Forgets unmatching tests, applies a curing statement and move on.
 
 =cut
 
-sub force {
-    my ($request) = @_;
+sub force($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -1647,8 +1598,7 @@ between versions on a stable branch (typically upgrading)
 
 =cut
 
-sub _rebuild_modules {
-    my ($request, $entrypoint, $database) = @_;
+sub _rebuild_modules($request, $entrypoint, $database) {
 
     # The order is important here:
     #  New modules should be able to depend on the latest changes
@@ -1675,8 +1625,7 @@ sub _rebuild_modules {
     return;
 }
 
-sub rebuild_modules {
-    my ($request) = @_;
+sub rebuild_modules($request) {
 
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
@@ -1701,8 +1650,7 @@ which is also where the 'initial-data.xml' file is located.
 
 =cut
 
-sub _reload_menu {
-    my ($request, $database) = @_;
+sub _reload_menu($request, $database) {
 
     my $c = LedgerSMB::Company->new( dbh => $request->{dbh} );
     my $m = $c->menu;
@@ -1722,8 +1670,7 @@ sub _reload_menu {
 }
 
 
-sub reload_menu {
-    my ($request) = @_;
+sub reload_menu($request) {
 
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
@@ -1745,8 +1692,7 @@ Gets the statistics info and shows the complete screen.
 
 =cut
 
-sub _complete {
-    my ($request, $database) = @_;
+sub _complete($request, $database = undef) {
 
     # the workflow state machine dispatches here (without database)
     if (not defined $database) {
@@ -1772,8 +1718,7 @@ sub _complete {
     return $template->render($request, 'setup/complete', $request);
 }
 
-sub complete {
-    my ($request) = @_;
+sub complete($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -1787,8 +1732,7 @@ Asks the various modules for system and version info, showing the result
 
 =cut
 
-sub system_info {
-    my ($request) = @_;
+sub system_info($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -1816,8 +1760,7 @@ Lists all database schema patches that have been applied.
 
 =cut
 
-sub db_patches_log {
-    my ($request) = @_;
+sub db_patches_log($request) {
     if (my $csrf = $request->verify_csrf) {
         return $csrf;
     }
@@ -1848,4 +1791,3 @@ your software.
 =cut
 
 
-1;

--- a/lib/LedgerSMB/Template/Plugin/External.pm
+++ b/lib/LedgerSMB/Template/Plugin/External.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 use experimental 'try';
 
 package LedgerSMB::Template::Plugin::External;
@@ -138,9 +137,7 @@ Implements the template's initialization protocol.
 
 =cut
 
-sub setup {
-    my ($self, $parent, $cleanvars, $output) = @_;
-
+sub setup($self, $parent, $cleanvars, $output) {
     my (undef, undef, $base) =
         File::Spec->splitpath( $self->rendered_template_name );
     my $dir = File::Temp->newdir( UNLINK => $self->cleanup );
@@ -163,8 +160,7 @@ Implements the template's post-processing protocol.
 
 =cut
 
-sub postprocess {
-    my ($self, $parent, $output, $config) = @_;
+sub postprocess($self, $parent, $output, $config) {
 
     my $dir = $config->{_dir}->dirname;
     my $cmd = $self->command;
@@ -207,14 +203,13 @@ sub postprocess {
     return undef;
 }
 
-=head2 mimetype()
+=head2 mimetype($config)
 
 Returns the rendered template's mimetype.
 
 =cut
 
-sub mimetype {
-    my $self = shift;
+sub mimetype($self, $config) {
     return $self->mime_type;
 }
 
@@ -228,5 +223,3 @@ your software.
 
 =cut
 
-
-1;

--- a/lib/LedgerSMB/Template/Plugin/XLSX.pm
+++ b/lib/LedgerSMB/Template/Plugin/XLSX.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 
 package LedgerSMB::Template::Plugin::XLSX;
 
@@ -44,8 +43,7 @@ has format => (is => 'ro', required => 1);
 my $binmode = undef;
 my $extension = 'xlsx';
 
-sub _get_extension {
-    my ($parent) = shift;
+sub _get_extension($parent) {
     if ($parent->{format_options}->{filetype}){
         return $parent->{format_options}->{filetype};
     } else {
@@ -59,8 +57,7 @@ my $rowcount;
 my $currcol;
 my $format;
 
-sub _worksheet_handler {
-    my ($twig, $elt) = @_;
+sub _worksheet_handler($twig, $elt) {
     $rowcount = 0;
     $currcol = 0;
 
@@ -74,8 +71,7 @@ sub _row_handler {
     return undef;
 }
 
-sub _cell_handler {
-    my ($twig, $elt) = @_;
+sub _cell_handler($twig, $elt) {
     $worksheet->write($rowcount,$currcol,$elt->att('text'),$format);
     $currcol++;
     return undef;
@@ -86,9 +82,7 @@ sub _formula_handler {
     return undef;
 }
 
-sub _format_handler {
-    my ($t, $format) = @_;
-
+sub _format_handler($t, $format) {
     my %properties;
     while (my ($attr, $val) = each %{$format->{att}}) {
         if ($attr eq 'border') {
@@ -130,13 +124,11 @@ sub _format_handler {
 #    return undef;
 #}
 
-sub _format_cleanup_handler {
-    my ($t, $format) = @_;
+sub _format_cleanup_handler($t, $format) {
     return ($t, $format); # dubious; evaluation of my is undoc/undefined
 }
 
-sub _xlsx_process {
-    my ($wbk, $template) = @_;
+sub _xlsx_process($wbk, $template) {
     $workbook = $wbk;
 
     my $parser = XML::Twig->new(
@@ -173,8 +165,7 @@ Implements the template's initialization protocol.
 
 =cut
 
-sub setup {
-    my ($self, $parent, $cleanvars, $output) = @_;
+sub setup($self, $parent, $cleanvars, $output) {
 
     my $temp_output;
     return (\$temp_output, {
@@ -191,8 +182,7 @@ Implements the template's post-processing protocol.
 
 =cut
 
-sub postprocess {
-    my ($self, $parent, $temp_output, $config) = @_;
+sub postprocess($self, $parent, $temp_output, $config) {
 
     # Implement Template Toolkit's protocol: if the variable
     # '$output' contains a string, it's a filename. If it's a
@@ -226,9 +216,7 @@ Returns the rendered template's mimetype.
 
 =cut
 
-sub mimetype {
-    my $self = shift;
-    my $config = shift;
+sub mimetype($self, $config) {
     my $mimetype;
 
     if (lc $self->format eq 'xlsx') {
@@ -251,4 +239,3 @@ your software.
 
 =cut
 
-1;

--- a/lib/LedgerSMB/Workflow.pm
+++ b/lib/LedgerSMB/Workflow.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 
 package LedgerSMB::Workflow;
 
@@ -64,8 +63,6 @@ sub init($self, @params) {
         $self->_factory->get_persister_for_workflow_type( $self->type );
     $self->{handle} = $persister->handle; # workaround for Workflow preventing write access
 }
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Action/Reconciliation.pm
+++ b/lib/LedgerSMB/Workflow/Action/Reconciliation.pm
@@ -1,8 +1,8 @@
-package LedgerSMB::Workflow::Action::Reconciliation;
 
-use v5.36;
-use warnings;
+use v5.38;
 no warnings "experimental::for_list"; ## no critic -- accepted in 5.40
+
+package LedgerSMB::Workflow::Action::Reconciliation;
 
 use parent qw( LedgerSMB::Workflow::Action );
 
@@ -97,9 +97,6 @@ sub _reject($self, $wf) {
     $wf->context->param( 'rejected', 1 );
 }
 
-
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Action/TransactionApprove.pm
+++ b/lib/LedgerSMB/Workflow/Action/TransactionApprove.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 
 package LedgerSMB::Workflow::Action::TransactionApprove;
 
@@ -49,8 +48,6 @@ sub execute( $self, $wf ) {
 
     return;
 }
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Action/TransactionDelete.pm
+++ b/lib/LedgerSMB/Workflow/Action/TransactionDelete.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 
 package LedgerSMB::Workflow::Action::TransactionDelete;
 
@@ -49,8 +48,6 @@ sub execute( $self, $wf ) {
 
     return;
 }
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Condition/ACL.pm
+++ b/lib/LedgerSMB/Workflow/Condition/ACL.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 
 package LedgerSMB::Workflow::Condition::ACL;
 
@@ -66,9 +65,6 @@ sub evaluate($self, $wf) {
     return $access;
 }
 
-
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Condition/PeriodClosed.pm
+++ b/lib/LedgerSMB/Workflow/Condition/PeriodClosed.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 
 package LedgerSMB::Workflow::Condition::PeriodClosed;
 
@@ -95,9 +94,6 @@ sub evaluate($self, $wf) {
     return not $opened;
 }
 
-
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Condition/SeparateDuties.pm
+++ b/lib/LedgerSMB/Workflow/Condition/SeparateDuties.pm
@@ -1,6 +1,5 @@
 
-use v5.36;
-use warnings;
+use v5.38;
 
 package LedgerSMB::Workflow::Condition::SeparateDuties;
 
@@ -49,9 +48,6 @@ sub evaluate($self, $wf) {
     return $separate_duties;
 }
 
-
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Persister/Email.pm
+++ b/lib/LedgerSMB/Workflow/Persister/Email.pm
@@ -1,8 +1,7 @@
 
-package LedgerSMB::Workflow::Persister::Email;
+use v5.38;
 
-use v5.36;
-use warnings;
+package LedgerSMB::Workflow::Persister::Email;
 
 =head1 NAME
 
@@ -277,8 +276,6 @@ sub fetch_workflow( $self, $wf_id ) {
     return $wf_info;
 }
 
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Persister/Email/TiedContent.pm
+++ b/lib/LedgerSMB/Workflow/Persister/Email/TiedContent.pm
@@ -1,7 +1,7 @@
-package LedgerSMB::Workflow::Persister::Email::TiedContent;
 
-use v5.32;
-use warnings;
+use v5.38;
+
+package LedgerSMB::Workflow::Persister::Email::TiedContent;
 
 =head1 NAME
 
@@ -38,9 +38,7 @@ Constructor. Called by Perl's C< tie() >.
 
 =cut
 
-sub TIESCALAR {
-    my $class = shift;
-    my %args = @_;
+sub TIESCALAR($class, %args) {
     my $self = bless { %args }, $class;
 
     $self->{dirty}     = defined $self->{value};
@@ -54,8 +52,7 @@ Called each time the variable's value is retrieved.
 
 =cut
 
-sub FETCH {
-    my $self = shift;
+sub FETCH($self) {
     return $self->{value} if $self->{has_value};
 
     my $dbh = $self->{dbh};
@@ -82,9 +79,7 @@ Called each time the variable is being assigned a new value.
 
 =cut
 
-sub STORE {
-    my ($self, $value) = @_;
-
+sub STORE($self, $value) {
     $self->{dirty} = 1;
     $self->{value} = $value;
     $self->{has_value} = 1;
@@ -98,8 +93,7 @@ Not implemented.
 
 =cut
 
-sub persist {
-    my ($self) = @_;
+sub persist($self) {
     return if not $self->{dirty};
 
     if ($self->{id}) { # update
@@ -107,8 +101,6 @@ sub persist {
     else { # create
     }
 }
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Workflow/Persister/Reconciliation.pm
+++ b/lib/LedgerSMB/Workflow/Persister/Reconciliation.pm
@@ -1,4 +1,9 @@
+
+use v5.38;
+
 package LedgerSMB::Workflow::Persister::Reconciliation;
+
+use parent qw( LedgerSMB::Workflow::Persister );
 
 =head1 NAME
 
@@ -12,15 +17,6 @@ The class inherits from LedgerSMB::Workflow::Persister::ExtraData; users are
 expected to declare the email table and fields as "ExtraData" configuration.
 
 =head1 METHODS
-
-=cut
-
-
-use v5.36;
-use strict;
-use parent qw( LedgerSMB::Workflow::Persister );
-
-
 
 =head2 create_workflow
 
@@ -103,8 +99,6 @@ sub update_workflow($self, $wf) {
     return;
 }
 
-
-1;
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1,3 +1,6 @@
+
+use v5.38;
+
 =head1 NAME
 
 LedgerSMB::Form - Provides general legacy support functions and the central object.
@@ -56,7 +59,6 @@ Deprecated
 
 package Form;
 
-use v5.36.1;
 use charnames qw(:full);
 use open ':utf8';
 use utf8;
@@ -2928,6 +2930,8 @@ sub get_batch_description {
 This function returns the HTML code for a dropdown box for a given setting
 key.  It is not generally to be used with code on new templates.
 
+=back
+
 =cut
 
 sub sequence_dropdown{
@@ -2954,10 +2958,4 @@ sub sequence_dropdown{
         return '';
     }
 }
-#end decrysiption
-
-1;
-
-
-=back
 

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -1,3 +1,7 @@
+
+use v5.38;
+use experimental 'try';
+
 =head1 NAME
 
 LedgerSMB::old_code - dispatching from new code to old code
@@ -20,10 +24,6 @@ LedgerSMB::old_code - dispatching from new code to old code
 =over
 
 =cut
-
-use v5.36;
-use warnings;
-use experimental 'try';
 
 package LedgerSMB::old_code;
 
@@ -55,13 +55,7 @@ Wraps a "call" to old code, returning a PSGI triplet for the response.
 
 =cut
 
-sub dispatch {
-    my $script = shift;
-    my $entrypoint = shift;
-    my $user = shift;
-    my $form_args = shift;
-    my @entrypoint_args = @_;
-
+sub dispatch($script, $entrypoint, $user, $form_args, @entrypoint_args) {
     my $stdout = IO::File->new_tmpfile;
     binmode $stdout, ':utf8';
     if (my $cpid = fork()) {
@@ -140,5 +134,3 @@ option any later version.  A copy of the license should have been included with
 your software.
 
 =cut
-
-1;

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -84,7 +84,7 @@ while (<>) {
           $state==NUL &&
               # the reports use a workaround with a function called Text()
               # or MarkText()
-              $source =~ m/^[^\n]*\b(([Mm]ark)?[tT]ext)[\s\t\n]*\(/gs
+              $source =~ m/^[^\n]*(?<!sub )\b(([Mm]ark)?[tT]ext)[\s\t\n]*\(/gs
               && do { $state = TXT; $text = $1; redo; };
 
          $state==TXT # All patterns must give $1 for the whole

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -115,13 +115,11 @@ pager = less
     set_themes = lsmb lsmb_new lsmb_old_wip
 [Modules::RequireBarewordIncludes]
     set_themes = lsmb lsmb_new lsmb_old_wip
-[Modules::RequireEndWithOne]
-    set_themes = lsmb lsmb_new lsmb_old
 [Modules::RequireExplicitInclusion]
     set_themes = lsmb lsmb_new
 [Modules::RequireExplicitPackage]
     set_themes = lsmb lsmb_new lsmb_old
-    allow_import_of = v5.38 v5.36 experimental warnings Syntax::Operator::In
+    allow_import_of = v5.38 experimental Sublike::Extended Syntax::Operator::In
 [Modules::RequireFilenameMatchesPackage]
     set_themes = lsmb lsmb_new lsmb_old_wip lsmb_tests
 
@@ -186,6 +184,10 @@ pager = less
 
 # LSMB is more application than lib
 #[Modules::RequireVersionVar]
+
+# With 'use v5.38' modules don't need to end with '1;'
+[Modules::RequireEndWithOne]
+    set_themes = lsmb_reject
 
 # After Perl 5.20 this is no longer a problem
 [Modules::RequireNoMatchVarsWithUseEnglish]


### PR DESCRIPTION
* Consistently use v5.38
* Consistently use function signatures
* Consistently remove '1;' from end-of-module
* Use Sublike::Extended where named arguments are desired
* Fix argument lists where too few were provided/ consumed
