### PR TITLE
Fix getting path argument to create_adr_index

### DIFF
--- a/utils/devel/create_adr_index
+++ b/utils/devel/create_adr_index
@@ -27,8 +27,8 @@ use warnings;
 use File::Spec;
 
 # Directory to scan; defaults to adr directory if not given
-my $dir = shift || '../../doc/adr';
-my $output_file = "../../doc/adr/index.md";
+my $dir = shift @ARGV || '../../doc/adr';
+my $output_file = "$dir/index.md";
 
 # Remote base URL
 #my $base_url = "https://github.com/ledgersmb/LedgerSMB/tree/master/doc/adr";


### PR DESCRIPTION
Script arguments are in @ARGV, but 'shift' uses @_ by default.
