### PR TITLE
Remove rules to block reverse-proxying config files

### DIFF
--- a/doc/conf/webserver/apache-vhost.conf
+++ b/doc/conf/webserver/apache-vhost.conf
@@ -41,8 +41,6 @@ NameVirtualHost *:443
   RewriteRule "^/$" "/login.pl" [R=301,L]
   # "hidden" files (those starting with a dot), don't exist
   RewriteRule "^/\." - [R=404,L]
-  # configuration files (those ending in '.conf'), don't exist
-  RewriteRule "\.conf$" - [R=404,L]
 
   RewriteCond "%{REQUEST_FILENAME}" -f
   RewriteRule .* "-" [L]

--- a/doc/conf/webserver/nginx-github.conf
+++ b/doc/conf/webserver/nginx-github.conf
@@ -51,11 +51,6 @@ http {
                deny all;
       }
 
-      # Configuration files don't exist
-      location ^~ \.conf$ {
-         return 404;
-      }
-
       # 'Hidden' files don't exist
       location ~ /\. {
          return 404;

--- a/doc/conf/webserver/nginx-vhost.conf
+++ b/doc/conf/webserver/nginx-vhost.conf
@@ -32,10 +32,6 @@ server {
   gzip off;
   gzip_static on;
 
-  # Configuration files don't exist
-  location ^~ \.conf$ {
-     return 404;
-  }
   # 'Hidden' files don't exist
   location ~ /\. {
      return 404;


### PR DESCRIPTION
* First of all, these are the previous generation of config files;
*  second of all, these config files are now named '*.yaml'; 
* third of all, config files are now (also) stored in 'local/'; 
* and last but not least: config files are not stored in 'UI/', but it's 'UI/' which is being reverse-proxied.