### PR TITLE
Fix ledgersmb-admin exit-code zero on user-creation failure

### DIFF
--- a/lib/LedgerSMB/Admin/Command/user.pm
+++ b/lib/LedgerSMB/Admin/Command/user.pm
@@ -233,11 +233,10 @@ sub change {
         $dbh->disconnect;
         $dbh = undef;
         $self->logger->warn('User successfully changed');
-
-        return 0;
     }
     catch ($e) {
         $self->logger->error("Unhandled error caught during user modification: $e");
+        return 1;
     }
     finally {
         if ($dbh) {
@@ -245,6 +244,9 @@ sub change {
             $dbh->disconnect;
         }
     }
+
+
+    return 0;
 }
 
 sub create {
@@ -297,11 +299,10 @@ sub create {
         $dbh->disconnect;
         $dbh = undef;
         $self->logger->warn('User successfully created');
-
-        return 0;
     }
     catch ($e) {
         $self->logger->error("Unhandled exception during user creation: $e");
+        return 1;
     }
     finally {
         if ($dbh) {
@@ -309,6 +310,8 @@ sub create {
             $dbh->disconnect;
         }
     }
+
+    return 0;
 }
 
 sub _create_employee {
@@ -419,10 +422,10 @@ sub delete {
         $dbh->disconnect;
         $dbh = undef;
         $self->logger->info('User successfully deleted');
-        return 0;
     }
     catch ($e) {
         $self->logger->error("Unhandled error during user deletion: $e");
+        return 1;
     }
     finally {
         if ($dbh) {
@@ -430,6 +433,8 @@ sub delete {
             $dbh->disconnect;
         }
     }
+
+    return 0;
 }
 
 sub list {


### PR DESCRIPTION
The last statement in the catch{} block returned a string (the log output), which needs to be 'normalized' to a number by 'exit'. The default when that happens is zero, making callers think the user creation succeeded...
