### PR TITLE
Rename array_endswith SQL function

### DIFF
--- a/sql/changes/1.14/drop-function-array_endswith.sql
+++ b/sql/changes/1.14/drop-function-array_endswith.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS array_endswith(anyelement, anyarray);

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -198,3 +198,4 @@ mc/delete-migration-validation-data.sql
 1.14/payments-first-order.sql
 1.14/drop-vouchers.sql
 1.14/parts_id-fkey-corrections.sql
+1.14/drop-function-array_endswith.sql

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -42,7 +42,6 @@ admin__save_user
 admin__search_users
 ar_ap__transaction_search
 ar_ap__transaction_search_summary
-array_endswith
 array_splice_from
 array_splice_to
 assembly__stock
@@ -489,6 +488,7 @@ user__check_my_expiration
 user__get_all_users
 user__get_preferences
 user__save_preferences
+util__array_endswith
 wage__list_for_entity
 wage__list_types
 wage__save

--- a/sql/modules/FinStatements.sql
+++ b/sql/modules/FinStatements.sql
@@ -647,7 +647,7 @@ hdr_meta AS (
                 WHERE language_code =
                        coalesce(in_language, preference__get('language'))) at
               ON aht.id = at.trans_id
-     WHERE array_endswith((SELECT value::int FROM defaults
+     WHERE util__array_endswith((SELECT value::int FROM defaults
                             WHERE setting_key = 'earn_id'), aht.path)
            -- legacy (no earn_id) returns all headers
            OR (NOT aht.path @> ARRAY[(SELECT value::int FROM defaults
@@ -750,7 +750,7 @@ hdr_balance AS (
       FROM acc_meta am
              INNER JOIN acc_balance ab on am.id = ab.id
   ) bs
-  WHERE array_endswith((SELECT value::int FROM defaults
+  WHERE util__array_endswith((SELECT value::int FROM defaults
                          WHERE setting_key = 'earn_id'), bs.path)
      -- legacy (no earn_id) returns all accounts; bug?
      OR (NOT bs.path @> ARRAY[(SELECT value::int FROM defaults

--- a/sql/modules/Util.sql
+++ b/sql/modules/Util.sql
@@ -145,7 +145,7 @@ $BODY$
   $BODY$
   LANGUAGE sql IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION array_endswith(elem anyelement, arr anyarray)
+CREATE OR REPLACE FUNCTION util__array_endswith(elem anyelement, arr anyarray)
   RETURNS boolean
   LANGUAGE SQL
 AS $$

--- a/xt/42-util.pg
+++ b/xt/42-util.pg
@@ -17,7 +17,8 @@ BEGIN;
 
     -- Validate required functions
 
-    SELECT has_function('array_endswith',ARRAY['anyelement','anyarray']);
+    SELECT has_function('util__array_endswith',
+                        ARRAY['anyelement','anyarray']);
     SELECT has_function('array_splice_from',ARRAY['anyelement','anyarray']);
     SELECT has_function('array_splice_to',ARRAY['anyelement','anyarray']);
     SELECT has_function('get_default_lang','{}'::text[]);


### PR DESCRIPTION
## Summary

- rename `array_endswith` to `util__array_endswith`
- update both financial-statement callers and the pgTAP assertion
- regenerate the function blacklist
- add a schema change that removes the legacy function before modules reload

## Verification

- `git diff --check`
- blacklist compared with the module function inventory
- disposable PostgreSQL 14 fresh-install and upgrade-path simulation

## Not run locally

- repository Perl and pgTAP suites; required local modules are unavailable, so CI will provide those results

Part of #9277