### PR TITLE
Prevent editing existing GIFI codes

### DIFF
--- a/UI/src/components/ConfigTableRow.vue
+++ b/UI/src/components/ConfigTableRow.vue
@@ -140,7 +140,9 @@ let mouseOverDefault = ref(false);
                 :type="column.type"
                 :value="data[column.key]"
                 :name="column.key"
-                :readonly="!editing"
+                :readonly="
+                    !editing || (props.type === 'existing' && column.immutable)
+                "
                 :class="editing ? 'editing' : 'neutral'"
                 class="input-box"
                 @input="(e) => send({ type: 'update', key: column.key, value: e.target.value })"

--- a/UI/src/views/GIFI.vue
+++ b/UI/src/views/GIFI.vue
@@ -10,7 +10,7 @@ import ImportCsvGifi from "@/views/ImportCSV-GIFI";
 
 const { t } = useI18n();
 const COLUMNS = [
-    { key: "accno",       type: "text", head: t("Code") },
+    { key: "accno", type: "text", head: t("Code"), immutable: true },
     { key: "description", type: "text", head: t("Description") }
 ];
 

--- a/UI/tests/specs/views/GIFI.spec.js
+++ b/UI/tests/specs/views/GIFI.spec.js
@@ -86,4 +86,26 @@ describe("GIFI - register as a component", () => {
             ["modify", "save", "cancel"]
         ]);
     });
+
+    it("should make GIFI codes immutable after creation", async () => {
+        sessionUser.$patch({ roles: ["gifi_create", "gifi_edit"] });
+
+        await retry(() =>
+            expect(wrapper.find(".dynatableData").isVisible()).toBe(true)
+        );
+
+        const existingRow = wrapper.findAll(".dynatableData .data-row").at(0);
+        const existingCode = existingRow.get('[name="accno"]');
+        const existingDescription = existingRow.get('[name="description"]');
+
+        await existingRow.get('[name="modify"]').trigger("click");
+        await retry(() =>
+            expect(existingDescription.element.readOnly).toBe(false)
+        );
+
+        expect(existingCode.element.readOnly).toBe(true);
+
+        const newCode = wrapper.get('tfoot [name="accno"]');
+        expect(newCode.element.readOnly).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary

- add optional immutable column metadata for configuration tables
- keep existing GIFI codes read-only while descriptions remain editable
- preserve code entry for new rows and add regression coverage for both cases

Fixes #9493

## Verification

- `corepack yarn test:unit` (62 tests passed)
- `corepack yarn eslint tests/specs/views/GIFI.spec.js`
- `corepack yarn eslint src/views/GIFI.vue src/components/ConfigTableRow.vue`
- `corepack yarn build`
- `git diff --check`

## Unverified checks

- The API-backed Vitest project was not run because this change is confined to the Vue configuration-table UI.
- Repository-wide lint could not provide a clean signal in this Windows checkout because Prettier reports CRLF endings across untouched files. The three changed files were normalised to LF and pass the targeted lint commands above.